### PR TITLE
feat(corruption): the three 8.3 corruption drawback tiers

### DIFF
--- a/sql/updates/world/2026_08_02_00_corruption_grasping_tendrils.sql
+++ b/sql/updates/world/2026_08_02_00_corruption_grasping_tendrils.sql
@@ -1,0 +1,19 @@
+-- Grasping Tendrils, the 1+ corruption drawback.
+--
+-- 315175 procs on damage taken and triggers the 5s snare 315176. SpellEffect.db2 gives
+-- 315176 a magnitude of 0 - retail computed it server-side - so the aura landed at
+-- "movement speed reduced by 0%". spell_corruption_grasping_tendrils supplies it.
+DELETE FROM `spell_script_names` WHERE `spell_id` = 315176 AND `ScriptName` = 'spell_corruption_grasping_tendrils';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(315176, 'spell_corruption_grasping_tendrils');
+
+-- 315175 ships every TAKEN proc flag (0x800AAAA8), three of which are not damage -
+-- including PROC_FLAG_TAKEN_PERIODIC, which SpellMgr.h documents as "damage / healing".
+-- With no spell_proc row the auto-generated one takes PROC_SPELL_TYPE_MASK_ALL, so
+-- standing in a druid's Efflorescence rooted the player once per healing tick.
+-- AttributesMask restores PROC_ATTR_TRIGGERED_CAN_PROC, which the generator sets for a
+-- TAKEN proc-trigger aura and a hand-written row would otherwise drop. Every other column
+-- stays 0 so ProcFlags, Chance, Cooldown and Charges keep their DB2 values.
+DELETE FROM `spell_proc` WHERE `SpellId` = 315175;
+INSERT INTO `spell_proc` (`SpellId`, `SpellTypeMask`, `AttributesMask`) VALUES
+(315175, 1, 2); -- PROC_SPELL_TYPE_DAMAGE, PROC_ATTR_TRIGGERED_CAN_PROC

--- a/sql/updates/world/2026_08_02_01_corruption_eye_of_corruption.sql
+++ b/sql/updates/world/2026_08_02_01_corruption_eye_of_corruption.sql
@@ -1,0 +1,15 @@
+-- Eye of Corruption, the 20+ corruption drawback.
+--
+-- The Eye already spawned: container 315169 procs on damage dealt and triggers 315154,
+-- which creates areatrigger 22815. But 22815 had no ScriptName and no rows in
+-- `areatrigger_template_actions`, and nothing anywhere cast the damage spell 315161, so
+-- the Eye was purely cosmetic - it appeared, sat for its eight seconds and did nothing.
+--
+-- A template action cannot serve here: AreaTrigger::DoActions fires once, from
+-- HandleUnitEnterExit, while the Eye has to tick for as long as the player stays in
+-- range. That needs AreaTriggerAI::OnPeriodicProc, reached only through a ScriptName.
+UPDATE `areatrigger_template` SET `ScriptName` = 'at_corruption_eye_of_corruption' WHERE `Id` = 22815;
+
+DELETE FROM `spell_script_names` WHERE `spell_id` = 315161 AND `ScriptName` = 'spell_corruption_eye_of_corruption';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(315161, 'spell_corruption_eye_of_corruption');

--- a/sql/updates/world/2026_08_02_02_corruption_grand_delusions.sql
+++ b/sql/updates/world/2026_08_02_02_corruption_grand_delusions.sql
@@ -1,0 +1,20 @@
+-- Grand Delusions, the 40+ corruption tier.
+--
+-- Container 315184 procs and triggers 315186, whose only effect summons creature 161895,
+-- the Thing From Beyond. Everything up to the summon is client data and already worked;
+-- the creature is the part with no behaviour attached to it.
+--
+-- AIName has to be cleared, not merely joined by a ScriptName: ObjectMgr keeps AIName when
+-- a template carries both and silently drops the ScriptName. 161895 is marked SmartAI with
+-- no smart_scripts rows of its own, which is exactly how it was inert to begin with.
+UPDATE `creature_template`
+SET `AIName` = '', `ScriptName` = 'npc_corruption_thing_from_beyond'
+WHERE `entry` = 161895;
+
+-- Same reasoning as 315175 in 2026_08_02_00: 315184's DB2 proc flags include the TAKEN
+-- flags that are not damage, so without this row the player's own heals summon Things as
+-- readily as being hit does. Both containers share SpellProcsPerMinuteID 86, so only the
+-- spell type needs restricting.
+DELETE FROM `spell_proc` WHERE `SpellId` = 315184;
+INSERT INTO `spell_proc` (`SpellId`, `SpellTypeMask`, `AttributesMask`) VALUES
+(315184, 1, 2); -- PROC_SPELL_TYPE_DAMAGE, PROC_ATTR_TRIGGERED_CAN_PROC

--- a/sql/updates/world/2026_08_05_01_corruption_eye_proc_types.sql
+++ b/sql/updates/world/2026_08_05_01_corruption_eye_proc_types.sql
@@ -1,0 +1,16 @@
+-- The Eye spawned on any positive utility cast - learning a mount was the report.
+--
+-- 315169 had no `spell_proc` row, so the generated entry took PROC_SPELL_TYPE_MASK_ALL and the
+-- type filter in CanSpellTriggerProcOnEvent was skipped. Mask 3 keeps damage and heals and drops
+-- PROC_SPELL_TYPE_NO_DMG_HEAL, the bucket Spell.cpp assigns to a cast that neither heals nor
+-- damages.
+--
+-- Unlike 315175 and 315184 this row sets SpellPhaseMask and no AttributesMask, because 315169's
+-- DB2 proc flags are all DONE: the load path never defaults the phase mask, and the generator's
+-- addTriggerFlag is gated on TAKEN_HIT_PROC_FLAG_MASK, so there is no PROC_ATTR_TRIGGERED_CAN_PROC
+-- to lose. The phase has to stay HIT-only - Spell::finish raises a second proc at
+-- PROC_SPELL_PHASE_CAST passing MASK_ALL as the event's own type mask, which no SpellTypeMask can
+-- reject.
+DELETE FROM `spell_proc` WHERE `SpellId` = 315169;
+INSERT INTO `spell_proc` (`SpellId`, `SpellTypeMask`, `SpellPhaseMask`) VALUES
+(315169, 3, 2); -- PROC_SPELL_TYPE_DAMAGE | PROC_SPELL_TYPE_HEAL, PROC_SPELL_PHASE_HIT

