### PR TITLE
build(cmake): discover MySQL installs by glob instead of a version list

### DIFF
--- a/cmake/macros/FindMySQL.cmake
+++ b/cmake/macros/FindMySQL.cmake
@@ -65,15 +65,91 @@ endif( UNIX )
 
 if( WIN32 )
   # read environment variables and change \ to /
-  SET(PROGRAM_FILES_32 $ENV{ProgramFiles})
-  if (${PROGRAM_FILES_32})
-    STRING(REPLACE "\\\\" "/" PROGRAM_FILES_32 ${PROGRAM_FILES_32})
-  endif(${PROGRAM_FILES_32})
+  # NOTE: test the variable, do not dereference it - "if (${VAR})" expands to
+  # if ("C:/Program Files") which CMake evaluates as false, so the normalization
+  # below never ran. The replace pattern was also wrong: in CMake "\\" is a
+  # single literal backslash, "\\\\" is two.
+  set(PROGRAM_FILES_32 "$ENV{ProgramFiles}")
+  if( PROGRAM_FILES_32 )
+    string(REPLACE "\\" "/" PROGRAM_FILES_32 "${PROGRAM_FILES_32}")
+  endif()
 
-  SET(PROGRAM_FILES_64 $ENV{ProgramW6432})
-  if (${PROGRAM_FILES_64})
-     STRING(REPLACE "\\\\" "/" PROGRAM_FILES_64 ${PROGRAM_FILES_64})
-  endif(${PROGRAM_FILES_64})
+  set(PROGRAM_FILES_64 "$ENV{ProgramW6432}")
+  if( PROGRAM_FILES_64 )
+    string(REPLACE "\\" "/" PROGRAM_FILES_64 "${PROGRAM_FILES_64}")
+  endif()
+
+  set(SYSTEM_DRIVE "$ENV{SystemDrive}")
+  if( SYSTEM_DRIVE )
+    string(REPLACE "\\" "/" SYSTEM_DRIVE "${SYSTEM_DRIVE}")
+  endif()
+
+  # Build the search bases one at a time: an unset environment variable would
+  # otherwise leave the bare string "/MySQL", which is truthy and gets probed
+  # against the filesystem root.
+  set(MYSQL_SEARCH_BASES "")
+  if( PROGRAM_FILES_64 )
+    list(APPEND MYSQL_SEARCH_BASES "${PROGRAM_FILES_64}/MySQL")
+  endif()
+  if( PROGRAM_FILES_32 )
+    list(APPEND MYSQL_SEARCH_BASES "${PROGRAM_FILES_32}/MySQL")
+  endif()
+  if( SYSTEM_DRIVE )
+    list(APPEND MYSQL_SEARCH_BASES "${SYSTEM_DRIVE}/MySQL")
+  endif()
+  list(APPEND MYSQL_SEARCH_BASES "C:/MySQL")
+
+  # Discover every installed "MySQL Server <version>" directory rather than
+  # relying on a hardcoded version list, which silently broke on each new MySQL
+  # release. Newest version is searched first.
+  set(MYSQL_VERSIONED_ROOTS "")
+  foreach( MYSQL_SEARCH_BASE ${MYSQL_SEARCH_BASES} )
+    if( IS_DIRECTORY "${MYSQL_SEARCH_BASE}" )
+      file(GLOB MYSQL_SEARCH_CANDIDATES LIST_DIRECTORIES true "${MYSQL_SEARCH_BASE}/MySQL Server *")
+      foreach( MYSQL_SEARCH_CANDIDATE ${MYSQL_SEARCH_CANDIDATES} )
+        if( IS_DIRECTORY "${MYSQL_SEARCH_CANDIDATE}" )
+          list(APPEND MYSQL_VERSIONED_ROOTS "${MYSQL_SEARCH_CANDIDATE}")
+        endif()
+      endforeach()
+    endif()
+  endforeach()
+
+  if( MYSQL_VERSIONED_ROOTS )
+    list(REMOVE_DUPLICATES MYSQL_VERSIONED_ROOTS)
+
+    # Sorting the full paths lets the directory prefix outweigh the version, so
+    # "C:/Program Files/MySQL/MySQL Server 5.7" would beat "C:/MySQL/MySQL Server 9.7".
+    # Sort on the version alone by prefixing it, then strip the prefix back off.
+    set(MYSQL_SORTABLE_ROOTS "")
+    foreach( MYSQL_ROOT_DIR ${MYSQL_VERSIONED_ROOTS} )
+      # A directory whose name carries no version sorts last rather than first
+      set(MYSQL_ROOT_VERSION "0")
+      if( "${MYSQL_ROOT_DIR}" MATCHES "MySQL Server ([0-9][0-9.]*)" )
+        set(MYSQL_ROOT_VERSION "${CMAKE_MATCH_1}")
+      endif()
+      list(APPEND MYSQL_SORTABLE_ROOTS "${MYSQL_ROOT_VERSION}|${MYSQL_ROOT_DIR}")
+    endforeach()
+    list(SORT MYSQL_SORTABLE_ROOTS COMPARE NATURAL ORDER DESCENDING)
+
+    set(MYSQL_VERSIONED_ROOTS "")
+    foreach( MYSQL_SORTABLE_ROOT ${MYSQL_SORTABLE_ROOTS} )
+      string(REGEX REPLACE "^[^|]*\\|" "" MYSQL_ROOT_DIR "${MYSQL_SORTABLE_ROOT}")
+      list(APPEND MYSQL_VERSIONED_ROOTS "${MYSQL_ROOT_DIR}")
+    endforeach()
+  endif()
+
+  set(MYSQL_DISCOVERED_INCLUDE_PATHS "")
+  set(MYSQL_DISCOVERED_LIB_PATHS "")
+  set(MYSQL_DISCOVERED_BIN_PATHS "")
+  foreach( MYSQL_ROOT_DIR ${MYSQL_VERSIONED_ROOTS} )
+    list(APPEND MYSQL_DISCOVERED_INCLUDE_PATHS "${MYSQL_ROOT_DIR}/include")
+    list(APPEND MYSQL_DISCOVERED_LIB_PATHS "${MYSQL_ROOT_DIR}/lib" "${MYSQL_ROOT_DIR}/lib/opt")
+    list(APPEND MYSQL_DISCOVERED_BIN_PATHS "${MYSQL_ROOT_DIR}/bin" "${MYSQL_ROOT_DIR}/bin/opt")
+  endforeach()
+
+  if( MYSQL_VERSIONED_ROOTS )
+    message(STATUS "Detected MySQL installations: ${MYSQL_VERSIONED_ROOTS}")
+  endif()
 endif ( WIN32 )
 
 find_path(MYSQL_INCLUDE_DIR
@@ -81,18 +157,13 @@ find_path(MYSQL_INCLUDE_DIR
     mysql.h
   PATHS
     ${MYSQL_ADD_INCLUDE_PATH}
+    ${MYSQL_DISCOVERED_INCLUDE_PATHS}
     /usr/include
     /usr/include/mysql
     /usr/local/include
     /usr/local/include/mysql
     /usr/local/mysql/include
-    "${PROGRAM_FILES_64}/MySQL/MySQL Server 9.0/include"
-    "${PROGRAM_FILES_64}/MySQL/MySQL Server 8.4/include"
-    "${PROGRAM_FILES_64}/MySQL/MySQL Server 8.0/include"
     "${PROGRAM_FILES_64}/MySQL/include"
-    "${PROGRAM_FILES_32}/MySQL/MySQL Server 9.0/include"
-    "${PROGRAM_FILES_32}/MySQL/MySQL Server 8.4/include"
-    "${PROGRAM_FILES_32}/MySQL/MySQL Server 8.0/include"
     "${PROGRAM_FILES_32}/MySQL/include"
     "C:/MySQL/include"
     "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MySQL AB\\MySQL Server 9.0;Location]/include"
@@ -101,12 +172,6 @@ find_path(MYSQL_INCLUDE_DIR
     "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\MySQL AB\\MySQL Server 9.0;Location]/include"
     "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\MySQL AB\\MySQL Server 8.4;Location]/include"
     "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\MySQL AB\\MySQL Server 8.0;Location]/include"
-    "$ENV{ProgramFiles}/MySQL/MySQL Server 9.0/include"
-    "$ENV{ProgramFiles}/MySQL/MySQL Server 8.4/include"
-    "$ENV{ProgramFiles}/MySQL/MySQL Server 8.0/include"
-    "$ENV{SystemDrive}/MySQL/MySQL Server 9.0/include"
-    "$ENV{SystemDrive}/MySQL/MySQL Server 8.4/include"
-    "$ENV{SystemDrive}/MySQL/MySQL Server 8.0/include"
     "c:/msys/local/include"
     "$ENV{MYSQL_ROOT}/include"
   DOC
@@ -136,19 +201,8 @@ if( WIN32 )
       libmysql
     PATHS
       ${MYSQL_ADD_LIBRARIES_PATH}
-      "${PROGRAM_FILES_64}/MySQL/MySQL Server 9.0/lib"
-      "${PROGRAM_FILES_64}/MySQL/MySQL Server 8.4/lib"
-      "${PROGRAM_FILES_64}/MySQL/MySQL Server 8.0/lib"
-      "${PROGRAM_FILES_64}/MySQL/MySQL Server 9.0/lib/opt"
-      "${PROGRAM_FILES_64}/MySQL/MySQL Server 8.4/lib/opt"
-      "${PROGRAM_FILES_64}/MySQL/MySQL Server 8.0/lib/opt"
+      ${MYSQL_DISCOVERED_LIB_PATHS}
       "${PROGRAM_FILES_64}/MySQL/lib"
-      "${PROGRAM_FILES_32}/MySQL/MySQL Server 9.0/lib"
-      "${PROGRAM_FILES_32}/MySQL/MySQL Server 8.4/lib"
-      "${PROGRAM_FILES_32}/MySQL/MySQL Server 8.0/lib"
-      "${PROGRAM_FILES_32}/MySQL/MySQL Server 9.0/lib/opt"
-      "${PROGRAM_FILES_32}/MySQL/MySQL Server 8.4/lib/opt"
-      "${PROGRAM_FILES_32}/MySQL/MySQL Server 8.0/lib/opt"
       "${PROGRAM_FILES_32}/MySQL/lib"
       "C:/MySQL/lib/debug"
       "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MySQL AB\\MySQL Server 9.0;Location]/lib"
@@ -163,12 +217,6 @@ if( WIN32 )
       "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\MySQL AB\\MySQL Server 9.0;Location]/lib/opt"
       "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\MySQL AB\\MySQL Server 8.4;Location]/lib/opt"
       "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\MySQL AB\\MySQL Server 8.0;Location]/lib/opt"
-      "$ENV{ProgramFiles}/MySQL/MySQL Server 9.0/lib/opt"
-      "$ENV{ProgramFiles}/MySQL/MySQL Server 8.4/lib/opt"
-      "$ENV{ProgramFiles}/MySQL/MySQL Server 8.0/lib/opt"
-      "$ENV{SystemDrive}/MySQL/MySQL Server 9.0/lib/opt"
-      "$ENV{SystemDrive}/MySQL/MySQL Server 8.4/lib/opt"
-      "$ENV{SystemDrive}/MySQL/MySQL Server 8.0/lib/opt"
       "c:/msys/local/include"
       "$ENV{MYSQL_ROOT}/lib"
     DOC "Specify the location of the mysql library here."
@@ -207,19 +255,8 @@ endif( UNIX )
 if( WIN32 )
     find_program(MYSQL_EXECUTABLE mysql
       PATHS
-        "${PROGRAM_FILES_64}/MySQL/MySQL Server 9.0/bin"
-        "${PROGRAM_FILES_64}/MySQL/MySQL Server 8.4/bin"
-        "${PROGRAM_FILES_64}/MySQL/MySQL Server 8.0/bin"
-        "${PROGRAM_FILES_64}/MySQL/MySQL Server 9.0/bin/opt"
-        "${PROGRAM_FILES_64}/MySQL/MySQL Server 8.4/bin/opt"
-        "${PROGRAM_FILES_64}/MySQL/MySQL Server 8.0/bin/opt"
+        ${MYSQL_DISCOVERED_BIN_PATHS}
         "${PROGRAM_FILES_64}/MySQL/bin"
-        "${PROGRAM_FILES_32}/MySQL/MySQL Server 9.0/bin"
-        "${PROGRAM_FILES_32}/MySQL/MySQL Server 8.4/bin"
-        "${PROGRAM_FILES_32}/MySQL/MySQL Server 8.0/bin"
-        "${PROGRAM_FILES_32}/MySQL/MySQL Server 9.0/bin/opt"
-        "${PROGRAM_FILES_32}/MySQL/MySQL Server 8.4/bin/opt"
-        "${PROGRAM_FILES_32}/MySQL/MySQL Server 8.0/bin/opt"
         "${PROGRAM_FILES_32}/MySQL/bin"
         "C:/MySQL/bin/debug"
         "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MySQL AB\\MySQL Server 9.0;Location]/bin"
@@ -234,12 +271,6 @@ if( WIN32 )
         "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\MySQL AB\\MySQL Server 9.0;Location]/bin/opt"
         "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\MySQL AB\\MySQL Server 8.4;Location]/bin/opt"
         "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\MySQL AB\\MySQL Server 8.0;Location]/bin/opt"
-        "$ENV{ProgramFiles}/MySQL/MySQL Server 9.0/bin/opt"
-        "$ENV{ProgramFiles}/MySQL/MySQL Server 8.4/bin/opt"
-        "$ENV{ProgramFiles}/MySQL/MySQL Server 8.0/bin/opt"
-        "$ENV{SystemDrive}/MySQL/MySQL Server 9.0/bin/opt"
-        "$ENV{SystemDrive}/MySQL/MySQL Server 8.4/bin/opt"
-        "$ENV{SystemDrive}/MySQL/MySQL Server 8.0/bin/opt"
         "c:/msys/local/include"
         "$ENV{MYSQL_ROOT}/bin"
      DOC

--- a/cmake/macros/FindMySQL.cmake
+++ b/cmake/macros/FindMySQL.cmake
@@ -94,7 +94,7 @@ if( WIN32 )
   endif()
   list(APPEND MYSQL_SEARCH_BASES "C:/MySQL")
   
-  # release. Newest version is searched first.
+  # Newest version is searched first.
   set(MYSQL_VERSIONED_ROOTS "")
   foreach( MYSQL_SEARCH_BASE ${MYSQL_SEARCH_BASES} )
     if( IS_DIRECTORY "${MYSQL_SEARCH_BASE}" )

--- a/cmake/macros/FindMySQL.cmake
+++ b/cmake/macros/FindMySQL.cmake
@@ -67,8 +67,6 @@ if( WIN32 )
   # read environment variables and change \ to /
   # NOTE: test the variable, do not dereference it - "if (${VAR})" expands to
   # if ("C:/Program Files") which CMake evaluates as false, so the normalization
-  # below never ran. The replace pattern was also wrong: in CMake "\\" is a
-  # single literal backslash, "\\\\" is two.
   set(PROGRAM_FILES_32 "$ENV{ProgramFiles}")
   if( PROGRAM_FILES_32 )
     string(REPLACE "\\" "/" PROGRAM_FILES_32 "${PROGRAM_FILES_32}")
@@ -84,9 +82,6 @@ if( WIN32 )
     string(REPLACE "\\" "/" SYSTEM_DRIVE "${SYSTEM_DRIVE}")
   endif()
 
-  # Build the search bases one at a time: an unset environment variable would
-  # otherwise leave the bare string "/MySQL", which is truthy and gets probed
-  # against the filesystem root.
   set(MYSQL_SEARCH_BASES "")
   if( PROGRAM_FILES_64 )
     list(APPEND MYSQL_SEARCH_BASES "${PROGRAM_FILES_64}/MySQL")
@@ -98,9 +93,7 @@ if( WIN32 )
     list(APPEND MYSQL_SEARCH_BASES "${SYSTEM_DRIVE}/MySQL")
   endif()
   list(APPEND MYSQL_SEARCH_BASES "C:/MySQL")
-
-  # Discover every installed "MySQL Server <version>" directory rather than
-  # relying on a hardcoded version list, which silently broke on each new MySQL
+  
   # release. Newest version is searched first.
   set(MYSQL_VERSIONED_ROOTS "")
   foreach( MYSQL_SEARCH_BASE ${MYSQL_SEARCH_BASES} )
@@ -116,9 +109,7 @@ if( WIN32 )
 
   if( MYSQL_VERSIONED_ROOTS )
     list(REMOVE_DUPLICATES MYSQL_VERSIONED_ROOTS)
-
-    # Sorting the full paths lets the directory prefix outweigh the version, so
-    # "C:/Program Files/MySQL/MySQL Server 5.7" would beat "C:/MySQL/MySQL Server 9.7".
+    
     # Sort on the version alone by prefixing it, then strip the prefix back off.
     set(MYSQL_SORTABLE_ROOTS "")
     foreach( MYSQL_ROOT_DIR ${MYSQL_VERSIONED_ROOTS} )


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).
-  [x] Build system — `cmake/macros/FindMySQL.cmake` only. None of the three categories above apply.

`FindMySQL.cmake` could not locate MySQL 9.7 on Windows, failing configure with
`Could not find the MySQL libraries!`. Three independent defects:

1. **The search paths were a hardcoded version list** — only `MySQL Server 9.0 / 8.4 / 8.0`.
   Every new MySQL release silently broke discovery until someone edited the list. The registry
   fallbacks did not cover it either: MySQL 8.0+ installers no longer write `HKLM\SOFTWARE\MySQL AB`.

2. **The ProgramFiles normalisation never ran.** It tested `if( ${PROGRAM_FILES_32} )`, which
   dereferences the variable, so CMake evaluated `if ("C:/Program Files")` → false. The replace
   pattern was wrong as well — `"\\\\"` is two literal backslashes in CMake, not one.

3. **Unset environment variables collapsed to filesystem-root paths.** Search bases were assembled
   by interpolating env vars into a literal list, so an unset `ProgramW6432`, `ProgramFiles` or
   `SystemDrive` produced `"/MySQL"` — a truthy string that passed the guard and was then stat'd
   against the root of the drive.

The `WIN32` block now globs `<base>/MySQL Server *` under each base that actually holds a value and
sorts the hits newest-first on a version key extracted from the directory name. Sorting whole paths
was not enough: the path prefix outweighs the version, which ranked
`C:/Program Files/.../Server 5.7` above `C:/MySQL/.../Server 9.7`. Registry, msys, `MYSQL_ROOT` and
non-versioned fallbacks are all kept; only the superseded hardcoded versioned entries are removed.

### AI-assisted Pull Requests

- [x] AI tools were used. **Claude Code, model Claude Opus 5.** Used for diagnosing the three
      defects and drafting the replacement `WIN32` discovery block. Every line has been reviewed and
      is defensible by the author.

## Issues Addressed:
- Closes nothing tracked; found while configuring the tree on a host with MySQL 9.7.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

None of the above apply — this is a build-system fix with no game-behaviour claim. The evidence is
the configure output quoted below.

## Tests Performed:
- [x] Tested by the author — configure and build, not in-game (nothing here is reachable in-game).
- [ ] Tested in-game by other community members/someone else other than the author.
- [x] This pull request requires further testing and may have edge cases to be tested.

Configured on Windows with MySQL 9.7 and CMake 4.3.4:

```
-- Detected MySQL installations: <program-files>/MySQL/MySQL Server 9.7
-- Found MySQL library: .../MySQL Server 9.7/lib/libmysql.lib
-- Found MySQL headers: .../MySQL Server 9.7/include
-- Found MySQL executable: .../MySQL Server 9.7/bin/mysql.exe
```

`worldserver` then builds clean on Windows / VS 2022 x64 RelWithDebInfo.

**Not tested:** Linux and macOS discovery paths, and Windows hosts whose MySQL lives somewhere the
glob does not reach. The non-Windows branches are untouched, but a second pair of eyes on a Linux
host would be worth having before this merges.

## How to Test the Changes:
- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Steps below.

1. Install a MySQL release whose version is **not** in the old hardcoded list (9.x, or anything newer
   than 9.0), and make sure no `MYSQL_ROOT` is set.
2. On `main`, run `cmake -S . -B build -G "Visual Studio 17 2022" -A x64 -DTOOLS=0`. Configure fails
   with `Could not find the MySQL libraries!`.
3. On this branch, run the same command. Configure succeeds and prints the
   `Detected MySQL installations:` line naming your install.

## Known Issues and TODO List:
- [ ] Version sorting keys off the directory name, so a non-standard install directory that does not
      end in a version number will sort last rather than being rejected. It is still found by the
      remaining fallbacks.
- [ ] The Linux/macOS branches were not touched and were not retested.

---

This is one of six PRs splitting a previously oversized branch apart. It is **independent** — it
shares no files with the other five and can merge in any order.
