### PR TITLE
Fix Issue #45: Fix incorrect achievements and titles awarded on login

### DIFF
--- a/src/server/game/Achievements/CriteriaHandler.cpp
+++ b/src/server/game/Achievements/CriteriaHandler.cpp
@@ -514,10 +514,15 @@ void CriteriaHandler::UpdateCriteria(CriteriaTypes type, uint64 miscValue1 /*= 0
             case CRITERIA_TYPE_WIN_ARENA: // This also behaves like CRITERIA_TYPE_WIN_RATED_ARENA
             case CRITERIA_TYPE_ON_LOGIN:
             case CRITERIA_TYPE_PLACE_GARRISON_BUILDING:
-            case CRITERIA_TYPE_COLLECT_BATTLEPET:
             case CRITERIA_TYPE_HONOR_LEVEL_REACHED:
             case CRITERIA_TYPE_PRESTIGE_REACHED:
                 SetCriteriaProgress(criteria, 1, referencePlayer, PROGRESS_ACCUMULATE);
+                break;
+            case CRITERIA_TYPE_COLLECT_BATTLEPET:
+                if (miscValue1)
+                    SetCriteriaProgress(criteria, miscValue1, referencePlayer, PROGRESS_ACCUMULATE);
+                else
+                    SetCriteriaProgress(criteria, referencePlayer->GetBattlePets()->size(), referencePlayer, PROGRESS_SET);
                 break;
             // std case: increment at miscValue1
             case CRITERIA_TYPE_MONEY_FROM_VENDORS:
@@ -2784,7 +2789,7 @@ bool CriteriaHandler::ModifierSatisfied(ModifierTreeEntry const* modifier, uint6
             break;
         }
         default:
-            break;
+            return false;
     }
     return true;
 }

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -31305,7 +31305,7 @@ bool Player::_LoadPetBattles(PreparedQueryResult result)
     _oldPetBattleSpellToMerge.clear();
 
     GetSession()->SendBattlePetJournal();
-    UpdateCriteria(CRITERIA_TYPE_COLLECT_BATTLEPET, 1);
+    UpdateCriteria(CRITERIA_TYPE_COLLECT_BATTLEPET);
 
     return true;
 }


### PR DESCRIPTION
## Changes Proposed

This PR fixes #45 (Titles which you shouldn't have on fresh new character).

While investigating the title issue, it turned out to be a broader problem. Fresh characters were receiving multiple achievements during login:

- 4 Feats of Strength (Arena Season 3)
- 3 Rated Arena achievements
- 1 Rated Battleground achievement
- 1 Battle Pet collection achievement

The changes ensure these achievements are no longer incorrectly granted during login while keeping the implementation minimal and non-invasive.

### AI-assisted Pull Requests

- [x] AI tools were used partially in preparing this pull request.

ChatGPT and OpenAI Codex were used during troubleshooting and to help prepare the final minimal code changes. The implementation was reviewed, compiled and tested by the author.

## Issues Addressed

- Closes #45

## Tests Performed

- [x] Tested in-game by the author.
- [x] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes

1. Create a fresh character.
2. Log in.
3. Verify that no Arena/RBG titles or achievements are awarded.
4. Learn a battle pet and verify that the collection achievement is awarded only after obtaining a real pet.