--- a/src/server/game/AuctionHouse/AuctionHouseMgr.cpp
+++ b/src/server/game/AuctionHouse/AuctionHouseMgr.cpp
@@ -1269,6 +1269,8 @@ void AuctionHouseObject::BuildListBuckets(WorldPackets::AuctionHouse::AuctionLis
             else if (bucketData->ItemClass == ITEM_CLASS_CONSUMABLE || bucketData->ItemClass == ITEM_CLASS_RECIPE || bucketData->ItemClass == ITEM_CLASS_MISCELLANEOUS)
             {
                 ItemTemplate const* itemTemplate = ASSERT_NOTNULL(sObjectMgr->GetItemTemplate(bucket.first.ItemId));
+                // Template effects only: an auction listing is described by item entry and
+                // bonus list ids, with no Item instance to ask for bonus-granted effects.
                 if (itemTemplate->Effects.size() >= 2 && (itemTemplate->Effects[0]->SpellID == 483 || itemTemplate->Effects[0]->SpellID == 55884))
                 {
                     if (player->HasSpell(itemTemplate->Effects[1]->SpellID))

--- a/src/server/game/BattlePay/BattlePayMgr.cpp
+++ b/src/server/game/BattlePay/BattlePayMgr.cpp
@@ -266,6 +266,7 @@ bool BattlepayManager::AlreadyOwnProduct(uint32 itemId) const
         if (!itemTemplate)
             return true;
 
+        // Template effects only: the shop entry names an item id, not an instance.
         for (auto itr : itemTemplate->Effects)
             if (itr->TriggerType == ITEM_SPELLTRIGGER_LEARN_SPELL_ID && player->HasSpell(itr->SpellID))
                 return true;
@@ -384,6 +385,7 @@ auto BattlepayManager::ProductFilter(Product product) -> bool
                 return false;
             }
 
+            // Template effects only: the shop entry names an item id, not an instance.
             for (auto effectData : itemTemplate->Effects)
             {
                 if (effectData->SpellID != 0 && effectData->TriggerType == ITEM_SPELLTRIGGER_LEARN_SPELL_ID)

--- a/src/server/game/Entities/AreaTrigger/AreaTrigger.cpp
+++ b/src/server/game/Entities/AreaTrigger/AreaTrigger.cpp
@@ -375,6 +375,36 @@ void AreaTrigger::SetDuration(int32 newDuration)
     SetUpdateFieldValue(m_values.ModifyValue(&AreaTrigger::m_areaTriggerData).ModifyValue(&UF::AreaTriggerData::Duration), std::max(newDuration, 0));
 }
 
+// Both points carry the same scale, so the curve holds steady for the trigger's whole life
+// and the interpolation mode cannot affect the result; Linear needs no special handling
+// anywhere. NoData stays clear - that bit tells the client to ignore the points entirely,
+// which is what keeps the misc template's default ExtraScaleCurve inert.
+void AreaTrigger::SetOverrideScaleCurve(float overrideScale)
+{
+    AreaTriggerScaleInfo curve;
+    curve.Data.Structured.CurveParameters.NoData = 0;
+    curve.Data.Structured.CurveParameters.InterpolationMode = 0; // Linear
+    curve.Data.Structured.CurveParameters.FirstPointOffset = 0;
+    curve.Data.Structured.CurveParameters.PointCount = 2;
+
+    auto scaleCurve = m_values.ModifyValue(&AreaTrigger::m_areaTriggerData).ModifyValue(&UF::AreaTriggerData::OverrideScaleCurve);
+    SetUpdateFieldValue(scaleCurve.ModifyValue(&UF::ScaleCurve::StartTimeOffset), 0u);
+    SetUpdateFieldValue(scaleCurve.ModifyValue(&UF::ScaleCurve::Points, 0), Position(0.0f, overrideScale));
+    SetUpdateFieldValue(scaleCurve.ModifyValue(&UF::ScaleCurve::Points, 1), Position(1.0f, overrideScale));
+    SetUpdateFieldValue(scaleCurve.ModifyValue(&UF::ScaleCurve::ParameterCurve), curve.Data.Raw[5]);
+    SetUpdateFieldValue(scaleCurve.ModifyValue(&UF::ScaleCurve::OverrideActive), true);
+}
+
+void AreaTrigger::ClearOverrideScaleCurve()
+{
+    auto scaleCurve = m_values.ModifyValue(&AreaTrigger::m_areaTriggerData).ModifyValue(&UF::AreaTriggerData::OverrideScaleCurve);
+    SetUpdateFieldValue(scaleCurve.ModifyValue(&UF::ScaleCurve::OverrideActive), false);
+    SetUpdateFieldValue(scaleCurve.ModifyValue(&UF::ScaleCurve::StartTimeOffset), 0u);
+    SetUpdateFieldValue(scaleCurve.ModifyValue(&UF::ScaleCurve::ParameterCurve), 0u);
+    SetUpdateFieldValue(scaleCurve.ModifyValue(&UF::ScaleCurve::Points, 0), Position());
+    SetUpdateFieldValue(scaleCurve.ModifyValue(&UF::ScaleCurve::Points, 1), Position());
+}
+
 GuidUnorderedSet const AreaTrigger::GetInsidePlayers() const
 {
     GuidUnorderedSet insidePlayers;

--- a/src/server/game/Entities/AreaTrigger/AreaTrigger.h
+++ b/src/server/game/Entities/AreaTrigger/AreaTrigger.h
@@ -84,6 +84,12 @@ public:
         uint32 GetTimeToTargetScale() const { return m_areaTriggerData->TimeToTargetScale; }
         void SetTimeToTargetScale(uint32 timeToTargetScale) { SetUpdateFieldValue(m_values.ModifyValue(&AreaTrigger::m_areaTriggerData).ModifyValue(&UF::AreaTriggerData::TimeToTargetScale), timeToTargetScale); }
 
+        // Resize the graphic the client draws, as a multiple of the template's size. The
+        // server-side shape is untouched - a script that scales the visual is responsible
+        // for scaling whatever range test it runs against it by the same factor.
+        void SetOverrideScaleCurve(float overrideScale);
+        void ClearOverrideScaleCurve();
+
         void UpdateTimeToTarget(uint32 timeToTarget);
         int32 GetDuration() const { return _duration; }
         int32 GetTotalDuration() const { return _totalDuration; }

--- a/src/server/game/Entities/Item/Item.cpp
+++ b/src/server/game/Entities/Item/Item.cpp
@@ -467,9 +467,14 @@ bool Item::Create(ObjectGuid::LowType guidlow, uint32 itemId, ItemContext contex
     SetUpdateFieldValue(m_values.ModifyValue(&Item::m_itemData).ModifyValue(&UF::ItemData::MaxDurability), itemProto->MaxDurability);
     SetDurability(itemProto->MaxDurability);
 
-    for (std::size_t i = 0; i < itemProto->Effects.size(); ++i)
-        if (i < 5)
-            SetSpellCharges(i, itemProto->Effects[i]->Charges);
+    uint8 chargeSlot = 0;
+    for (ItemEffectEntry const* itemEffect : GetEffects())
+    {
+        if (chargeSlot >= MAX_ITEM_SPELLS)
+            break;
+
+        SetSpellCharges(chargeSlot++, itemEffect->Charges);
+    }
 
     SetExpiration(itemProto->GetDuration());
     SetCreatePlayedTime(0);
@@ -558,10 +563,12 @@ void Item::SaveToDB(CharacterDatabaseTransaction& trans)
             stmt->setUInt32(++index, GetCount());
             stmt->setUInt32(++index, m_itemData->Expiration);
 
+            // Charge slots are keyed by effect index and the update field holds only
+            // MAX_ITEM_SPELLS of them. LoadFromDB reads back at the same clamped width.
             std::ostringstream ssSpells;
-            if (ItemTemplate const* itemProto = sObjectMgr->GetItemTemplate(GetEntry()))
-                for (uint8 i = 0; i < itemProto->Effects.size(); ++i)
-                    ssSpells << GetSpellCharges(i) << ' ';
+            uint8 const chargeSlots = uint8(std::min<uint32>(_bonusData.EffectCount, MAX_ITEM_SPELLS));
+            for (uint8 i = 0; i < chargeSlots; ++i)
+                ssSpells << GetSpellCharges(i) << ' ';
             stmt->setString(++index, ssSpells.str());
 
             stmt->setUInt32(++index, m_itemData->DynamicFlags);
@@ -848,11 +855,6 @@ bool Item::LoadFromDB(ObjectGuid::LowType guid, ObjectGuid ownerGuid, Field* fie
         need_save = true;
     }
 
-    Tokenizer tokens(fields[6].GetString(), ' ', proto->Effects.size());
-    if (tokens.size() == proto->Effects.size())
-        for (uint8 i = 0; i < proto->Effects.size(); ++i)
-            SetSpellCharges(i, atoi(tokens[i]));
-
     SetItemFlags(ItemFieldFlags(itemFlags));
 
     /*SetUInt32Value(ITEM_FIELD_CONTEXT, fields[19].GetUInt8());
@@ -890,6 +892,14 @@ bool Item::LoadFromDB(ObjectGuid::LowType guid, ObjectGuid ownerGuid, Field* fie
     for (char const* token : bonusListString)
         bonusListIDs.push_back(atoi(token));
     SetBonuses(std::move(bonusListIDs));
+
+    // Must run after SetBonuses: before it only the template effects are known. An item
+    // stored before its bonus list changed legitimately has fewer tokens than effects,
+    // so read what is there rather than discarding every charge on a count mismatch.
+    Tokenizer tokens(fields[6].GetString(), ' ', _bonusData.EffectCount);
+    uint8 const chargeSlots = uint8(std::min({ uint32(tokens.size()), _bonusData.EffectCount, uint32(MAX_ITEM_SPELLS) }));
+    for (uint8 i = 0; i < chargeSlots; ++i)
+        SetSpellCharges(i, atoi(tokens[i]));
 
     SetModifier(ITEM_MODIFIER_TRANSMOG_APPEARANCE_ALL_SPECS, fields[19].GetUInt32());
     SetModifier(ITEM_MODIFIER_TRANSMOG_APPEARANCE_SPEC_1, fields[20].GetUInt32());
@@ -2414,8 +2424,10 @@ void Item::AddBonuses(uint32 bonusListID)
         std::vector<int32> bonusListIDs = m_itemData->BonusListIDs;
         bonusListIDs.push_back(bonusListID);
         SetUpdateFieldValue(m_values.ModifyValue(&Item::m_itemData).ModifyValue(&UF::ItemData::BonusListIDs), std::move(bonusListIDs));
+        uint32 const oldEffectCount = _bonusData.EffectCount;
         for (ItemBonusEntry const* bonus : *bonuses)
             _bonusData.AddBonus(bonus->Type, bonus->Value);
+        SeedSpellCharges(oldEffectCount);
         SetUpdateFieldValue(m_values.ModifyValue(&Item::m_itemData).ModifyValue(&UF::ItemData::ItemAppearanceModID), _bonusData.AppearanceModID);
     }
 }
@@ -2424,9 +2436,11 @@ void Item::SetBonuses(std::vector<int32> bonusListIDs)
 {
     SetUpdateFieldValue(m_values.ModifyValue(&Item::m_itemData).ModifyValue(&UF::ItemData::BonusListIDs), std::move(bonusListIDs));
 
+    uint32 const oldEffectCount = _bonusData.EffectCount;
     for (int32 bonusListID : *m_itemData->BonusListIDs)
         _bonusData.AddBonusList(bonusListID);
 
+    SeedSpellCharges(oldEffectCount);
     SetUpdateFieldValue(m_values.ModifyValue(&Item::m_itemData).ModifyValue(&UF::ItemData::ItemAppearanceModID), _bonusData.AppearanceModID);
 }
 
@@ -2435,6 +2449,17 @@ void Item::ClearBonuses()
     SetUpdateFieldValue(m_values.ModifyValue(&Item::m_itemData).ModifyValue(&UF::ItemData::BonusListIDs), std::vector<int32>());
     _bonusData.Initialize(GetTemplate());
     SetUpdateFieldValue(m_values.ModifyValue(&Item::m_itemData).ModifyValue(&UF::ItemData::ItemAppearanceModID), _bonusData.AppearanceModID);
+}
+
+// Create seeds charges from the template effects alone and every caller applies bonus
+// lists afterwards, so an effect arriving through ITEM_BONUS_ITEM_EFFECT_ID would keep a
+// charge slot of 0 and Spell::CheckItems would reject every cast. Slots below firstEffect
+// are left alone - a live item's charges are spent over time and must not reset.
+void Item::SeedSpellCharges(uint32 firstEffect)
+{
+    uint8 const chargeSlots = uint8(std::min<uint32>(_bonusData.EffectCount, MAX_ITEM_SPELLS));
+    for (uint8 i = uint8(std::min<uint32>(firstEffect, MAX_ITEM_SPELLS)); i < chargeSlots; ++i)
+        SetSpellCharges(i, _bonusData.Effects[i]->Charges);
 }
 
 bool Item::IsArtifactDisabled() const
@@ -2708,6 +2733,18 @@ void BonusData::Initialize(ItemTemplate const* proto)
     CanDisenchant = (proto->GetFlags() & ITEM_FLAG_NO_DISENCHANT) == 0;
     CanScrap = (proto->GetFlags4() & ITEM_FLAG4_SCRAPABLE) != 0;
 
+    EffectCount = 0;
+    for (ItemEffectEntry const* itemEffect : proto->Effects)
+    {
+        if (EffectCount >= MAX_BONUS_ITEM_EFFECTS)
+            break;
+
+        Effects[EffectCount++] = itemEffect;
+    }
+
+    for (uint32 i = EffectCount; i < MAX_BONUS_ITEM_EFFECTS; ++i)
+        Effects[i] = nullptr;
+
     _state.SuffixPriority = std::numeric_limits<int32>::max();
     _state.AppearanceModPriority = std::numeric_limits<int32>::max();
     _state.ScalingStatDistributionPriority = std::numeric_limits<int32>::max();
@@ -2829,6 +2866,13 @@ void BonusData::AddBonus(uint32 type, int32 const (&values)[3])
             break;
         case ITEM_BONUS_OVERRIDE_CAN_SCRAP:
             CanScrap = values[0] != 0;
+            break;
+        case ITEM_BONUS_ITEM_EFFECT_ID:
+            // Skip unknown ids silently: bad hotfix data must not crash, and logging
+            // here would fire once per item instance.
+            if (ItemEffectEntry const* itemEffect = sItemEffectStore.LookupEntry(uint32(values[0])))
+                if (EffectCount < MAX_BONUS_ITEM_EFFECTS)
+                    Effects[EffectCount++] = itemEffect;
             break;
     }
 }

--- a/src/server/game/Entities/Item/Item.h
+++ b/src/server/game/Entities/Item/Item.h
@@ -24,6 +24,7 @@
 #include "ItemDefines.h"
 #include "ItemEnchantmentMgr.h"
 #include "ItemTemplate.h"
+#include "IteratorPair.h"
 #include "Loot.h"
 
 class SpellInfo;
@@ -66,6 +67,11 @@ enum ItemUpdateState
 
 #define MAX_ITEM_SPELLS 5
 
+// Caps the template effects plus bonus-granted ones (ITEM_BONUS_ITEM_EFFECT_ID). Far
+// above anything a live item reaches; it exists only so malformed hotfix data cannot
+// grow the set without limit.
+#define MAX_BONUS_ITEM_EFFECTS 16
+
 bool ItemCanGoIntoBag(ItemTemplate const* proto, ItemTemplate const* pBagProto);
 extern ItemModifier const AppearanceModifierSlotBySpec[MAX_SPECIALIZATIONS];
 extern ItemModifier const IllusionModifierSlotBySpec[MAX_SPECIALIZATIONS];
@@ -96,6 +102,8 @@ struct BonusData
     bool CanDisenchant;
     bool CanScrap;
     bool HasFixedLevel;
+    ItemEffectEntry const* Effects[MAX_BONUS_ITEM_EFFECTS];
+    uint32 EffectCount;
 
     void Initialize(ItemTemplate const* proto);
     void Initialize(WorldPackets::Item::ItemInstance const& itemInstance);
@@ -184,6 +192,16 @@ public:
 
     ItemTemplate const* GetTemplate() const;
     BonusData const* GetBonus() const { return &_bonusData; }
+
+    // Template effects plus bonus-granted ones, in that order. Prefer this over
+    // GetTemplate()->Effects wherever an Item instance is in hand - the template
+    // alone does not know about bonus-granted effects.
+    Trinity::IteratorPair<ItemEffectEntry const* const*> GetEffects() const
+    {
+        return { { _bonusData.Effects, _bonusData.Effects + _bonusData.EffectCount } };
+    }
+
+    uint32 GetEffectCount() const { return _bonusData.EffectCount; }
 
     ObjectGuid GetOwnerGUID()    const { return m_itemData->Owner; }
     void SetOwnerGUID(ObjectGuid guid) { SetUpdateFieldValue(m_values.ModifyValue(&Item::m_itemData).ModifyValue(&UF::ItemData::Owner), guid); }
@@ -425,6 +443,7 @@ public:
 
     protected:
         void ApplyBonusList(uint32 itemBonusListId);
+        void SeedSpellCharges(uint32 firstEffect);
         BonusData _bonusData;
 
     private:

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -685,6 +685,7 @@ bool Player::Create(ObjectGuid::LowType guidlow, WorldPackets::Character::Charac
                 // special amount for food/drink
                 if (iProto->GetClass() == ITEM_CLASS_CONSUMABLE && iProto->GetSubClass() == ITEM_SUBCLASS_FOOD_DRINK)
                 {
+                    // Template effects only: this walks stored item ids, not instances.
                     if (iProto->Effects.size() >= 1)
                     {
                         switch (iProto->Effects[0]->SpellCategoryID)
@@ -8335,13 +8336,12 @@ void Player::CastAllObtainSpells()
 
 void Player::ApplyItemObtainSpells(Item* item, bool apply)
 {
-    ItemTemplate const* itemTemplate = item->GetTemplate();
-    for (uint8 i = 0; i < itemTemplate->Effects.size(); ++i)
+    for (ItemEffectEntry const* effectData : item->GetEffects())
     {
-        if (itemTemplate->Effects[i]->TriggerType != ITEM_SPELLTRIGGER_ON_OBTAIN) // On obtain trigger
+        if (effectData->TriggerType != ITEM_SPELLTRIGGER_ON_OBTAIN) // On obtain trigger
             continue;
 
-        int32 const spellId = itemTemplate->Effects[i]->SpellID;
+        int32 const spellId = effectData->SpellID;
         if (spellId <= 0)
             continue;
 
@@ -8382,14 +8382,11 @@ void Player::ApplyItemEquipSpell(Item* item, bool apply, bool formChange /*= fal
     if (!item)
         return;
 
-    ItemTemplate const* proto = item->GetTemplate();
-    if (!proto)
+    if (!item->GetTemplate())
         return;
 
-    for (uint8 i = 0; i < proto->Effects.size(); ++i)
+    for (ItemEffectEntry const* effectData : item->GetEffects())
     {
-        ItemEffectEntry const* effectData = proto->Effects[i];
-
         // wrong triggering type
         if (apply && effectData->TriggerType != ITEM_SPELLTRIGGER_ON_EQUIP)
             continue;
@@ -8727,10 +8724,8 @@ void Player::CastItemCombatSpell(DamageInfo const& damageInfo, Item* item, ItemT
     bool canTrigger = (damageInfo.GetHitMask() & (PROC_HIT_NORMAL | PROC_HIT_CRITICAL | PROC_HIT_ABSORB)) != 0;
     if (canTrigger)
     {
-        for (uint8 i = 0; i < proto->Effects.size(); ++i)
+        for (ItemEffectEntry const* effectData : item->GetEffects())
         {
-            ItemEffectEntry const* effectData = proto->Effects[i];
-
             // wrong triggering type
             if (effectData->TriggerType != ITEM_SPELLTRIGGER_CHANCE_ON_HIT)
                 continue;
@@ -8857,6 +8852,8 @@ void Player::CastItemUseSpell(Item* item, SpellCastTargets const& targets, Objec
 {
     ItemTemplate const* proto = item->GetTemplate();
     // special learning case
+    // Template effects only: the learn-spell special case is keyed to the two fixed
+    // template effect slots, which bonus-granted effects are appended after.
     if (proto->Effects.size() >= 2)
     {
         if (proto->Effects[0]->SpellID == 483 || proto->Effects[0]->SpellID == 55884)
@@ -8888,10 +8885,8 @@ void Player::CastItemUseSpell(Item* item, SpellCastTargets const& targets, Objec
     }
 
     // item spells cast at use
-    for (uint8 i = 0; i < proto->Effects.size(); ++i)
+    for (ItemEffectEntry const* effectData : item->GetEffects())
     {
-        ItemEffectEntry const* effectData = proto->Effects[i];
-
         // wrong triggering type
         if (effectData->TriggerType != ITEM_SPELLTRIGGER_ON_USE)
             continue;
@@ -12709,6 +12704,7 @@ InventoryResult Player::CanUseItem(ItemTemplate const* proto, bool skipRequiredL
         return EQUIP_ERR_CANT_EQUIP_REPUTATION;
 
     // learning (recipes, mounts, pets, etc.)
+    // Template effects only: same fixed learn-spell slots as CastItemUseSpell.
     if (proto->Effects.size() >= 2)
         if (proto->Effects[0]->SpellID == 483 || proto->Effects[0]->SpellID == 55884)
             if (HasSpell(proto->Effects[1]->SpellID))
@@ -24598,6 +24594,8 @@ void Player::UpdatePotionCooldown(Spell* spell)
     {
         // spell/item pair let set proper cooldown (except non-existing charged spell cooldown spellmods for potions)
         if (ItemTemplate const* proto = sObjectMgr->GetItemTemplate(m_lastPotionId))
+            // Template effects only: UpdatePotionCooldown is keyed off m_lastPotionId,
+            // an item id kept after the Item itself is gone.
             for (uint8 idx = 0; idx < proto->Effects.size(); ++idx)
                 if (proto->Effects[idx]->TriggerType == ITEM_SPELLTRIGGER_ON_USE)
                     if (SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(proto->Effects[idx]->SpellID))
@@ -25555,10 +25553,8 @@ void Player::ApplyEquipCooldown(Item* pItem)
         return;
 
     std::chrono::steady_clock::time_point now = GameTime::GetGameTimeSteadyPoint();
-    for (uint8 i = 0; i < proto->Effects.size(); ++i)
+    for (ItemEffectEntry const* effectData : pItem->GetEffects())
     {
-        ItemEffectEntry const* effectData = proto->Effects[i];
-
         // apply proc cooldown to equip auras if we have any
         if (effectData->TriggerType == ITEM_SPELLTRIGGER_ON_EQUIP)
         {

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1089,6 +1089,12 @@ void Player::Update(uint32 p_time)
     if (!IsInWorld())
         return;
 
+    if (m_corruptionNeedsUpdate)
+    {
+        m_corruptionNeedsUpdate = false;
+        UpdateCorruption();
+    }
+
     // undelivered mail
     if (m_nextMailDelivereTime && m_nextMailDelivereTime <= time(nullptr))
     {
@@ -4636,6 +4642,11 @@ void Player::ResurrectPlayer(float restore_percent, bool applySickness)
 
     setDeathState(ALIVE);
 
+    // RemoveAllAurasOnDeath stripped the corruption penalties and nothing puts them back:
+    // the sync is driven by a rating change or an area transition, and resurrecting is
+    // neither. Reviving where you fell otherwise leaves the player uncorrupted.
+    ScheduleCorruptionUpdate();
+
     // add the flag to make sure opcode is always sent
     AddUnitMovementFlag(MOVEMENTFLAG_WATERWALKING);
     SetWaterWalking(false);
@@ -5527,7 +5538,11 @@ void Player::UpdateRating(CombatRating cr)
             break;
         case CR_CORRUPTION:
         case CR_CORRUPTION_RESISTANCE:
-            UpdateCorruption();
+            // Bulk rebuilds strip every item's corruption before re-applying it, so syncing per
+            // mutation would walk the total down to zero and tear down each tier's aura on the
+            // way. Callers that clear this flag are responsible for one sync when they finish.
+            if (affectStats)
+                ScheduleCorruptionUpdate();
             break;
         case CR_SPEED:
         case CR_RESILIENCE_PLAYER_DAMAGE:
@@ -7690,6 +7705,11 @@ void Player::UpdateArea(uint32 newArea)
                 if (garrison.second->IsAllowedArea(newArea))
                     garrison.second->Enter();
         }
+
+        // A corruption penalty can be gated on a PlayerConditionID that reads the player's
+        // location, and nothing else re-evaluates those conditions when only the area
+        // changes. Safe on every transition: the sync casts only what is missing.
+        ScheduleCorruptionUpdate();
     }
 }
 
@@ -30828,12 +30848,15 @@ void Player::CreateChallengeKey(Item* item)
 void Player::SetEffectiveLevelAndMaxItemLevel(uint32 effectiveLevel, uint32 maxItemLevel)
 {
     float healthPct = GetHealthPct();
+    SetCanModifyStats(false);
     _RemoveAllItemMods();
 
     SetUpdateFieldValue(m_values.ModifyValue(&Unit::m_unitData).ModifyValue(&UF::UnitData::EffectiveLevel), effectiveLevel);
     SetUpdateFieldValue(m_values.ModifyValue(&Unit::m_unitData).ModifyValue(&UF::UnitData::MaxItemLevel), maxItemLevel);
 
     _ApplyAllItemMods();
+    SetCanModifyStats(true);
+
     UpdateAverageItemLevel();
 
     uint32 basemana = 0;
@@ -30861,9 +30884,15 @@ void Player::UpdateItemLevelAreaBasedScaling()
     if (_usePvpItemLevels != pvpActivity)
     {
         float healthPct = GetHealthPct();
+        SetCanModifyStats(false);
         _RemoveAllItemMods();
         ActivatePvpItemLevels(pvpActivity);
         _ApplyAllItemMods();
+        SetCanModifyStats(true);
+        // The bracket defers every derived stat, not only corruption, and neither item-mod
+        // pass recomputes on its own - so settle them all once here, as _ApplyAllStatBonuses
+        // does, leaving the max health scaled below freshly computed rather than stale.
+        UpdateAllStats();
         SetHealth(CalculatePct(GetMaxHealth(), healthPct));
     }
     // @todo other types of power scaling

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1993,7 +1993,12 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         void UpdateLeechPercentage();
 
         void UpdateSpellCritChance();
+        float GetEffectiveCorruption() const;
         void UpdateCorruption();
+        // Corruption penalties are synced once per tick rather than at each mutation site.
+        // A single item swap can move several corrupted pieces through several intermediate
+        // states; syncing each one would apply and remove the same penalty auras repeatedly.
+        void ScheduleCorruptionUpdate() { m_corruptionNeedsUpdate = true; }
         void UpdateArmorPenetration(int32 amount);
         void UpdateExpertise(WeaponAttackType attType);
         void ApplyManaRegenBonus(int32 amount, bool apply);
@@ -3016,6 +3021,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         bool m_canParry;
         bool m_canBlock;
         bool m_canTitanGrip;
+        bool m_corruptionNeedsUpdate = false;
         uint32 m_titanGripPenaltySpellId;
         uint8 m_swingErrorMsg;
 

--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -721,9 +721,14 @@ void Player::UpdateSpellCritChance()
     SetUpdateFieldValue(m_values.ModifyValue(&Player::m_activePlayerData).ModifyValue(&UF::ActivePlayerData::SpellCritPercentage), crit);
 }
 
+float Player::GetEffectiveCorruption() const
+{
+    return GetRatingBonusValue(CR_CORRUPTION) - GetRatingBonusValue(CR_CORRUPTION_RESISTANCE);
+}
+
 void Player::UpdateCorruption()
 {
-    float effectiveCorruption = GetRatingBonusValue(CR_CORRUPTION) - GetRatingBonusValue(CR_CORRUPTION_RESISTANCE);
+    float const effectiveCorruption = GetEffectiveCorruption();
     for (CorruptionEffectsEntry const* corruptionEffect : sCorruptionEffectsStore)
     {
         if ((CorruptionEffectsFlag(corruptionEffect->Flags) & CorruptionEffectsFlag::Disabled) != CorruptionEffectsFlag::None)
@@ -744,7 +749,13 @@ void Player::UpdateCorruption()
             }
         }
 
-        CastSpell(this, corruptionEffect->Aura, true);
+        // Re-casting a penalty that is already applied restarts its duration and resets its
+        // proc state, and this runs on every rating change and area transition. Cast only
+        // what is missing; what is already there recomputes its magnitudes in place.
+        if (Aura* corruptionAura = GetAura(corruptionEffect->Aura))
+            corruptionAura->RecalculateAmountOfEffects();
+        else
+            CastSpell(this, corruptionEffect->Aura, true);
     }
 }
 

--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -210,7 +210,7 @@ bool Player::UpdateAllStats()
     }
 
     UpdateArmor();
-    // calls UpdateAttackPowerAndDamage() in UpdateArmor for SPELL_AURA_MOD_ATTACK_POWER_OF_ARMOR
+    // UpdateArmor refreshes melee attack power on its way out, so only ranged is needed here
     UpdateAttackPowerAndDamage(true);
     UpdateMaxHealth();
 
@@ -288,7 +288,7 @@ void Player::UpdateArmor()
     if (Guardian* guardian = GetGuardianPet())
         guardian->UpdateArmor();
 
-    UpdateAttackPowerAndDamage();                           // armor dependent auras update for SPELL_AURA_MOD_ATTACK_POWER_OF_ARMOR
+    UpdateAttackPowerAndDamage();                           // melee attack power refresh
 }
 
 float Player::GetHealthBonusFromStamina()
@@ -389,17 +389,6 @@ void Player::UpdateAttackPowerAndDamage(bool ranged)
     float base_attPower  = GetModifierValue(unitMod, BASE_VALUE) * GetModifierValue(unitMod, BASE_PCT);
     float attPowerMod = GetModifierValue(unitMod, TOTAL_VALUE);
     float attPowerMultiplier = GetModifierValue(unitMod, TOTAL_PCT) - 1.0f;
-
-    //add dynamic flat mods
-    if (!ranged)
-    {
-        AuraEffectList const& mAPbyArmor = GetAuraEffectsByType(SPELL_AURA_MOD_ATTACK_POWER_OF_ARMOR);
-        for (AuraEffectList::const_iterator iter = mAPbyArmor.begin(); iter != mAPbyArmor.end(); ++iter)
-        {
-            attPowerMod += int32(GetArmor());
-            (*iter)->GetAmount();
-        }
-    }
 
     if (ranged)
     {

--- a/src/server/game/Handlers/ItemHandler.cpp
+++ b/src/server/game/Handlers/ItemHandler.cpp
@@ -1190,7 +1190,7 @@ void WorldSession::HandleUseCritterItem(WorldPackets::Item::UseCritterItem& useC
     if (!item)
         return;
 
-    if (item->GetTemplate()->Effects.size() < 2)
+    if (item->GetEffectCount() < 2)
         return;
 
     _player->DestroyItem(item->GetBagSlot(), item->GetSlot(), true);

--- a/src/server/game/Handlers/SpellHandler.cpp
+++ b/src/server/game/Handlers/SpellHandler.cpp
@@ -95,9 +95,14 @@ void WorldSession::HandleUseItemOpcode(WorldPackets::Spells::UseItem& packet)
 
     if (user->IsInCombat())
     {
-        for (uint32 i = 0; i < proto->Effects.size(); ++i)
+        for (ItemEffectEntry const* itemEffect : item->GetEffects())
         {
-            if (SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(proto->Effects[i]->SpellID))
+            // Only the on-use effect is being cast here - a passive effect that happens to
+            // be flagged unusable in combat must not block it
+            if (itemEffect->TriggerType != ITEM_SPELLTRIGGER_ON_USE)
+                continue;
+
+            if (SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(itemEffect->SpellID))
             {
                 if (!spellInfo->CanBeUsedInCombat())
                 {

--- a/src/server/game/Handlers/ToyHandler.cpp
+++ b/src/server/game/Handlers/ToyHandler.cpp
@@ -61,6 +61,8 @@ void WorldSession::HandleUseToy(WorldPackets::Toy::UseToy& packet)
     if (!_collectionMgr->HasToy(itemId))
         return;
 
+    // Template effects only: a toy is used from the collection by item entry - the
+    // player need not own an instance of it.
     auto effect = std::find_if(item->Effects.begin(), item->Effects.end(), [&packet](ItemEffectEntry const* effect)
     {
         return packet.Cast.SpellID == effect->SpellID;

--- a/src/server/game/Loot/Loot.cpp
+++ b/src/server/game/Loot/Loot.cpp
@@ -81,7 +81,8 @@ bool LootItem::AllowedForPlayer(Player const* player) const
             return false;
 
         // not show loot for players without profession or those who already know the recipe
-        if ((pProto->GetFlags() & ITEM_FLAG_HIDE_UNUSABLE_RECIPE) && (!player->HasSkill(pProto->GetRequiredSkill()) || player->HasSpell(pProto->Effects[1]->SpellID)))
+        // Template effects only: loot is filtered before any Item is created.
+        if ((pProto->GetFlags() & ITEM_FLAG_HIDE_UNUSABLE_RECIPE) && (!player->HasSkill(pProto->GetRequiredSkill()) || (pProto->Effects.size() > 1 && player->HasSpell(pProto->Effects[1]->SpellID))))
             return false;
 
         // not show loot for not own team

--- a/src/server/game/Spells/Auras/SpellAuraDefines.h
+++ b/src/server/game/Spells/Auras/SpellAuraDefines.h
@@ -360,7 +360,7 @@ enum AuraType : uint32
     SPELL_AURA_MOD_BASE_HEALTH_PCT                          = 282,
     SPELL_AURA_MOD_HEALING_RECEIVED                         = 283,  // Possibly only for some spell family class spells
     SPELL_AURA_LINKED                                       = 284,
-    SPELL_AURA_MOD_ATTACK_POWER_OF_ARMOR                    = 285,
+    SPELL_AURA_LINKED_2                                     = 285,
     SPELL_AURA_ABILITY_PERIODIC_CRIT                        = 286,
     SPELL_AURA_DEFLECT_SPELLS                               = 287,
     SPELL_AURA_IGNORE_HIT_DIRECTION                         = 288,

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -350,7 +350,7 @@ NonDefaultConstructible<pAuraEffectHandler> AuraEffectHandler[TOTAL_AURAS]=
     &AuraEffect::HandleAuraIncreaseBaseHealthPercent,             //282 SPELL_AURA_INCREASE_BASE_HEALTH_PERCENT
     &AuraEffect::HandleNoImmediateEffect,                         //283 SPELL_AURA_MOD_HEALING_RECEIVED       implemented in Unit::SpellHealingBonus
     &AuraEffect::HandleAuraLinked,                                //284 SPELL_AURA_LINKED
-    &AuraEffect::HandleAuraModAttackPowerOfArmor,                 //285 SPELL_AURA_MOD_ATTACK_POWER_OF_ARMOR  implemented in Player::UpdateAttackPowerAndDamage
+    &AuraEffect::HandleAuraLinked,                                //285 SPELL_AURA_LINKED_2
     &AuraEffect::HandleUnused,                                    //286 old SPELL_AURA_ABILITY_PERIODIC_CRIT
     &AuraEffect::HandleNoImmediateEffect,                         //287 SPELL_AURA_DEFLECT_SPELLS             implemented in Unit::MagicSpellHitResult and Unit::MeleeSpellHitResult
     &AuraEffect::HandleNoImmediateEffect,                         //288 SPELL_AURA_IGNORE_HIT_DIRECTION  implemented in Unit::MagicSpellHitResult and Unit::MeleeSpellHitResult Unit::RollMeleeOutcomeAgainst
@@ -4351,18 +4351,6 @@ void AuraEffect::HandleAuraModRangedAttackPowerPercent(AuraApplication const* au
 
     //UNIT_FIELD_RANGED_ATTACK_POWER_MULTIPLIER = multiplier - 1
     target->HandleStatModifier(UNIT_MOD_ATTACK_POWER_RANGED, TOTAL_PCT, float(GetAmount()), apply);
-}
-
-void AuraEffect::HandleAuraModAttackPowerOfArmor(AuraApplication const* aurApp, uint8 mode, bool /*apply*/) const
-{
-    if (!(mode & (AURA_EFFECT_HANDLE_CHANGE_AMOUNT_MASK | AURA_EFFECT_HANDLE_STAT)))
-        return;
-
-    Unit* target = aurApp->GetTarget();
-
-    // Recalculate bonus
-    if (target->GetTypeId() == TYPEID_PLAYER)
-        target->ToPlayer()->UpdateAttackPowerAndDamage(false);
 }
 
 /********************************/

--- a/src/server/game/Spells/Auras/SpellAuraEffects.h
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.h
@@ -307,7 +307,6 @@ class TC_GAME_API AuraEffect
         void HandleAuraModRangedAttackPower(AuraApplication const* aurApp, uint8 mode, bool apply) const;
         void HandleAuraModAttackPowerPercent(AuraApplication const* aurApp, uint8 mode, bool apply) const;
         void HandleAuraModRangedAttackPowerPercent(AuraApplication const* aurApp, uint8 mode, bool apply) const;
-        void HandleAuraModAttackPowerOfArmor(AuraApplication const* aurApp, uint8 mode, bool apply) const;
         //   damage bonus
         void HandleModDamageDone(AuraApplication const* aurApp, uint8 mode, bool apply) const;
         void HandleModDamagePercentDone(AuraApplication const* aurApp, uint8 mode, bool apply) const;

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -4693,14 +4693,20 @@ void Spell::TakeCastItem()
     }
 
     bool expendable = false;
-    bool withoutCharges = false;
+    // Starts set so the verdict of every charged effect can be folded in below; an item
+    // with no charged effect at all is never expendable and so is never destroyed here.
+    bool withoutCharges = true;
 
-    for (uint8 i = 0; i < proto->Effects.size() && i < 5; ++i)
+    uint8 i = 0;
+    for (ItemEffectEntry const* itemEffect : m_CastItem->GetEffects())
     {
+        if (i >= MAX_ITEM_SPELLS)
+            break;
+
         // item has limited charges
-        if (proto->Effects[i]->Charges)
+        if (itemEffect->Charges)
         {
-            if (proto->Effects[i]->Charges < 0)
+            if (itemEffect->Charges < 0)
                 expendable = true;
 
             int32 charges = m_CastItem->GetSpellCharges(i);
@@ -4714,9 +4720,15 @@ void Spell::TakeCastItem()
                 m_CastItem->SetState(ITEM_CHANGED, player);
             }
 
-            // all charges used
-            withoutCharges = (charges == 0);
+            // A stack shares one charge array, so the write above was skipped and this
+            // reads back the seeded value - only a persisted count says the item is spent.
+            // Fold rather than assign, so one spent effect cannot condemn an item whose
+            // other effects still have charges.
+            if (proto->GetMaxStackSize() == 1)
+                withoutCharges = withoutCharges && (charges == 0);
         }
+
+        ++i;
     }
 
     if (expendable && withoutCharges)
@@ -4897,14 +4909,19 @@ void Spell::TakeReagents()
         uint32 itemid = m_spellInfo->Reagent[x];
         uint32 itemcount = m_spellInfo->ReagentCount[x];
 
-        // if CastItem is also spell reagent
-        if (castItemTemplate && castItemTemplate->GetId() == itemid)
+        // if CastItem is also spell reagent - the template outlives m_CastItem, which this
+        // block clears, so a second reagent slot naming the same item must not re-enter it
+        if (m_CastItem && castItemTemplate && castItemTemplate->GetId() == itemid)
         {
-            for (uint8 s = 0; s < castItemTemplate->Effects.size() && s < 5; ++s)
+            uint8 s = 0;
+            for (ItemEffectEntry const* itemEffect : m_CastItem->GetEffects())
             {
+                if (s >= MAX_ITEM_SPELLS)
+                    break;
+
                 // CastItem will be used up and does not count as reagent
-                int32 charges = m_CastItem->GetSpellCharges(s);
-                if (castItemTemplate->Effects[s]->Charges < 0 && abs(charges) < 2)
+                int32 charges = m_CastItem->GetSpellCharges(s++);
+                if (itemEffect->Charges < 0 && abs(charges) < 2)
                 {
                     ++itemcount;
                     break;
@@ -6476,10 +6493,17 @@ SpellCastResult Spell::CheckItems(uint32* param1 /*= nullptr*/, uint32* param2 /
         if (!proto)
             return SPELL_FAILED_ITEM_NOT_READY;
 
-        for (uint8 i = 0; i < proto->Effects.size() && i < 5; ++i)
-            if (proto->Effects[i]->Charges)
-                if (m_CastItem->GetSpellCharges(i) == 0)
-                    return SPELL_FAILED_NO_CHARGES_REMAIN;
+        uint8 chargeSlot = 0;
+        for (ItemEffectEntry const* itemEffect : m_CastItem->GetEffects())
+        {
+            if (chargeSlot >= MAX_ITEM_SPELLS)
+                break;
+
+            if (itemEffect->Charges && m_CastItem->GetSpellCharges(chargeSlot) == 0)
+                return SPELL_FAILED_NO_CHARGES_REMAIN;
+
+            ++chargeSlot;
+        }
 
         // consumable cast item checks
         if (proto->GetClass() == ITEM_CLASS_CONSUMABLE && m_targets.GetUnitTarget())
@@ -6578,11 +6602,15 @@ SpellCastResult Spell::CheckItems(uint32* param1 /*= nullptr*/, uint32* param2 /
                     ItemTemplate const* proto = m_CastItem->GetTemplate();
                     if (!proto)
                         return SPELL_FAILED_ITEM_NOT_READY;
-                    for (uint8 s = 0; s < proto->Effects.size() && s < 5; ++s)
+                    uint8 s = 0;
+                    for (ItemEffectEntry const* itemEffect : m_CastItem->GetEffects())
                     {
+                        if (s >= MAX_ITEM_SPELLS)
+                            break;
+
                         // CastItem will be used up and does not count as reagent
-                        int32 charges = m_CastItem->GetSpellCharges(s);
-                        if (proto->Effects[s]->Charges < 0 && abs(charges) < 2)
+                        int32 charges = m_CastItem->GetSpellCharges(s++);
+                        if (itemEffect->Charges < 0 && abs(charges) < 2)
                         {
                             ++itemcount;
                             break;
@@ -6716,10 +6744,9 @@ SpellCastResult Spell::CheckItems(uint32* param1 /*= nullptr*/, uint32* param2 /
                     return SPELL_FAILED_LOWLEVEL;
 
                 bool isItemUsable = false;
-                ItemTemplate const* proto = targetItem->GetTemplate();
-                for (uint8 e = 0; e < proto->Effects.size(); ++e)
+                for (ItemEffectEntry const* itemEffect : targetItem->GetEffects())
                 {
-                    if (proto->Effects[e]->SpellID && proto->Effects[e]->TriggerType == ITEM_SPELLTRIGGER_ON_USE)
+                    if (itemEffect->SpellID && itemEffect->TriggerType == ITEM_SPELLTRIGGER_ON_USE)
                     {
                         isItemUsable = true;
                         break;
@@ -6914,9 +6941,17 @@ SpellCastResult Spell::CheckItems(uint32* param1 /*= nullptr*/, uint32* param2 /
 
                  if (Item* item = player->GetItemByEntry(itemId))
                  {
-                     for (uint8 x = 0; x < proto->Effects.size() && x < 5; ++x)
-                         if (proto->Effects[x]->Charges != 0 && item->GetSpellCharges(x) == proto->Effects[x]->Charges)
+                     uint8 x = 0;
+                     for (ItemEffectEntry const* itemEffect : item->GetEffects())
+                     {
+                         if (x >= MAX_ITEM_SPELLS)
+                             break;
+
+                         if (itemEffect->Charges != 0 && item->GetSpellCharges(x) == itemEffect->Charges)
                              return SPELL_FAILED_ITEM_AT_MAX_CHARGES;
+
+                         ++x;
+                     }
                  }
                  break;
             }

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -5777,9 +5777,15 @@ void Spell::EffectRechargeItem(SpellEffIndex /*effIndex*/)
 
     if (Item* item = player->GetItemByEntry(effectInfo->ItemType))
     {
-        ItemTemplate const* proto = item->GetTemplate();
-        for (size_t x = 0; x < proto->Effects.size() && x < 5; ++x)
-            item->SetSpellCharges(x, proto->Effects[x]->Charges);
+        uint8 x = 0;
+        for (ItemEffectEntry const* itemEffect : item->GetEffects())
+        {
+            if (x >= MAX_ITEM_SPELLS)
+                break;
+
+            item->SetSpellCharges(x++, itemEffect->Charges);
+        }
+
         item->SetState(ITEM_CHANGED, player);
     }
 }

--- a/src/server/game/Spells/SpellHistory.cpp
+++ b/src/server/game/Spells/SpellHistory.cpp
@@ -1032,6 +1032,9 @@ void SpellHistory::GetCooldownDurations(SpellInfo const* spellInfo, uint32 itemI
     {
         if (ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId))
         {
+            // Template effects only: this receives an item id, not an Item*, so a
+            // bonus-granted effect's cooldown override is out of reach. Corruption
+            // effects are passive, so nothing needs it yet.
             for (ItemEffectEntry const* itemEffect : proto->Effects)
             {
                 if (uint32(itemEffect->SpellID) == spellInfo->Id)

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -4086,6 +4086,14 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->AttributesEx8 |= SPELL_ATTR8_AURA_SEND_AMOUNT;
     });
 
+    // Corruption: the Grasping Tendrils snare is computed from effective corruption by
+    // spell_corruption_grasping_tendrils. Its DB2 base points are 0 like the payloads
+    // above, so the client needs the runtime amount to render anything but "0%".
+    ApplySpellFix({ 315176 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx8 |= SPELL_ATTR8_AURA_SEND_AMOUNT;
+    });
+
     SpellInfo* spellInfo = nullptr;
     for (uint32 i = 0; i < GetSpellInfoStoreSize(); ++i)
     {

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -4071,6 +4071,21 @@ void SpellMgr::LoadSpellInfoCorrections()
         const_cast<SpellEffectInfo*>(spellInfo->GetEffect(EFFECT_1))->Effect = 0;
     });
 
+    // Corruption: stat payloads whose entire magnitude is supplied at runtime by their
+    // aura-285 container via HandleAuraLinked -> CastCustomSpell. Their own DB2 base
+    // points are 0, so without AFLAG_SCALABLE the client renders 0 while the server
+    // holds the real value. See AuraApplication::BuildUpdatePacket.
+    ApplySpellFix({
+        320249, // Strikethrough
+        320253, // Masterful
+        320257, // Expedient
+        320259, // Versatile
+        320261  // Severe
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx8 |= SPELL_ATTR8_AURA_SEND_AMOUNT;
+    });
+
     SpellInfo* spellInfo = nullptr;
     for (uint32 i = 0; i < GetSpellInfoStoreSize(); ++i)
     {

--- a/src/server/scripts/Commands/cs_debug.cpp
+++ b/src/server/scripts/Commands/cs_debug.cpp
@@ -117,6 +117,7 @@ public:
             { "transportState", rbac::RBAC_PERM_COMMAND_DEBUG,              false, &HandleDebugTransportStateCommand,   "" },
             { "worldstate" ,   rbac::RBAC_PERM_COMMAND_DEBUG,               false, &HandleDebugWorldStateCommand,       "" },
             { "wsexpression" , rbac::RBAC_PERM_COMMAND_DEBUG,               false, &HandleDebugWSExpressionCommand,     "" },
+            { "corruption",    rbac::RBAC_PERM_COMMAND_DEBUG,               false, &HandleDebugCorruptionCommand,       "" },
         };
         static std::vector<ChatCommand> commandTable =
         {
@@ -1425,6 +1426,48 @@ public:
             handler->PSendSysMessage("True");
         else
             handler->PSendSysMessage("False");
+
+        return true;
+    }
+
+    static bool HandleDebugCorruptionCommand(ChatHandler* handler, char const* /*args*/)
+    {
+        Player* target = handler->getSelectedPlayerOrSelf();
+        if (!target)
+        {
+            handler->SendSysMessage(LANG_NO_CHAR_SELECTED);
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
+        float const effectiveCorruption = target->GetEffectiveCorruption();
+        handler->PSendSysMessage("Corruption for %s: effective %.2f (corruption %.2f - resistance %.2f)",
+            target->GetName().c_str(), effectiveCorruption,
+            target->GetRatingBonusValue(CR_CORRUPTION), target->GetRatingBonusValue(CR_CORRUPTION_RESISTANCE));
+
+        uint32 rows = 0;
+        for (CorruptionEffectsEntry const* corruptionEffect : sCorruptionEffectsStore)
+        {
+            ++rows;
+
+            char const* state;
+            if ((CorruptionEffectsFlag(corruptionEffect->Flags) & CorruptionEffectsFlag::Disabled) != CorruptionEffectsFlag::None)
+                state = "disabled";
+            else if (effectiveCorruption < corruptionEffect->MinCorruption)
+                state = "below threshold";
+            else if (PlayerConditionEntry const* playerCondition = sPlayerConditionStore.LookupEntry(corruptionEffect->PlayerConditionID))
+                state = ConditionMgr::IsPlayerMeetingCondition(target, playerCondition) ? "qualifies" : "condition failed";
+            else
+                state = "qualifies";
+
+            handler->PSendSysMessage("  row %u: min %.2f aura %d cond %d - %s, aura %s",
+                corruptionEffect->ID, corruptionEffect->MinCorruption, corruptionEffect->Aura,
+                corruptionEffect->PlayerConditionID, state,
+                target->HasAura(corruptionEffect->Aura) ? "APPLIED" : "absent");
+        }
+
+        if (!rows)
+            handler->SendSysMessage("CorruptionEffects.db2 holds no rows - no penalty can apply on this server. That is missing client data, not a core fault.");
 
         return true;
     }

--- a/src/server/scripts/Spells/spell_corruption.cpp
+++ b/src/server/scripts/Spells/spell_corruption.cpp
@@ -1,0 +1,77 @@
+/*
+ * 2026 BFA-HavenCore
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Scripts for the 8.3 corruption drawback penalties that Player::UpdateCorruption
+ * applies from CorruptionEffects.db2.
+ *
+ * Every magnitude in this file is a documented approximation. SpellEffect.db2 gives each
+ * drawback spell BasePoints 0, Coefficient 0 and RealPointsPerLevel 0, and no world DB
+ * override table carries a row for them - retail computed these server-side and shipped
+ * the client a placeholder. The sourcing for each curve is in the commit that added it.
+ */
+
+#include "Player.h"
+#include "ScriptMgr.h"
+#include "SpellAuraEffects.h"
+#include "SpellScript.h"
+
+#include <algorithm>
+#include <cmath>
+
+// Grasping Tendrils, 1+ Corruption. Container 315175 procs on damage taken and triggers
+// this 5 second snare, whose magnitude is Corruption + 10 percent.
+namespace GraspingTendrils
+{
+    constexpr float SlowBasePct     = 10.0f;  // snare at zero effective corruption
+    constexpr float SlowPctPerPoint = 1.0f;   // added per point of effective corruption
+    constexpr float SlowMaxPct      = 100.0f; // reported to reach a full root around 90
+}
+
+// Grasping Tendrils - 315176
+class spell_corruption_grasping_tendrils : public AuraScript
+{
+    PrepareAuraScript(spell_corruption_grasping_tendrils);
+
+    void CalculateAmount(AuraEffect const* /*aurEff*/, int32& amount, bool& canBeRecalculated)
+    {
+        Player* player = GetUnitOwner()->ToPlayer();
+        if (!player)
+            return;
+
+        float const slow = std::min(GraspingTendrils::SlowBasePct + player->GetEffectiveCorruption() * GraspingTendrils::SlowPctPerPoint,
+            GraspingTendrils::SlowMaxPct);
+
+        // Unit::UpdateSpeed feeds the strongest negative modifier straight to AddPct, so a
+        // snare has to be stored negative.
+        amount = -int32(std::lround(slow));
+
+        // Corruption can change while the 5s debuff is up - an item swap, a zone granting
+        // resistance. Snapshot at application rather than retuning mid-flight.
+        canBeRecalculated = false;
+    }
+
+    void Register() override
+    {
+        DoEffectCalcAmount += AuraEffectCalcAmountFn(spell_corruption_grasping_tendrils::CalculateAmount, EFFECT_0, SPELL_AURA_MOD_DECREASE_SPEED);
+    }
+};
+
+void AddSC_corruption_spell_scripts()
+{
+    RegisterAuraScript(spell_corruption_grasping_tendrils);
+}

--- a/src/server/scripts/Spells/spell_corruption.cpp
+++ b/src/server/scripts/Spells/spell_corruption.cpp
@@ -25,13 +25,25 @@
  * the client a placeholder. The sourcing for each curve is in the commit that added it.
  */
 
+#include "AreaTrigger.h"
+#include "AreaTriggerAI.h"
+#include "Log.h"
 #include "Player.h"
 #include "ScriptMgr.h"
 #include "SpellAuraEffects.h"
+#include "SpellInfo.h"
+#include "SpellMgr.h"
 #include "SpellScript.h"
+#include "Util.h"
 
 #include <algorithm>
 #include <cmath>
+
+enum CorruptionSpells
+{
+    SPELL_EYE_OF_CORRUPTION_SUMMON = 315154,
+    SPELL_EYE_OF_CORRUPTION_DAMAGE = 315161
+};
 
 // Grasping Tendrils, 1+ Corruption. Container 315175 procs on damage taken and triggers
 // this 5 second snare, whose magnitude is Corruption + 10 percent.
@@ -71,7 +83,126 @@ class spell_corruption_grasping_tendrils : public AuraScript
     }
 };
 
+// Eye of Corruption, 20+ Corruption. Container 315169 procs on damage dealt and triggers
+// 315154, which creates areatrigger 22815 for eight seconds.
+//
+// The tooltip promises that "range and damage increase with further Corruption", and those
+// are exactly the two quantities the client does not carry: every scaling field on the
+// damage effect 315161 is zero, ContentTuningID is 0 and there is no hotfix row. Both
+// curves below are Wowhead's 8.3 PTR sampling (news 295810), which its own author calls
+// approximate. The timings around them are read from the data instead - see the ctor.
+namespace EyeOfCorruption
+{
+    constexpr float DamagePerCorruption = 875.0f;  // per point of effective corruption
+    constexpr float DamageFlatOffset    = 1000.0f; // subtracted from the total
+    constexpr float RadiusPerCorruption = 0.2f;    // yards per point, ie corruption / 5
+    constexpr float DefaultRadius       = 5.0f;    // yards, if 22815 ever loses its shape data
+    constexpr uint32 DefaultPeriod      = 2;       // seconds, if 315154 ever loses its effect 1
+}
+
+// Eye of Corruption - areatrigger 22815, created by 315154
+struct at_corruption_eye_of_corruption : AreaTriggerAI
+{
+    at_corruption_eye_of_corruption(AreaTrigger* areatrigger) : AreaTriggerAI(areatrigger), _radius(0.0f)
+    {
+        uint32 period = EyeOfCorruption::DefaultPeriod;
+
+        // The client renders this same field as "every $s2 sec", so reading it keeps the
+        // tooltip and the server in step.
+        if (SpellInfo const* summon = sSpellMgr->GetSpellInfo(SPELL_EYE_OF_CORRUPTION_SUMMON))
+            if (SpellEffectInfo const* periodEffect = summon->GetEffect(EFFECT_1))
+                if (periodEffect->BasePoints > 0)
+                    period = uint32(periodEffect->BasePoints);
+
+        areatrigger->SetPeriodicProcTimer(period * IN_MILLISECONDS);
+    }
+
+    void OnCreate() override
+    {
+        // Scale the drawn ring and the range test off one division, so they cannot drift.
+        // An earlier version drove the graphic with SetObjectScale instead, and the damage
+        // then cut off outside the ring the player could see.
+        float const templateRadius = at->GetTemplate()->CylinderDatas.Radius > 0.0f
+            ? at->GetTemplate()->CylinderDatas.Radius
+            : EyeOfCorruption::DefaultRadius;
+
+        _radius = templateRadius;
+
+        if (Player* player = at->GetCaster() ? at->GetCaster()->ToPlayer() : nullptr)
+        {
+            // A zero reading is possible - a tier aura can outlive the gear that granted
+            // it - and must not shrink the zone to nothing.
+            float const scaled = player->GetEffectiveCorruption() * EyeOfCorruption::RadiusPerCorruption;
+            if (scaled > 0.0f)
+                _radius = scaled;
+        }
+
+        at->SetOverrideScaleCurve(_radius / templateRadius);
+
+        TC_LOG_DEBUG("scripts.corruption", "Eye of Corruption: spawned, caster %s, radius %.2f (template %.2f)",
+            at->GetCasterGuid().ToString().c_str(), _radius, templateRadius);
+    }
+
+    void OnPeriodicProc() override
+    {
+        Unit* caster = at->GetCaster();
+        if (!caster)
+            return;
+
+        // Measured centre to centre, and deliberately 2d because the zone is a cylinder.
+        // Neither IsWithinDist2d nor GetInsideUnits() will do: both reach IsInDist, which
+        // adds the player's GetObjectSize() to the radius and so pads the damage zone past
+        // the drawn ring by the player's CombatReach.
+        if (caster->GetExactDist2d(at) <= _radius)
+            caster->CastSpell(caster, SPELL_EYE_OF_CORRUPTION_DAMAGE, true);
+    }
+
+private:
+    float _radius;
+};
+
+// Eye of Corruption - 315161
+class spell_corruption_eye_of_corruption : public SpellScript
+{
+    PrepareSpellScript(spell_corruption_eye_of_corruption);
+
+    void CalculateDamage(SpellEffIndex /*effIndex*/)
+    {
+        Unit* target = GetHitUnit();
+        Unit* caster = GetCaster();
+        if (!target || !caster)
+            return;
+
+        Player* player = caster->ToPlayer();
+        if (!player)
+            return;
+
+        float damage = EyeOfCorruption::DamagePerCorruption * player->GetEffectiveCorruption() - EyeOfCorruption::DamageFlatOffset;
+
+        // Below about 1.15 corruption the formula is still negative. The tier only unlocks
+        // at 20, so this never fires in practice, but a negative SetHitDamage would heal.
+        if (damage <= 0.0f)
+            return;
+
+        // "Increasing Shadow damage": each tick leaves a stack that raises the next one.
+        // Effect 1 holds the per-stack figure and the client renders the tooltip from that
+        // same row. The stack this cast applies is not counted - effect 1 has not run yet
+        // at effect 0's hook, which is what makes the first tick land unamplified.
+        if (SpellEffectInfo const* stackEffect = GetSpellInfo()->GetEffect(EFFECT_1))
+            AddPct(damage, float(stackEffect->BasePoints) * float(target->GetAuraCount(GetSpellInfo()->Id)));
+
+        SetHitDamage(int32(damage));
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_corruption_eye_of_corruption::CalculateDamage, EFFECT_0, SPELL_EFFECT_SCHOOL_DAMAGE);
+    }
+};
+
 void AddSC_corruption_spell_scripts()
 {
     RegisterAuraScript(spell_corruption_grasping_tendrils);
+    RegisterSpellScript(spell_corruption_eye_of_corruption);
+    RegisterAreaTriggerAI(at_corruption_eye_of_corruption);
 }

--- a/src/server/scripts/Spells/spell_corruption.cpp
+++ b/src/server/scripts/Spells/spell_corruption.cpp
@@ -28,12 +28,16 @@
 #include "AreaTrigger.h"
 #include "AreaTriggerAI.h"
 #include "Log.h"
+#include "MotionMaster.h"
+#include "ObjectAccessor.h"
 #include "Player.h"
+#include "ScriptedCreature.h"
 #include "ScriptMgr.h"
 #include "SpellAuraEffects.h"
 #include "SpellInfo.h"
 #include "SpellMgr.h"
 #include "SpellScript.h"
+#include "Unit.h"
 #include "Util.h"
 
 #include <algorithm>
@@ -42,7 +46,8 @@
 enum CorruptionSpells
 {
     SPELL_EYE_OF_CORRUPTION_SUMMON = 315154,
-    SPELL_EYE_OF_CORRUPTION_DAMAGE = 315161
+    SPELL_EYE_OF_CORRUPTION_DAMAGE = 315161,
+    SPELL_GRAND_DELUSIONS_SUMMON   = 315186
 };
 
 // Grasping Tendrils, 1+ Corruption. Container 315175 procs on damage taken and triggers
@@ -200,9 +205,160 @@ class spell_corruption_eye_of_corruption : public SpellScript
     }
 };
 
+// Grand Delusions, 40+ Corruption. Container 315184 procs on damage taken and triggers
+// 315186, whose single effect summons creature 161895, the Thing From Beyond.
+//
+// The client carries the summon itself: 315186 has DurationIndex 31 for an 8 second life,
+// radius index 9 so the Thing appears up to 20 yards away, and SummonProperties 4793 for
+// Control NONE, faction 14 over the template's friendly 35, and a personal spawn. What it
+// does not carry is the pursuit speed or the damage - the tooltip promises the speed rises
+// with corruption but gives no numbers, and no movement-speed aura exists anywhere in the
+// corruption block. Both constants below are approximations, isolated for retuning.
+namespace GrandDelusions
+{
+    constexpr uint32 ContainerSpell   = 315184; // the debuff the player carries
+    constexpr uint32 CloneCasterSpell = 60352;  // generic Clone Caster, see IsSummonedBy
+    constexpr float Threshold         = 40.0f;  // CorruptionEffects.db2 MinCorruption
+
+    constexpr float SpeedRateAtThreshold = 0.75f;   // 5.25 yd/s against a player's 7.0
+    constexpr float SpeedRatePerPoint    = 0.0125f; // reaches parity at 60, overtakes above
+    constexpr float SpeedRateMax         = 2.0f;
+
+    // "About your health" is what a whole pursuit costs, not what one swing does, so the
+    // total is divided across the strikes the Thing has time to land.
+    constexpr float TotalDamagePctOfMaxHealth = 90.0f;
+}
+
+// Thing From Beyond - creature 161895, summoned by 315186
+struct npc_corruption_thing_from_beyond : ScriptedAI
+{
+    npc_corruption_thing_from_beyond(Creature* creature) : ScriptedAI(creature),
+        _strikeCooldown(0), _damagePctPerStrike(GrandDelusions::TotalDamagePctOfMaxHealth) { }
+
+    void IsSummonedBy(Unit* summoner) override
+    {
+        Player* player = summoner ? summoner->ToPlayer() : nullptr;
+        if (!player)
+        {
+            me->DespawnOrUnsummon();
+            return;
+        }
+
+        _summonerGuid = player->GetGUID();
+
+        // Retail's Thing From Beyond is a copy of the player it chases, so its appearance
+        // was never meant to come from the template - 161895's only model is the invisible
+        // stalker 11686. The clone must be a real aura: HandleMirrorImageDataRequest answers
+        // the client's request for the copy's gear only if the unit carries
+        // SPELL_AURA_CLONE_CASTER, and reads the appearance off that aura's caster.
+        //
+        // Applied rather than cast, because Clone Caster is positive and this summon is
+        // hostile, so CheckCast answers SPELL_FAILED_BAD_TARGETS. Forgiving that needs
+        // TRIGGERED_IGNORE_TARGET_CHECK, which sits outside TRIGGERED_FULL_MASK and so is
+        // unreachable from CastSpell(..., true). AddAura skips CheckCast and screens only
+        // for immunity, which 161895 has none of.
+        player->AddAura(GrandDelusions::CloneCasterSpell, me);
+
+        // GetEffectiveResistChance adds (victim level - attacker level) * 5 resistance, so
+        // a Thing below its target's level has much of its damage resisted before it lands.
+        // A mirror of the player should be the player's level at any level.
+        me->SetLevel(player->getLevel());
+
+        // Both figures are the summon's own: the creature's swing timer, and TempSummon's
+        // remaining life, still the full duration here because InitSummon runs immediately
+        // after InitStats set it.
+        uint32 const swingTime = me->GetBaseAttackTime(BASE_ATTACK);
+        uint32 const pursuitTime = me->ToTempSummon() ? me->ToTempSummon()->GetTimer() : 0;
+        uint32 const strikes = (swingTime && pursuitTime) ? std::max(1u, pursuitTime / swingTime) : 1;
+
+        _damagePctPerStrike = GrandDelusions::TotalDamagePctOfMaxHealth / float(strikes);
+
+        // The Thing is a movement puzzle, not a fight. Passive keeps the core's own melee
+        // out of it, which would otherwise land ordinary swings alongside the scripted ones
+        // and drag the Thing into normal combat and evade handling.
+        me->SetReactState(REACT_PASSIVE);
+
+        float const corruption = player->GetEffectiveCorruption();
+        float const rate = std::min(GrandDelusions::SpeedRateMax,
+            GrandDelusions::SpeedRateAtThreshold
+                + std::max(0.0f, corruption - GrandDelusions::Threshold) * GrandDelusions::SpeedRatePerPoint);
+
+        TC_LOG_DEBUG("scripts.corruption", "Thing From Beyond: spawned for %s at corruption %.1f, speed rate %.2f, clone %s",
+            _summonerGuid.ToString().c_str(), corruption, rate,
+            me->HasAuraType(SPELL_AURA_CLONE_CASTER) ? "applied" : "MISSING");
+
+        me->SetSpeedRate(MOVE_RUN, rate);
+        me->GetMotionMaster()->MoveChase(player);
+    }
+
+    void UpdateAI(uint32 diff) override
+    {
+        if (_summonerGuid.IsEmpty())
+            return;
+
+        Player* player = ObjectAccessor::GetPlayer(*me, _summonerGuid);
+        if (!player || !player->IsAlive())
+        {
+            me->DespawnOrUnsummon();
+            return;
+        }
+
+        if (_strikeCooldown > diff)
+        {
+            _strikeCooldown -= diff;
+            return;
+        }
+
+        // Measure the way the chase generator measures. IsWithinMeleeRange squares the
+        // height difference into the distance while ChaseMovementGenerator stops on a 2d
+        // test, so on uneven ground the pursuit arrives and then fails its own strike check
+        // forever - one observed pursuit ended at 2d 5.72 with dz -1.34, which is 5.88 in
+        // three dimensions against a melee range of 5.08.
+        if (me->GetExactDist2d(player) > me->GetMeleeRange(player))
+            return;
+
+        // No spell exists for this hit: 315186 has one effect, neither creature carries a
+        // spell in creature_template.spell1-8 or creature_template_spell, and nothing in
+        // the surrounding id range is a plausible contact hit. Retail drove it from creature
+        // data the client never shipped, so the magnitude stays a script constant.
+        //
+        // It is still reported as 315184 rather than dealt anonymously. DealDamage writes
+        // health and sends nothing, so the player was killed by an attack that never
+        // appeared in their combat log - and it bypassed absorbs, resistances and every
+        // damage-taken modifier, making the hit an unconditional execute.
+        SpellInfo const* damageSpell = sSpellMgr->GetSpellInfo(GrandDelusions::ContainerSpell);
+        if (!damageSpell)
+        {
+            me->DespawnOrUnsummon();
+            return;
+        }
+
+        uint32 const damage = CalculatePct(player->GetMaxHealth(), _damagePctPerStrike);
+
+        SpellNonMeleeDamage damageInfo(me, player, damageSpell->Id,
+            damageSpell->GetSpellXSpellVisualId(me), SPELL_SCHOOL_MASK_SHADOW);
+        me->CalculateSpellDamageTaken(&damageInfo, int32(damage), damageSpell);
+        me->SendSpellNonMeleeDamageLog(&damageInfo);
+        me->DealSpellDamage(&damageInfo, false);
+
+        // Connecting does not spend the Thing. Cascading Disaster settles it: "if you are
+        // struck by the Thing From Beyond, you will be immediately afflicted by Grasping
+        // Tendrils and Eye of Corruption" - a snare applied by a pursuer that vanished on
+        // contact would do nothing. The 8 seconds are the escape window, not a countdown to
+        // one guaranteed hit.
+        _strikeCooldown = me->GetBaseAttackTime(BASE_ATTACK);
+    }
+
+private:
+    ObjectGuid _summonerGuid;
+    uint32 _strikeCooldown;
+    float _damagePctPerStrike;
+};
+
 void AddSC_corruption_spell_scripts()
 {
     RegisterAuraScript(spell_corruption_grasping_tendrils);
     RegisterSpellScript(spell_corruption_eye_of_corruption);
     RegisterAreaTriggerAI(at_corruption_eye_of_corruption);
+    RegisterCreatureAI(npc_corruption_thing_from_beyond);
 }

--- a/src/server/scripts/Spells/spell_script_loader.cpp
+++ b/src/server/scripts/Spells/spell_script_loader.cpp
@@ -34,6 +34,7 @@ void AddSC_item_spell_scripts();
 void AddSC_toy_spell_scripts();
 void AddSC_artifact_spell_scripts();
 void AddSC_mastery_spell_scripts();
+void AddSC_corruption_spell_scripts();
 
 // The name of this function should match:
 // void Add${NameOfDirectory}Scripts()
@@ -57,4 +58,5 @@ void AddSpellsScripts()
     AddSC_toy_spell_scripts();
     AddSC_artifact_spell_scripts();
     AddSC_mastery_spell_scripts();
+    AddSC_corruption_spell_scripts();
 }


### PR DESCRIPTION
> **This PR was rewritten.** Its history was 62 commits carrying an oversized, essay-style comment
> block on nearly every hunk. That was fair criticism and it has been addressed: the branch is now 12
> commits, every comment states one *why*-fact in at most three lines, and the reasoning that used to
> live in the code lives here instead. @Hextv's commit `fix: add safeguards to some SQL updates` was
> pushed directly onto this branch and is preserved with its original authorship — it now sits in
> PR #78.
>
> **This is the last of six PRs.** The independent groundwork was split out so it can be reviewed
> without the feature attached:
>
> | | | |
> |---|---|---|
> | #77 | `build(cmake)` MySQL discovery | independent |
> | #78 | SQL updates directory rename | independent — **this PR stacks on it** |
> | #79 | bonus-granted item effects | independent — **this PR stacks on it** |
> | #80 | aura 285 → linked-aura handler | independent — **this PR stacks on it** |
> | #81 | corruption penalty re-evaluation | independent — **this PR stacks on it** |
>
> Everything below `core/areatrigger: let a script resize the trigger the client draws` in the commit
> list belongs to one of those five. **This PR's own contribution is the top five commits.** It is
> kept as a draft because one known defect is unresolved — see Known Issues.

## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

The three 8.3 corruption drawback tiers, plus the two core capabilities they need.

### `core/areatrigger`: let a script resize the trigger the client draws

Nothing in this core ever wrote `OverrideScaleCurve`. `AreaTrigger::Create` fills in `ExtraScaleCurve`
from the misc template and leaves this one default-constructed, so every areatrigger is drawn at
exactly the size its template describes. A script whose trigger has to change size had no way to tell
the client, and the drawn ring then disagreed with whatever the server tested against.

`SetOverrideScaleCurve` writes a flat two-point curve at the requested multiple of the template size;
`ClearOverrideScaleCurve` returns the trigger to the template's own size. **Rendering only** — the
server-side shape is unchanged, so a caller that scales the visual must scale its own range test to
match.

### `core/spells`: send runtime aura amounts for the corruption stat payloads

The five corruption stat payload spells carry DB2 base points of 0. The whole magnitude is supplied
at runtime by their aura-285 container, through `HandleAuraLinked` into `CastCustomSpell`. Without
`SPELL_ATTR8_AURA_SEND_AMOUNT` the amount never reaches the client (see
`AuraApplication::BuildUpdatePacket`), so the server holds the real value while the tooltip renders 0.

### Grasping Tendrils — the 1+ corruption drawback

The first threshold penalty did nothing. Its snare **315176** carries `BasePoints 0` in
`SpellEffect.db2` and has no world DB override, so the aura applied at *"movement speed reduced by
0%"*. Retail computed the magnitude server-side and shipped the client a placeholder — which is why
Blizzard's own 8.3 PTR tooltip read *"slow your movement speed for 0 sec"*.

The curve is taken from its primary source rather than guessed. Wowhead's 8.3 PTR article
[*Corrupted Items — Corruption Debuff Breakpoints and Scaling of Debuffs*](https://www.wowhead.com/news/295810)
states outright that **"the magnitude of the slow is equal to {Corruption + 10}"**, and tabulates it
from 10 corruption (20%) through 90 (100%). That is what the constants here produce.

The container also fired on heals. **315175** ships every `TAKEN` proc flag, including
`PROC_FLAG_TAKEN_PERIODIC`, which `SpellMgr.h` documents as *"damage / healing"*; with no
`spell_proc` row, the auto-generated entry takes `PROC_SPELL_TYPE_MASK_ALL`. Standing in a druid's
Efflorescence rooted the player once per healing tick. The new row restricts it to
`PROC_SPELL_TYPE_DAMAGE` and restores `PROC_ATTR_TRIGGERED_CAN_PROC`, which a hand-written row would
otherwise drop.

### Eye of Corruption — the 20+ corruption drawback

The Eye spawned and did nothing. Container **315169** procs on damage dealt and triggers **315154**,
which creates areatrigger **22815** — but 22815 carried no `ScriptName` and no template actions, and
nothing cast the damage spell **315161**. The Eye appeared, sat for its eight seconds and left. A
template action could not fix it either: `DoActions` fires once on enter, while the Eye has to tick
for as long as the player stays in range.

**What the client supplies is read, not hardcoded.** The 8 second duration is `SpellDuration` index
31, the 2 second tick is 315154 effect 1, the school is `SpellMisc` `SchoolMask` 32, and the
per-stack amplification is 315161 effect 1 — the same row the client renders *"damage taken increased
by $s2%"* from.

**What it does not supply is the damage and the radius** — the two things the tooltip promises scale
with corruption. Every scaling field on 315161 effect 0 is zero: `EffectBasePoints`,
`EffectBonusCoefficient`, `BonusCoefficientFromAP`, `Coefficient`, `Variance`,
`EffectRealPointsPerLevel`, `ResourceCoefficient` and `EffectPointsPerResource`. `ContentTuningID` is
0 and there is no hotfix row. Retail computed both server-side. Both come instead from the same
Wowhead PTR sampling ([news 295810](https://www.wowhead.com/news/295810)): **875 × Corruption − 1000
per tick**, and a radius of **Corruption / 5 yards**. The stated formulas are used rather than a fit
to the article's own table, because the table's drift past 50 corruption is an artefact of Inevitable
Doom amplifying all damage taken.

The ring the player sees and the range the damage covers are the same edge by construction — both
come from one division against the template radius. An earlier attempt scaled the radius but drove
the graphic with `SetObjectScale`, and the damage then cut off outside the visible ring. The range
test is deliberately 2d and centre-to-centre: the zone is a cylinder, and both `IsWithinDist2d` and
`GetInsideUnits()` route through `IsInDist`, which pads the radius by the player's `CombatReach` and
so damages a player standing outside the edge they can see.

### Grand Delusions — the 40+ corruption drawback

Container **315184** triggers **315186**, which summons creature **161895** — the Thing From Beyond —
and nothing happened after that. The creature was marked SmartAI with no `smart_scripts` rows of its
own, so it spawned, stood still and despawned.

**Its appearance comes from a clone aura, not the template.** 161895's only `creature_template_model`
row is display 11686 — the invisible stalker shared by 8467 templates for bunnies and kill credit.
That reads like an oversight and is not one: retail's Thing From Beyond is a copy of the player it
chases, so the model was never meant to come from the template. The clone has to be a real aura,
because `WorldSession::HandleMirrorImageDataRequest` answers the client's request for the copy's gear
only if the unit carries `SPELL_AURA_CLONE_CASTER`, and reads the appearance off that aura's caster.
It is **applied** rather than cast: Clone Caster is a positive spell and this summon is hostile
(`SummonProperties` 4793 sets faction 14 over the template's friendly 35), so `CheckCast` answers
`SPELL_FAILED_BAD_TARGETS` — and forgiving that requires `TRIGGERED_IGNORE_TARGET_CHECK`, which sits
outside `TRIGGERED_FULL_MASK` and is therefore unreachable from `CastSpell(..., true)`.

**The Thing is levelled to its summoner.** `GetEffectiveResistChance` adds
`(victim level − attacker level) × 5` resistance, so a Thing below its target's level had roughly half
its damage resisted away before it landed.

**The strike is measured the way the chase generator measures.** `IsWithinMeleeRange` squares the
height difference into the distance while `ChaseMovementGenerator` stops on a 2d test, so on uneven
ground the pursuit arrived and then failed its own strike check for the whole eight seconds. One
observed pursuit ended at 2d 5.72 with `dz` −1.34 — 5.88 in three dimensions, against a melee range
of 5.08.

**Damage goes through `SpellNonMeleeDamage`, not `DealDamage`**, so it appears in the combat log and
passes through absorbs, resistances and damage-taken modifiers instead of executing unconditionally.
The tooltip figure — *"reaching you deals about your health in damage"* — is the cost of a whole
pursuit, so it is divided across the strikes the Thing has time to land: being caught late costs less
than being caught at once. Connecting does not spend the Thing, because Cascading Disaster's tooltip
says being struck applies Grasping Tendrils and Eye of Corruption, which a pursuer that vanished on
contact could not do.

**Pursuit speed is an approximation** and is isolated in the `GrandDelusions` namespace for retuning.
The tooltip states the speed rises with corruption but gives no numbers,
`creature_template.speed_run` is TrinityCore's stock default on all three pursuer creatures, and
there is no movement-speed aura anywhere in the corruption block.

### Removed from the previous revision

An earlier revision played the Thing From Beyond's own spell visual kits on the summon and added
`.debug visualkit` / `.debug spellvisual` to iterate on them. The visual kits did not produce the
retail appearance — the clone aura does — so that code and its two debug commands are gone rather
than left in place. The `TC_LOG_DEBUG` instrumentation used during that investigation is gone too.

### AI-assisted Pull Requests

- [x] AI tools were used. **Claude Code, model Claude Opus 5.** Used for the DB2 field surveys, the
      call-site tracing, drafting, and the comment cleanup / history rewrite described at the top.
      Every line has been reviewed and is defensible by the author.

## Issues Addressed:
- Closes nothing tracked.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Two distinct sources, kept separate on purpose:

1. **The 8.3.7 client data**, for everything it actually describes — durations, tick periods, school
   masks, amplification percentages, summon properties, faction. Cited inline above by DB2 table and
   field so a reviewer can check each one.
2. **Wowhead's 8.3 PTR sampling, [news 295810](https://www.wowhead.com/news/295810)**, for the two
   things retail computed server-side and never shipped: the Grasping Tendrils slow curve and the Eye
   of Corruption damage and radius. These are the numbers most worth a second opinion, because no
   client-side ground truth exists for them.

Where neither source has an answer — pursuit speed — that is stated as an approximation rather than
presented as retail behaviour.

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author.
- [x] This pull request requires further testing and may have edge cases to be tested.

Builds clean on Windows / VS 2022 x64 RelWithDebInfo. Verified in-game, per tier:

- **Grasping Tendrils** — the snare applies on damage taken, not on heals, and its magnitude tracks
  effective corruption.
- **Eye of Corruption** — the Eye spawns, draws at a corruption-scaled radius, and ticks while the
  player stands in it.
- **Grand Delusions** — the Thing spawns as a copy of its summoner, pursues, and its strike is
  reported as spell damage in the combat log.

**Not tested:** the numbers themselves against retail. Nobody has sniffed 8.3 corruption damage; the
formulas are as good as the Wowhead sampling they come from.

## How to Test the Changes:
- [x] This pull request requires further testing. Steps below.

1. `.additem <itemId> 1 <bonusListId>` with a corruption bonus list — e.g. `6552` (Infinite Stars,
   20 corruption). The third argument is a **bonus list id**, not a spell id.
2. `.debug corruption` (from #81) to confirm the effective total and which threshold rows qualify.
3. **1+** — take damage and confirm the snare applies with a non-zero magnitude that tracks the total.
   Then stand in a HoT or an Efflorescence and confirm it does *not* fire on heals.
4. **20+** — deal damage and confirm the Eye spawns, that the ring you see matches the range that
   damages you, and that it ticks every 2 seconds.
5. **40+** — confirm the Thing From Beyond spawns looking like you, chases, and that its strike lands
   in the combat log rather than executing silently. Test on sloped ground specifically — that is the
   case the 2d/3d measurement mismatch broke.

## Known Issues and TODO List:
- [ ] **Unequip does not remove the effect** (inherited from #79, not introduced here). A corrupted
      item's affix keeps firing after the item is unequipped, until it leaves the bags or the player
      relogs. Root cause is not established: the effects are confirmed `TriggerType = ON_EQUIP`, and
      `ApplyItemEquipSpell(item, false)` *is* reached on unequip, but the removal is not matching.
      **This is why the PR is still a draft.**
- [ ] Some items that should carry a corruption effect do not — @Hextv reports `172227`
      [Shard of the Black Empire]. Triaged as bonus-list data rather than code, but unconfirmed.
- [ ] Only the three drawback tiers are implemented. The corruption *affixes* — Echoing Void, Twilight
      Devastation, Infinite Stars and the rest — are not.
- [ ] Pursuit speed for the Thing From Beyond is an approximation with no source (see above).
- [ ] The Eye's damage and radius formulas rest entirely on one Wowhead PTR article. If anyone has a
      sniff, it should replace them.
- [ ] **If you hand-applied the previous revision's migrations**, note that its seven incremental
      files are replaced by three final-state ones. The three reach the same end state on their own,
      with one exception: the old `2026_08_01_02` briefly moved the AI onto creature `160966` and
      `2026_08_01_03` moved it back. If you applied `_02` but not `_03`, clear that row by hand —
      `UPDATE creature_template SET AIName = 'SmartAI', ScriptName = '' WHERE entry = 160966;`
