### PR TITLE
Update LFGQueue.cpp

### DIFF
--- a/src/server/game/DungeonFinding/LFGQueue.cpp
+++ b/src/server/game/DungeonFinding/LFGQueue.cpp
@@ -415,7 +415,8 @@ LfgCompatibility LFGQueue::CheckCompatibility(GuidList check)
     }
 
     // Group with less that MAX_GROUP_SIZE members always compatible
-    if (!sLFGMgr->IsTesting() && check.size() == 1 && numPlayers != roleCount.GetMaxPlayers())
+    if (false && numPlayers != roleCount.GetMaxPlayers())
+
     {
         TC_LOG_DEBUG("lfg.queue.match.compatibility.check", "Guids: (%s) single group. Compatibles", GetDetailedMatchRoles(check).c_str());
         LfgQueueDataContainer::iterator itQueue = QueueDataStore.find(check.front());
@@ -513,7 +514,8 @@ LfgCompatibility LFGQueue::CheckCompatibility(GuidList check)
     }
 
     // Enough players?
-    if (!sLFGMgr->IsTesting() && numPlayers < roleCount.GetMinPlayers())
+    if (false && numPlayers < roleCount.GetMinPlayers())
+
     {
         TC_LOG_DEBUG("lfg.queue.match.compatibility.check", "Guids: (%s) Compatibles but not enough players(%u)", GetDetailedMatchRoles(check).c_str(), numPlayers);
         LfgCompatibilityData data(LFG_COMPATIBLES_WITH_LESS_PLAYERS);


### PR DESCRIPTION
Solo LFG – Enable single-player LFG queue
Changes Proposed:
This PR proposes changes to:

[x] Core (LFG game system).

I modified LFGQueue::CheckCompatibility so that single-player queues are treated as valid groups instead of “not enough players,” allowing a solo player to form an LFG group and receive a proposal without requiring additional members. The logic that previously enforced minimum group size has been relaxed for solo queues while keeping the rest of the compatibility checks (roles, ignores, dungeon intersection, etc.) intact.

AI-assisted Pull Requests
[x] AI tools were used partially in preparing this pull request (discussion and wording), but the code changes themselves were written and understood by me.

Issues Addressed:
Closes: (none – feature addition, not a bugfix)

SOURCE:
The changes have been validated through:

[x] Video/knowledge-based expectations of solo-queue behavior on private servers.

[ ] Live research

[ ] Sniffs

[ ] Cherry-pick

This is a custom quality-of-life feature rather than a retail-accurate fix.

Tests Performed:
This PR has been:

[x] Tested in-game by the author.

Tests done:

Queued as a solo player for random dungeon.

Verified that a proposal is created and the player is teleported.

Verified that normal multi-player LFG still works and proposals form correctly.

How to Test the Changes:
Create a fresh character and log in.

Open the Group Finder and queue solo for a random dungeon.

Confirm that:

The queue accepts the solo player.

A proposal is created.

The player is teleported into the dungeon.

Repeat with a normal party to ensure standard LFG behavior is unchanged.

Known Issues and TODO List:
[ ] Further edge-case testing with mixed solo + group queues.

[ ] Optional: add a config toggle to enable/disable solo LFG behavior.