### PR TITLE
core/items: apply item effects granted by bonus lists

### DIFF
--- a/src/server/game/AuctionHouse/AuctionHouseMgr.cpp
+++ b/src/server/game/AuctionHouse/AuctionHouseMgr.cpp
@@ -1269,6 +1269,8 @@ void AuctionHouseObject::BuildListBuckets(WorldPackets::AuctionHouse::AuctionLis
             else if (bucketData->ItemClass == ITEM_CLASS_CONSUMABLE || bucketData->ItemClass == ITEM_CLASS_RECIPE || bucketData->ItemClass == ITEM_CLASS_MISCELLANEOUS)
             {
                 ItemTemplate const* itemTemplate = ASSERT_NOTNULL(sObjectMgr->GetItemTemplate(bucket.first.ItemId));
+                // Template effects only: an auction listing is described by item entry and
+                // bonus list ids, with no Item instance to ask for bonus-granted effects.
                 if (itemTemplate->Effects.size() >= 2 && (itemTemplate->Effects[0]->SpellID == 483 || itemTemplate->Effects[0]->SpellID == 55884))
                 {
                     if (player->HasSpell(itemTemplate->Effects[1]->SpellID))

--- a/src/server/game/BattlePay/BattlePayMgr.cpp
+++ b/src/server/game/BattlePay/BattlePayMgr.cpp
@@ -266,6 +266,7 @@ bool BattlepayManager::AlreadyOwnProduct(uint32 itemId) const
         if (!itemTemplate)
             return true;
 
+        // Template effects only: the shop entry names an item id, not an instance.
         for (auto itr : itemTemplate->Effects)
             if (itr->TriggerType == ITEM_SPELLTRIGGER_LEARN_SPELL_ID && player->HasSpell(itr->SpellID))
                 return true;
@@ -384,6 +385,7 @@ auto BattlepayManager::ProductFilter(Product product) -> bool
                 return false;
             }
 
+            // Template effects only: the shop entry names an item id, not an instance.
             for (auto effectData : itemTemplate->Effects)
             {
                 if (effectData->SpellID != 0 && effectData->TriggerType == ITEM_SPELLTRIGGER_LEARN_SPELL_ID)

--- a/src/server/game/Entities/Item/Item.cpp
+++ b/src/server/game/Entities/Item/Item.cpp
@@ -467,9 +467,14 @@ bool Item::Create(ObjectGuid::LowType guidlow, uint32 itemId, ItemContext contex
     SetUpdateFieldValue(m_values.ModifyValue(&Item::m_itemData).ModifyValue(&UF::ItemData::MaxDurability), itemProto->MaxDurability);
     SetDurability(itemProto->MaxDurability);
 
-    for (std::size_t i = 0; i < itemProto->Effects.size(); ++i)
-        if (i < 5)
-            SetSpellCharges(i, itemProto->Effects[i]->Charges);
+    uint8 chargeSlot = 0;
+    for (ItemEffectEntry const* itemEffect : GetEffects())
+    {
+        if (chargeSlot >= MAX_ITEM_SPELLS)
+            break;
+
+        SetSpellCharges(chargeSlot++, itemEffect->Charges);
+    }
 
     SetExpiration(itemProto->GetDuration());
     SetCreatePlayedTime(0);
@@ -558,10 +563,12 @@ void Item::SaveToDB(CharacterDatabaseTransaction& trans)
             stmt->setUInt32(++index, GetCount());
             stmt->setUInt32(++index, m_itemData->Expiration);
 
+            // Charge slots are keyed by effect index and the update field holds only
+            // MAX_ITEM_SPELLS of them. LoadFromDB reads back at the same clamped width.
             std::ostringstream ssSpells;
-            if (ItemTemplate const* itemProto = sObjectMgr->GetItemTemplate(GetEntry()))
-                for (uint8 i = 0; i < itemProto->Effects.size(); ++i)
-                    ssSpells << GetSpellCharges(i) << ' ';
+            uint8 const chargeSlots = uint8(std::min<uint32>(_bonusData.EffectCount, MAX_ITEM_SPELLS));
+            for (uint8 i = 0; i < chargeSlots; ++i)
+                ssSpells << GetSpellCharges(i) << ' ';
             stmt->setString(++index, ssSpells.str());
 
             stmt->setUInt32(++index, m_itemData->DynamicFlags);
@@ -848,11 +855,6 @@ bool Item::LoadFromDB(ObjectGuid::LowType guid, ObjectGuid ownerGuid, Field* fie
         need_save = true;
     }
 
-    Tokenizer tokens(fields[6].GetString(), ' ', proto->Effects.size());
-    if (tokens.size() == proto->Effects.size())
-        for (uint8 i = 0; i < proto->Effects.size(); ++i)
-            SetSpellCharges(i, atoi(tokens[i]));
-
     SetItemFlags(ItemFieldFlags(itemFlags));
 
     /*SetUInt32Value(ITEM_FIELD_CONTEXT, fields[19].GetUInt8());
@@ -890,6 +892,14 @@ bool Item::LoadFromDB(ObjectGuid::LowType guid, ObjectGuid ownerGuid, Field* fie
     for (char const* token : bonusListString)
         bonusListIDs.push_back(atoi(token));
     SetBonuses(std::move(bonusListIDs));
+
+    // Must run after SetBonuses: before it only the template effects are known. An item
+    // stored before its bonus list changed legitimately has fewer tokens than effects,
+    // so read what is there rather than discarding every charge on a count mismatch.
+    Tokenizer tokens(fields[6].GetString(), ' ', _bonusData.EffectCount);
+    uint8 const chargeSlots = uint8(std::min({ uint32(tokens.size()), _bonusData.EffectCount, uint32(MAX_ITEM_SPELLS) }));
+    for (uint8 i = 0; i < chargeSlots; ++i)
+        SetSpellCharges(i, atoi(tokens[i]));
 
     SetModifier(ITEM_MODIFIER_TRANSMOG_APPEARANCE_ALL_SPECS, fields[19].GetUInt32());
     SetModifier(ITEM_MODIFIER_TRANSMOG_APPEARANCE_SPEC_1, fields[20].GetUInt32());
@@ -2414,8 +2424,10 @@ void Item::AddBonuses(uint32 bonusListID)
         std::vector<int32> bonusListIDs = m_itemData->BonusListIDs;
         bonusListIDs.push_back(bonusListID);
         SetUpdateFieldValue(m_values.ModifyValue(&Item::m_itemData).ModifyValue(&UF::ItemData::BonusListIDs), std::move(bonusListIDs));
+        uint32 const oldEffectCount = _bonusData.EffectCount;
         for (ItemBonusEntry const* bonus : *bonuses)
             _bonusData.AddBonus(bonus->Type, bonus->Value);
+        SeedSpellCharges(oldEffectCount);
         SetUpdateFieldValue(m_values.ModifyValue(&Item::m_itemData).ModifyValue(&UF::ItemData::ItemAppearanceModID), _bonusData.AppearanceModID);
     }
 }
@@ -2424,9 +2436,11 @@ void Item::SetBonuses(std::vector<int32> bonusListIDs)
 {
     SetUpdateFieldValue(m_values.ModifyValue(&Item::m_itemData).ModifyValue(&UF::ItemData::BonusListIDs), std::move(bonusListIDs));
 
+    uint32 const oldEffectCount = _bonusData.EffectCount;
     for (int32 bonusListID : *m_itemData->BonusListIDs)
         _bonusData.AddBonusList(bonusListID);
 
+    SeedSpellCharges(oldEffectCount);
     SetUpdateFieldValue(m_values.ModifyValue(&Item::m_itemData).ModifyValue(&UF::ItemData::ItemAppearanceModID), _bonusData.AppearanceModID);
 }
 
@@ -2435,6 +2449,17 @@ void Item::ClearBonuses()
     SetUpdateFieldValue(m_values.ModifyValue(&Item::m_itemData).ModifyValue(&UF::ItemData::BonusListIDs), std::vector<int32>());
     _bonusData.Initialize(GetTemplate());
     SetUpdateFieldValue(m_values.ModifyValue(&Item::m_itemData).ModifyValue(&UF::ItemData::ItemAppearanceModID), _bonusData.AppearanceModID);
+}
+
+// Create seeds charges from the template effects alone and every caller applies bonus
+// lists afterwards, so an effect arriving through ITEM_BONUS_ITEM_EFFECT_ID would keep a
+// charge slot of 0 and Spell::CheckItems would reject every cast. Slots below firstEffect
+// are left alone - a live item's charges are spent over time and must not reset.
+void Item::SeedSpellCharges(uint32 firstEffect)
+{
+    uint8 const chargeSlots = uint8(std::min<uint32>(_bonusData.EffectCount, MAX_ITEM_SPELLS));
+    for (uint8 i = uint8(std::min<uint32>(firstEffect, MAX_ITEM_SPELLS)); i < chargeSlots; ++i)
+        SetSpellCharges(i, _bonusData.Effects[i]->Charges);
 }
 
 bool Item::IsArtifactDisabled() const
@@ -2708,6 +2733,18 @@ void BonusData::Initialize(ItemTemplate const* proto)
     CanDisenchant = (proto->GetFlags() & ITEM_FLAG_NO_DISENCHANT) == 0;
     CanScrap = (proto->GetFlags4() & ITEM_FLAG4_SCRAPABLE) != 0;
 
+    EffectCount = 0;
+    for (ItemEffectEntry const* itemEffect : proto->Effects)
+    {
+        if (EffectCount >= MAX_BONUS_ITEM_EFFECTS)
+            break;
+
+        Effects[EffectCount++] = itemEffect;
+    }
+
+    for (uint32 i = EffectCount; i < MAX_BONUS_ITEM_EFFECTS; ++i)
+        Effects[i] = nullptr;
+
     _state.SuffixPriority = std::numeric_limits<int32>::max();
     _state.AppearanceModPriority = std::numeric_limits<int32>::max();
     _state.ScalingStatDistributionPriority = std::numeric_limits<int32>::max();
@@ -2829,6 +2866,13 @@ void BonusData::AddBonus(uint32 type, int32 const (&values)[3])
             break;
         case ITEM_BONUS_OVERRIDE_CAN_SCRAP:
             CanScrap = values[0] != 0;
+            break;
+        case ITEM_BONUS_ITEM_EFFECT_ID:
+            // Skip unknown ids silently: bad hotfix data must not crash, and logging
+            // here would fire once per item instance.
+            if (ItemEffectEntry const* itemEffect = sItemEffectStore.LookupEntry(uint32(values[0])))
+                if (EffectCount < MAX_BONUS_ITEM_EFFECTS)
+                    Effects[EffectCount++] = itemEffect;
             break;
     }
 }

--- a/src/server/game/Entities/Item/Item.cpp
+++ b/src/server/game/Entities/Item/Item.cpp
@@ -893,9 +893,6 @@ bool Item::LoadFromDB(ObjectGuid::LowType guid, ObjectGuid ownerGuid, Field* fie
         bonusListIDs.push_back(atoi(token));
     SetBonuses(std::move(bonusListIDs));
 
-    // Must run after SetBonuses: before it only the template effects are known. An item
-    // stored before its bonus list changed legitimately has fewer tokens than effects,
-    // so read what is there rather than discarding every charge on a count mismatch.
     Tokenizer tokens(fields[6].GetString(), ' ', _bonusData.EffectCount);
     uint8 const chargeSlots = uint8(std::min({ uint32(tokens.size()), _bonusData.EffectCount, uint32(MAX_ITEM_SPELLS) }));
     for (uint8 i = 0; i < chargeSlots; ++i)
@@ -2451,10 +2448,6 @@ void Item::ClearBonuses()
     SetUpdateFieldValue(m_values.ModifyValue(&Item::m_itemData).ModifyValue(&UF::ItemData::ItemAppearanceModID), _bonusData.AppearanceModID);
 }
 
-// Create seeds charges from the template effects alone and every caller applies bonus
-// lists afterwards, so an effect arriving through ITEM_BONUS_ITEM_EFFECT_ID would keep a
-// charge slot of 0 and Spell::CheckItems would reject every cast. Slots below firstEffect
-// are left alone - a live item's charges are spent over time and must not reset.
 void Item::SeedSpellCharges(uint32 firstEffect)
 {
     uint8 const chargeSlots = uint8(std::min<uint32>(_bonusData.EffectCount, MAX_ITEM_SPELLS));
@@ -2868,7 +2861,6 @@ void BonusData::AddBonus(uint32 type, int32 const (&values)[3])
             CanScrap = values[0] != 0;
             break;
         case ITEM_BONUS_ITEM_EFFECT_ID:
-            // Skip unknown ids silently: bad hotfix data must not crash, and logging
             // here would fire once per item instance.
             if (ItemEffectEntry const* itemEffect = sItemEffectStore.LookupEntry(uint32(values[0])))
                 if (EffectCount < MAX_BONUS_ITEM_EFFECTS)

--- a/src/server/game/Entities/Item/Item.h
+++ b/src/server/game/Entities/Item/Item.h
@@ -24,6 +24,7 @@
 #include "ItemDefines.h"
 #include "ItemEnchantmentMgr.h"
 #include "ItemTemplate.h"
+#include "IteratorPair.h"
 #include "Loot.h"
 
 class SpellInfo;
@@ -66,6 +67,11 @@ enum ItemUpdateState
 
 #define MAX_ITEM_SPELLS 5
 
+// Caps the template effects plus bonus-granted ones (ITEM_BONUS_ITEM_EFFECT_ID). Far
+// above anything a live item reaches; it exists only so malformed hotfix data cannot
+// grow the set without limit.
+#define MAX_BONUS_ITEM_EFFECTS 16
+
 bool ItemCanGoIntoBag(ItemTemplate const* proto, ItemTemplate const* pBagProto);
 extern ItemModifier const AppearanceModifierSlotBySpec[MAX_SPECIALIZATIONS];
 extern ItemModifier const IllusionModifierSlotBySpec[MAX_SPECIALIZATIONS];
@@ -96,6 +102,8 @@ struct BonusData
     bool CanDisenchant;
     bool CanScrap;
     bool HasFixedLevel;
+    ItemEffectEntry const* Effects[MAX_BONUS_ITEM_EFFECTS];
+    uint32 EffectCount;
 
     void Initialize(ItemTemplate const* proto);
     void Initialize(WorldPackets::Item::ItemInstance const& itemInstance);
@@ -184,6 +192,16 @@ public:
 
     ItemTemplate const* GetTemplate() const;
     BonusData const* GetBonus() const { return &_bonusData; }
+
+    // Template effects plus bonus-granted ones, in that order. Prefer this over
+    // GetTemplate()->Effects wherever an Item instance is in hand - the template
+    // alone does not know about bonus-granted effects.
+    Trinity::IteratorPair<ItemEffectEntry const* const*> GetEffects() const
+    {
+        return { { _bonusData.Effects, _bonusData.Effects + _bonusData.EffectCount } };
+    }
+
+    uint32 GetEffectCount() const { return _bonusData.EffectCount; }
 
     ObjectGuid GetOwnerGUID()    const { return m_itemData->Owner; }
     void SetOwnerGUID(ObjectGuid guid) { SetUpdateFieldValue(m_values.ModifyValue(&Item::m_itemData).ModifyValue(&UF::ItemData::Owner), guid); }
@@ -425,6 +443,7 @@ public:
 
     protected:
         void ApplyBonusList(uint32 itemBonusListId);
+        void SeedSpellCharges(uint32 firstEffect);
         BonusData _bonusData;
 
     private:

--- a/src/server/game/Entities/Item/Item.h
+++ b/src/server/game/Entities/Item/Item.h
@@ -67,9 +67,6 @@ enum ItemUpdateState
 
 #define MAX_ITEM_SPELLS 5
 
-// Caps the template effects plus bonus-granted ones (ITEM_BONUS_ITEM_EFFECT_ID). Far
-// above anything a live item reaches; it exists only so malformed hotfix data cannot
-// grow the set without limit.
 #define MAX_BONUS_ITEM_EFFECTS 16
 
 bool ItemCanGoIntoBag(ItemTemplate const* proto, ItemTemplate const* pBagProto);
@@ -193,9 +190,6 @@ public:
     ItemTemplate const* GetTemplate() const;
     BonusData const* GetBonus() const { return &_bonusData; }
 
-    // Template effects plus bonus-granted ones, in that order. Prefer this over
-    // GetTemplate()->Effects wherever an Item instance is in hand - the template
-    // alone does not know about bonus-granted effects.
     Trinity::IteratorPair<ItemEffectEntry const* const*> GetEffects() const
     {
         return { { _bonusData.Effects, _bonusData.Effects + _bonusData.EffectCount } };

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -685,6 +685,7 @@ bool Player::Create(ObjectGuid::LowType guidlow, WorldPackets::Character::Charac
                 // special amount for food/drink
                 if (iProto->GetClass() == ITEM_CLASS_CONSUMABLE && iProto->GetSubClass() == ITEM_SUBCLASS_FOOD_DRINK)
                 {
+                    // Template effects only: this walks stored item ids, not instances.
                     if (iProto->Effects.size() >= 1)
                     {
                         switch (iProto->Effects[0]->SpellCategoryID)
@@ -8335,13 +8336,12 @@ void Player::CastAllObtainSpells()
 
 void Player::ApplyItemObtainSpells(Item* item, bool apply)
 {
-    ItemTemplate const* itemTemplate = item->GetTemplate();
-    for (uint8 i = 0; i < itemTemplate->Effects.size(); ++i)
+    for (ItemEffectEntry const* effectData : item->GetEffects())
     {
-        if (itemTemplate->Effects[i]->TriggerType != ITEM_SPELLTRIGGER_ON_OBTAIN) // On obtain trigger
+        if (effectData->TriggerType != ITEM_SPELLTRIGGER_ON_OBTAIN) // On obtain trigger
             continue;
 
-        int32 const spellId = itemTemplate->Effects[i]->SpellID;
+        int32 const spellId = effectData->SpellID;
         if (spellId <= 0)
             continue;
 
@@ -8382,14 +8382,11 @@ void Player::ApplyItemEquipSpell(Item* item, bool apply, bool formChange /*= fal
     if (!item)
         return;
 
-    ItemTemplate const* proto = item->GetTemplate();
-    if (!proto)
+    if (!item->GetTemplate())
         return;
 
-    for (uint8 i = 0; i < proto->Effects.size(); ++i)
+    for (ItemEffectEntry const* effectData : item->GetEffects())
     {
-        ItemEffectEntry const* effectData = proto->Effects[i];
-
         // wrong triggering type
         if (apply && effectData->TriggerType != ITEM_SPELLTRIGGER_ON_EQUIP)
             continue;
@@ -8727,10 +8724,8 @@ void Player::CastItemCombatSpell(DamageInfo const& damageInfo, Item* item, ItemT
     bool canTrigger = (damageInfo.GetHitMask() & (PROC_HIT_NORMAL | PROC_HIT_CRITICAL | PROC_HIT_ABSORB)) != 0;
     if (canTrigger)
     {
-        for (uint8 i = 0; i < proto->Effects.size(); ++i)
+        for (ItemEffectEntry const* effectData : item->GetEffects())
         {
-            ItemEffectEntry const* effectData = proto->Effects[i];
-
             // wrong triggering type
             if (effectData->TriggerType != ITEM_SPELLTRIGGER_CHANCE_ON_HIT)
                 continue;
@@ -8857,6 +8852,8 @@ void Player::CastItemUseSpell(Item* item, SpellCastTargets const& targets, Objec
 {
     ItemTemplate const* proto = item->GetTemplate();
     // special learning case
+    // Template effects only: the learn-spell special case is keyed to the two fixed
+    // template effect slots, which bonus-granted effects are appended after.
     if (proto->Effects.size() >= 2)
     {
         if (proto->Effects[0]->SpellID == 483 || proto->Effects[0]->SpellID == 55884)
@@ -8888,10 +8885,8 @@ void Player::CastItemUseSpell(Item* item, SpellCastTargets const& targets, Objec
     }
 
     // item spells cast at use
-    for (uint8 i = 0; i < proto->Effects.size(); ++i)
+    for (ItemEffectEntry const* effectData : item->GetEffects())
     {
-        ItemEffectEntry const* effectData = proto->Effects[i];
-
         // wrong triggering type
         if (effectData->TriggerType != ITEM_SPELLTRIGGER_ON_USE)
             continue;
@@ -12709,6 +12704,7 @@ InventoryResult Player::CanUseItem(ItemTemplate const* proto, bool skipRequiredL
         return EQUIP_ERR_CANT_EQUIP_REPUTATION;
 
     // learning (recipes, mounts, pets, etc.)
+    // Template effects only: same fixed learn-spell slots as CastItemUseSpell.
     if (proto->Effects.size() >= 2)
         if (proto->Effects[0]->SpellID == 483 || proto->Effects[0]->SpellID == 55884)
             if (HasSpell(proto->Effects[1]->SpellID))
@@ -24598,6 +24594,8 @@ void Player::UpdatePotionCooldown(Spell* spell)
     {
         // spell/item pair let set proper cooldown (except non-existing charged spell cooldown spellmods for potions)
         if (ItemTemplate const* proto = sObjectMgr->GetItemTemplate(m_lastPotionId))
+            // Template effects only: UpdatePotionCooldown is keyed off m_lastPotionId,
+            // an item id kept after the Item itself is gone.
             for (uint8 idx = 0; idx < proto->Effects.size(); ++idx)
                 if (proto->Effects[idx]->TriggerType == ITEM_SPELLTRIGGER_ON_USE)
                     if (SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(proto->Effects[idx]->SpellID))
@@ -25555,10 +25553,8 @@ void Player::ApplyEquipCooldown(Item* pItem)
         return;
 
     std::chrono::steady_clock::time_point now = GameTime::GetGameTimeSteadyPoint();
-    for (uint8 i = 0; i < proto->Effects.size(); ++i)
+    for (ItemEffectEntry const* effectData : pItem->GetEffects())
     {
-        ItemEffectEntry const* effectData = proto->Effects[i];
-
         // apply proc cooldown to equip auras if we have any
         if (effectData->TriggerType == ITEM_SPELLTRIGGER_ON_EQUIP)
         {

--- a/src/server/game/Handlers/ItemHandler.cpp
+++ b/src/server/game/Handlers/ItemHandler.cpp
@@ -1190,7 +1190,7 @@ void WorldSession::HandleUseCritterItem(WorldPackets::Item::UseCritterItem& useC
     if (!item)
         return;
 
-    if (item->GetTemplate()->Effects.size() < 2)
+    if (item->GetEffectCount() < 2)
         return;
 
     _player->DestroyItem(item->GetBagSlot(), item->GetSlot(), true);

--- a/src/server/game/Handlers/SpellHandler.cpp
+++ b/src/server/game/Handlers/SpellHandler.cpp
@@ -95,9 +95,14 @@ void WorldSession::HandleUseItemOpcode(WorldPackets::Spells::UseItem& packet)
 
     if (user->IsInCombat())
     {
-        for (uint32 i = 0; i < proto->Effects.size(); ++i)
+        for (ItemEffectEntry const* itemEffect : item->GetEffects())
         {
-            if (SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(proto->Effects[i]->SpellID))
+            // Only the on-use effect is being cast here - a passive effect that happens to
+            // be flagged unusable in combat must not block it
+            if (itemEffect->TriggerType != ITEM_SPELLTRIGGER_ON_USE)
+                continue;
+
+            if (SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(itemEffect->SpellID))
             {
                 if (!spellInfo->CanBeUsedInCombat())
                 {

--- a/src/server/game/Handlers/ToyHandler.cpp
+++ b/src/server/game/Handlers/ToyHandler.cpp
@@ -61,6 +61,8 @@ void WorldSession::HandleUseToy(WorldPackets::Toy::UseToy& packet)
     if (!_collectionMgr->HasToy(itemId))
         return;
 
+    // Template effects only: a toy is used from the collection by item entry - the
+    // player need not own an instance of it.
     auto effect = std::find_if(item->Effects.begin(), item->Effects.end(), [&packet](ItemEffectEntry const* effect)
     {
         return packet.Cast.SpellID == effect->SpellID;

--- a/src/server/game/Loot/Loot.cpp
+++ b/src/server/game/Loot/Loot.cpp
@@ -81,7 +81,8 @@ bool LootItem::AllowedForPlayer(Player const* player) const
             return false;
 
         // not show loot for players without profession or those who already know the recipe
-        if ((pProto->GetFlags() & ITEM_FLAG_HIDE_UNUSABLE_RECIPE) && (!player->HasSkill(pProto->GetRequiredSkill()) || player->HasSpell(pProto->Effects[1]->SpellID)))
+        // Template effects only: loot is filtered before any Item is created.
+        if ((pProto->GetFlags() & ITEM_FLAG_HIDE_UNUSABLE_RECIPE) && (!player->HasSkill(pProto->GetRequiredSkill()) || (pProto->Effects.size() > 1 && player->HasSpell(pProto->Effects[1]->SpellID))))
             return false;
 
         // not show loot for not own team

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -4693,14 +4693,20 @@ void Spell::TakeCastItem()
     }
 
     bool expendable = false;
-    bool withoutCharges = false;
+    // Starts set so the verdict of every charged effect can be folded in below; an item
+    // with no charged effect at all is never expendable and so is never destroyed here.
+    bool withoutCharges = true;
 
-    for (uint8 i = 0; i < proto->Effects.size() && i < 5; ++i)
+    uint8 i = 0;
+    for (ItemEffectEntry const* itemEffect : m_CastItem->GetEffects())
     {
+        if (i >= MAX_ITEM_SPELLS)
+            break;
+
         // item has limited charges
-        if (proto->Effects[i]->Charges)
+        if (itemEffect->Charges)
         {
-            if (proto->Effects[i]->Charges < 0)
+            if (itemEffect->Charges < 0)
                 expendable = true;
 
             int32 charges = m_CastItem->GetSpellCharges(i);
@@ -4714,9 +4720,15 @@ void Spell::TakeCastItem()
                 m_CastItem->SetState(ITEM_CHANGED, player);
             }
 
-            // all charges used
-            withoutCharges = (charges == 0);
+            // A stack shares one charge array, so the write above was skipped and this
+            // reads back the seeded value - only a persisted count says the item is spent.
+            // Fold rather than assign, so one spent effect cannot condemn an item whose
+            // other effects still have charges.
+            if (proto->GetMaxStackSize() == 1)
+                withoutCharges = withoutCharges && (charges == 0);
         }
+
+        ++i;
     }
 
     if (expendable && withoutCharges)
@@ -4897,14 +4909,19 @@ void Spell::TakeReagents()
         uint32 itemid = m_spellInfo->Reagent[x];
         uint32 itemcount = m_spellInfo->ReagentCount[x];
 
-        // if CastItem is also spell reagent
-        if (castItemTemplate && castItemTemplate->GetId() == itemid)
+        // if CastItem is also spell reagent - the template outlives m_CastItem, which this
+        // block clears, so a second reagent slot naming the same item must not re-enter it
+        if (m_CastItem && castItemTemplate && castItemTemplate->GetId() == itemid)
         {
-            for (uint8 s = 0; s < castItemTemplate->Effects.size() && s < 5; ++s)
+            uint8 s = 0;
+            for (ItemEffectEntry const* itemEffect : m_CastItem->GetEffects())
             {
+                if (s >= MAX_ITEM_SPELLS)
+                    break;
+
                 // CastItem will be used up and does not count as reagent
-                int32 charges = m_CastItem->GetSpellCharges(s);
-                if (castItemTemplate->Effects[s]->Charges < 0 && abs(charges) < 2)
+                int32 charges = m_CastItem->GetSpellCharges(s++);
+                if (itemEffect->Charges < 0 && abs(charges) < 2)
                 {
                     ++itemcount;
                     break;
@@ -6476,10 +6493,17 @@ SpellCastResult Spell::CheckItems(uint32* param1 /*= nullptr*/, uint32* param2 /
         if (!proto)
             return SPELL_FAILED_ITEM_NOT_READY;
 
-        for (uint8 i = 0; i < proto->Effects.size() && i < 5; ++i)
-            if (proto->Effects[i]->Charges)
-                if (m_CastItem->GetSpellCharges(i) == 0)
-                    return SPELL_FAILED_NO_CHARGES_REMAIN;
+        uint8 chargeSlot = 0;
+        for (ItemEffectEntry const* itemEffect : m_CastItem->GetEffects())
+        {
+            if (chargeSlot >= MAX_ITEM_SPELLS)
+                break;
+
+            if (itemEffect->Charges && m_CastItem->GetSpellCharges(chargeSlot) == 0)
+                return SPELL_FAILED_NO_CHARGES_REMAIN;
+
+            ++chargeSlot;
+        }
 
         // consumable cast item checks
         if (proto->GetClass() == ITEM_CLASS_CONSUMABLE && m_targets.GetUnitTarget())
@@ -6578,11 +6602,15 @@ SpellCastResult Spell::CheckItems(uint32* param1 /*= nullptr*/, uint32* param2 /
                     ItemTemplate const* proto = m_CastItem->GetTemplate();
                     if (!proto)
                         return SPELL_FAILED_ITEM_NOT_READY;
-                    for (uint8 s = 0; s < proto->Effects.size() && s < 5; ++s)
+                    uint8 s = 0;
+                    for (ItemEffectEntry const* itemEffect : m_CastItem->GetEffects())
                     {
+                        if (s >= MAX_ITEM_SPELLS)
+                            break;
+
                         // CastItem will be used up and does not count as reagent
-                        int32 charges = m_CastItem->GetSpellCharges(s);
-                        if (proto->Effects[s]->Charges < 0 && abs(charges) < 2)
+                        int32 charges = m_CastItem->GetSpellCharges(s++);
+                        if (itemEffect->Charges < 0 && abs(charges) < 2)
                         {
                             ++itemcount;
                             break;
@@ -6716,10 +6744,9 @@ SpellCastResult Spell::CheckItems(uint32* param1 /*= nullptr*/, uint32* param2 /
                     return SPELL_FAILED_LOWLEVEL;
 
                 bool isItemUsable = false;
-                ItemTemplate const* proto = targetItem->GetTemplate();
-                for (uint8 e = 0; e < proto->Effects.size(); ++e)
+                for (ItemEffectEntry const* itemEffect : targetItem->GetEffects())
                 {
-                    if (proto->Effects[e]->SpellID && proto->Effects[e]->TriggerType == ITEM_SPELLTRIGGER_ON_USE)
+                    if (itemEffect->SpellID && itemEffect->TriggerType == ITEM_SPELLTRIGGER_ON_USE)
                     {
                         isItemUsable = true;
                         break;
@@ -6914,9 +6941,17 @@ SpellCastResult Spell::CheckItems(uint32* param1 /*= nullptr*/, uint32* param2 /
 
                  if (Item* item = player->GetItemByEntry(itemId))
                  {
-                     for (uint8 x = 0; x < proto->Effects.size() && x < 5; ++x)
-                         if (proto->Effects[x]->Charges != 0 && item->GetSpellCharges(x) == proto->Effects[x]->Charges)
+                     uint8 x = 0;
+                     for (ItemEffectEntry const* itemEffect : item->GetEffects())
+                     {
+                         if (x >= MAX_ITEM_SPELLS)
+                             break;
+
+                         if (itemEffect->Charges != 0 && item->GetSpellCharges(x) == itemEffect->Charges)
                              return SPELL_FAILED_ITEM_AT_MAX_CHARGES;
+
+                         ++x;
+                     }
                  }
                  break;
             }

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -4693,8 +4693,7 @@ void Spell::TakeCastItem()
     }
 
     bool expendable = false;
-    // Starts set so the verdict of every charged effect can be folded in below; an item
-    // with no charged effect at all is never expendable and so is never destroyed here.
+
     bool withoutCharges = true;
 
     uint8 i = 0;
@@ -4719,11 +4718,6 @@ void Spell::TakeCastItem()
                     m_CastItem->SetSpellCharges(i, charges);
                 m_CastItem->SetState(ITEM_CHANGED, player);
             }
-
-            // A stack shares one charge array, so the write above was skipped and this
-            // reads back the seeded value - only a persisted count says the item is spent.
-            // Fold rather than assign, so one spent effect cannot condemn an item whose
-            // other effects still have charges.
             if (proto->GetMaxStackSize() == 1)
                 withoutCharges = withoutCharges && (charges == 0);
         }
@@ -4909,8 +4903,7 @@ void Spell::TakeReagents()
         uint32 itemid = m_spellInfo->Reagent[x];
         uint32 itemcount = m_spellInfo->ReagentCount[x];
 
-        // if CastItem is also spell reagent - the template outlives m_CastItem, which this
-        // block clears, so a second reagent slot naming the same item must not re-enter it
+        // if CastItem is also spell reagent
         if (m_CastItem && castItemTemplate && castItemTemplate->GetId() == itemid)
         {
             uint8 s = 0;

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -5777,9 +5777,15 @@ void Spell::EffectRechargeItem(SpellEffIndex /*effIndex*/)
 
     if (Item* item = player->GetItemByEntry(effectInfo->ItemType))
     {
-        ItemTemplate const* proto = item->GetTemplate();
-        for (size_t x = 0; x < proto->Effects.size() && x < 5; ++x)
-            item->SetSpellCharges(x, proto->Effects[x]->Charges);
+        uint8 x = 0;
+        for (ItemEffectEntry const* itemEffect : item->GetEffects())
+        {
+            if (x >= MAX_ITEM_SPELLS)
+                break;
+
+            item->SetSpellCharges(x++, itemEffect->Charges);
+        }
+
         item->SetState(ITEM_CHANGED, player);
     }
 }

--- a/src/server/game/Spells/SpellHistory.cpp
+++ b/src/server/game/Spells/SpellHistory.cpp
@@ -1032,6 +1032,9 @@ void SpellHistory::GetCooldownDurations(SpellInfo const* spellInfo, uint32 itemI
     {
         if (ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId))
         {
+            // Template effects only: this receives an item id, not an Item*, so a
+            // bonus-granted effect's cooldown override is out of reach. Corruption
+            // effects are passive, so nothing needs it yet.
             for (ItemEffectEntry const* itemEffect : proto->Effects)
             {
                 if (uint32(itemEffect->SpellID) == spellInfo->Id)

--- a/src/server/game/Spells/SpellHistory.cpp
+++ b/src/server/game/Spells/SpellHistory.cpp
@@ -1032,9 +1032,6 @@ void SpellHistory::GetCooldownDurations(SpellInfo const* spellInfo, uint32 itemI
     {
         if (ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId))
         {
-            // Template effects only: this receives an item id, not an Item*, so a
-            // bonus-granted effect's cooldown override is out of reach. Corruption
-            // effects are passive, so nothing needs it yet.
             for (ItemEffectEntry const* itemEffect : proto->Effects)
             {
                 if (uint32(itemEffect->SpellID) == spellInfo->Id)


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

`ITEM_BONUS_ITEM_EFFECT_ID = 23` is declared in `DBCEnums.h` but had **no case in
`BonusData::AddBonus`**, `BonusData` had no storage for effects, and every consumer read
`proto->Effects` — the static `ItemTemplate` list. An item whose effect arrives through a bonus list
therefore contributed its stats but never its effect spell.

This is not corruption-specific. **Any** bonus-granted item effect was silently dropped; corrupted
gear is just the most visible case, because on 8.3 every corruption affix is delivered this way.

`BonusData` gains an effect set, seeded from the template in `Initialize` and appended to by
`AddBonus`. `Item::GetEffects()` returns it and `Item::GetEffectCount()` its size.

### The migration rule

A call site uses `GetEffects()` **if and only if it holds an `Item*`**. Sites that hold only an
`ItemTemplate const*` keep `proto->Effects` and carry a comment saying why:

| Site | Why it keeps the template list |
|---|---|
| `LootItem::AllowedForPlayer` | A loot filter runs before any `Item` exists |
| `AuctionHouseMgr` | A listing is an entry plus bonus ids, not an instance |
| `ToyHandler` | A toy is used from the collection, not from an item |
| `Player::UpdatePotionCooldown` | Keyed off `m_lastPotionId`, an id kept after the `Item` is gone |
| `CastItemUseSpell` / `CanUseItem` learn-spell case | Keyed to the two fixed template slots that bonus effects are appended *after* |

### Charge handling

Charge slots are keyed by effect index into a 5-wide update field, so every walk is clamped to
`MAX_ITEM_SPELLS` and indexed with `uint8`. `Item::Create` seeds from the template only and every
caller applies bonus lists afterwards, so `SeedSpellCharges` fills the slots a newly applied bonus
list just added without touching charges already spent. `SaveToDB` and `LoadFromDB` agree on the
clamped width, and `LoadFromDB` now runs *after* `SetBonuses` and reads however many tokens are
present instead of discarding every charge on a count mismatch.

`MAX_BONUS_ITEM_EFFECTS` caps the set at 16 so malformed hotfix data cannot grow it without limit.
Unknown effect ids are skipped silently — logging would fire once per item instance.

### Four defects surfaced while migrating the call sites

- **`Spell::TakeCastItem`** judged "no charges left" from whichever effect it looked at last, and read
  a charge array that a stacked item never writes to. It now folds the verdict across every charged
  effect and only trusts a persisted count.
- **`Spell::TakeReagents`** dereferenced `m_CastItem` in a block that had already cleared it, if a
  second reagent slot named the same item.
- **`LootItem::AllowedForPlayer`** indexed `Effects[1]` unconditionally.
- **`WorldSession::HandleUseItemOpcode`** rejected an in-combat use because a *passive* effect on the
  item was flagged unusable in combat, rather than judging the on-use effect being cast.

### AI-assisted Pull Requests

- [x] AI tools were used. **Claude Code, model Claude Opus 5.** Used for the call-site survey, the
      migration rule, and drafting. Every line has been reviewed and is defensible by the author.

## Issues Addressed:
- Closes nothing tracked.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources.
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

The behaviour claim is grounded in the 8.3.7 client data itself. Parsing `ItemBonus.db2` and
`ItemEffect.db2` for this build gives **220 rows of `Type = 23`**, resolving to 88 distinct effect
spells. That parse was cross-checked against the `item_effect` rows that also exist in the hotfix
database and agrees 70/70 on `TriggerType`, `SpellID`, `LegacySlotIndex` and both cooldown columns.

## Tests Performed:
- [x] Tested in-game by the author.
- [x] Tested in-game by other community members/someone else other than the author.
- [x] This pull request requires further testing and may have edge cases to be tested.

Built clean on Windows / VS 2022 x64 RelWithDebInfo, and verified in-game: a corrupted item's effect
spell now applies on equip, and charged on-use items are consumed at the right time.

**This is a generic change and deserves regression testing well beyond the case that motivated it.**
Any item with an on-use or on-equip effect is in scope, as is anything with spell charges. The charge
serialization path in particular changes what `LoadFromDB` accepts.

## How to Test the Changes:
- [x] This pull request requires further testing. Steps below.

1. `.additem 174103 1 6552` (or any item id with a corruption bonus list — the third argument is a
   **bonus list id**, not a spell id). Equip it: on `main` no effect aura appears, on this branch it does.
2. Regression: use a charged item (a potion, a trinket with charges), confirm the charge is spent
   once and persists across a relog.
3. Regression: use an on-use trinket in combat that also carries a passive effect. On `main` this
   could be wrongly rejected as unusable in combat.
4. Regression: loot an item whose template has exactly one effect — `AllowedForPlayer` previously
   indexed `Effects[1]` unconditionally.

## Known Issues and TODO List:
- [ ] **Unequip does not remove the effect.** A corrupted item's affix keeps firing after the item is
      unequipped, until it leaves the bags or the player relogs. Root cause is not yet established —
      the effects are confirmed `TriggerType = ON_EQUIP` (so the on-obtain path is not responsible),
      and `ApplyItemEquipSpell(item, false)` is reached on unequip, but something in the removal is
      not matching. **This is not fixed in this PR** and is being investigated separately.
- [ ] Some items that should carry a corruption effect do not — @Hextv reports `172227`
      [Shard of the Black Empire]. Triaged as bonus-list data rather than this code path, but unconfirmed.

---

This is one of six PRs splitting a previously oversized branch apart. It is **independent** of the
other five and can merge on its own; the corruption feature PR stacks on top of it.
