### PR TITLE
CMake: Set CMake policy CMP0167 to OLD for Boost compatibility

### DIFF
--- a/dep/boost/CMakeLists.txt
+++ b/dep/boost/CMakeLists.txt
@@ -30,6 +30,8 @@ include (CheckCXXSourceCompiles)
 
 set(BOOST_REQUIRED_VERSION 1.72)
 
+cmake_policy(SET CMP0167 OLD)
+
 find_package(Boost ${BOOST_REQUIRED_VERSION} REQUIRED system filesystem thread program_options iostreams regex)
 
 # Find if Boost was compiled in C++03 mode because it requires -DBOOST_NO_CXX11_SCOPED_ENUMS


### PR DESCRIPTION
Suppress cmake generation warning about boost.