### PR TITLE
core/player: re-evaluate corruption penalties without re-applying them

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1088,6 +1088,12 @@ void Player::Update(uint32 p_time)
     if (!IsInWorld())
         return;
 
+    if (m_corruptionNeedsUpdate)
+    {
+        m_corruptionNeedsUpdate = false;
+        UpdateCorruption();
+    }
+
     // undelivered mail
     if (m_nextMailDelivereTime && m_nextMailDelivereTime <= time(nullptr))
     {
@@ -4635,6 +4641,11 @@ void Player::ResurrectPlayer(float restore_percent, bool applySickness)
 
     setDeathState(ALIVE);
 
+    // RemoveAllAurasOnDeath stripped the corruption penalties and nothing puts them back:
+    // the sync is driven by a rating change or an area transition, and resurrecting is
+    // neither. Reviving where you fell otherwise leaves the player uncorrupted.
+    ScheduleCorruptionUpdate();
+
     // add the flag to make sure opcode is always sent
     AddUnitMovementFlag(MOVEMENTFLAG_WATERWALKING);
     SetWaterWalking(false);
@@ -5526,7 +5537,11 @@ void Player::UpdateRating(CombatRating cr)
             break;
         case CR_CORRUPTION:
         case CR_CORRUPTION_RESISTANCE:
-            UpdateCorruption();
+            // Bulk rebuilds strip every item's corruption before re-applying it, so syncing per
+            // mutation would walk the total down to zero and tear down each tier's aura on the
+            // way. Callers that clear this flag are responsible for one sync when they finish.
+            if (affectStats)
+                ScheduleCorruptionUpdate();
             break;
         case CR_SPEED:
         case CR_RESILIENCE_PLAYER_DAMAGE:
@@ -7689,6 +7704,11 @@ void Player::UpdateArea(uint32 newArea)
                 if (garrison.second->IsAllowedArea(newArea))
                     garrison.second->Enter();
         }
+
+        // A corruption penalty can be gated on a PlayerConditionID that reads the player's
+        // location, and nothing else re-evaluates those conditions when only the area
+        // changes. Safe on every transition: the sync casts only what is missing.
+        ScheduleCorruptionUpdate();
     }
 }
 
@@ -30832,12 +30852,15 @@ void Player::CreateChallengeKey(Item* item)
 void Player::SetEffectiveLevelAndMaxItemLevel(uint32 effectiveLevel, uint32 maxItemLevel)
 {
     float healthPct = GetHealthPct();
+    SetCanModifyStats(false);
     _RemoveAllItemMods();
 
     SetUpdateFieldValue(m_values.ModifyValue(&Unit::m_unitData).ModifyValue(&UF::UnitData::EffectiveLevel), effectiveLevel);
     SetUpdateFieldValue(m_values.ModifyValue(&Unit::m_unitData).ModifyValue(&UF::UnitData::MaxItemLevel), maxItemLevel);
 
     _ApplyAllItemMods();
+    SetCanModifyStats(true);
+
     UpdateAverageItemLevel();
 
     uint32 basemana = 0;
@@ -30865,9 +30888,15 @@ void Player::UpdateItemLevelAreaBasedScaling()
     if (_usePvpItemLevels != pvpActivity)
     {
         float healthPct = GetHealthPct();
+        SetCanModifyStats(false);
         _RemoveAllItemMods();
         ActivatePvpItemLevels(pvpActivity);
         _ApplyAllItemMods();
+        SetCanModifyStats(true);
+        // The bracket defers every derived stat, not only corruption, and neither item-mod
+        // pass recomputes on its own - so settle them all once here, as _ApplyAllStatBonuses
+        // does, leaving the max health scaled below freshly computed rather than stale.
+        UpdateAllStats();
         SetHealth(CalculatePct(GetMaxHealth(), healthPct));
     }
     // @todo other types of power scaling

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1993,7 +1993,12 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         void UpdateLeechPercentage();
 
         void UpdateSpellCritChance();
+        float GetEffectiveCorruption() const;
         void UpdateCorruption();
+        // Corruption penalties are synced once per tick rather than at each mutation site.
+        // A single item swap can move several corrupted pieces through several intermediate
+        // states; syncing each one would apply and remove the same penalty auras repeatedly.
+        void ScheduleCorruptionUpdate() { m_corruptionNeedsUpdate = true; }
         void UpdateArmorPenetration(int32 amount);
         void UpdateExpertise(WeaponAttackType attType);
         void ApplyManaRegenBonus(int32 amount, bool apply);
@@ -3016,6 +3021,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         bool m_canParry;
         bool m_canBlock;
         bool m_canTitanGrip;
+        bool m_corruptionNeedsUpdate = false;
         uint32 m_titanGripPenaltySpellId;
         uint8 m_swingErrorMsg;
 

--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -732,9 +732,14 @@ void Player::UpdateSpellCritChance()
     SetUpdateFieldValue(m_values.ModifyValue(&Player::m_activePlayerData).ModifyValue(&UF::ActivePlayerData::SpellCritPercentage), crit);
 }
 
+float Player::GetEffectiveCorruption() const
+{
+    return GetRatingBonusValue(CR_CORRUPTION) - GetRatingBonusValue(CR_CORRUPTION_RESISTANCE);
+}
+
 void Player::UpdateCorruption()
 {
-    float effectiveCorruption = GetRatingBonusValue(CR_CORRUPTION) - GetRatingBonusValue(CR_CORRUPTION_RESISTANCE);
+    float const effectiveCorruption = GetEffectiveCorruption();
     for (CorruptionEffectsEntry const* corruptionEffect : sCorruptionEffectsStore)
     {
         if ((CorruptionEffectsFlag(corruptionEffect->Flags) & CorruptionEffectsFlag::Disabled) != CorruptionEffectsFlag::None)
@@ -755,7 +760,13 @@ void Player::UpdateCorruption()
             }
         }
 
-        CastSpell(this, corruptionEffect->Aura, true);
+        // Re-casting a penalty that is already applied restarts its duration and resets its
+        // proc state, and this runs on every rating change and area transition. Cast only
+        // what is missing; what is already there recomputes its magnitudes in place.
+        if (Aura* corruptionAura = GetAura(corruptionEffect->Aura))
+            corruptionAura->RecalculateAmountOfEffects();
+        else
+            CastSpell(this, corruptionEffect->Aura, true);
     }
 }
 

--- a/src/server/scripts/Commands/cs_debug.cpp
+++ b/src/server/scripts/Commands/cs_debug.cpp
@@ -117,6 +117,7 @@ public:
             { "transportState", rbac::RBAC_PERM_COMMAND_DEBUG,              false, &HandleDebugTransportStateCommand,   "" },
             { "worldstate" ,   rbac::RBAC_PERM_COMMAND_DEBUG,               false, &HandleDebugWorldStateCommand,       "" },
             { "wsexpression" , rbac::RBAC_PERM_COMMAND_DEBUG,               false, &HandleDebugWSExpressionCommand,     "" },
+            { "corruption",    rbac::RBAC_PERM_COMMAND_DEBUG,               false, &HandleDebugCorruptionCommand,       "" },
         };
         static std::vector<ChatCommand> commandTable =
         {
@@ -1425,6 +1426,48 @@ public:
             handler->PSendSysMessage("True");
         else
             handler->PSendSysMessage("False");
+
+        return true;
+    }
+
+    static bool HandleDebugCorruptionCommand(ChatHandler* handler, char const* /*args*/)
+    {
+        Player* target = handler->getSelectedPlayerOrSelf();
+        if (!target)
+        {
+            handler->SendSysMessage(LANG_NO_CHAR_SELECTED);
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
+        float const effectiveCorruption = target->GetEffectiveCorruption();
+        handler->PSendSysMessage("Corruption for %s: effective %.2f (corruption %.2f - resistance %.2f)",
+            target->GetName().c_str(), effectiveCorruption,
+            target->GetRatingBonusValue(CR_CORRUPTION), target->GetRatingBonusValue(CR_CORRUPTION_RESISTANCE));
+
+        uint32 rows = 0;
+        for (CorruptionEffectsEntry const* corruptionEffect : sCorruptionEffectsStore)
+        {
+            ++rows;
+
+            char const* state;
+            if ((CorruptionEffectsFlag(corruptionEffect->Flags) & CorruptionEffectsFlag::Disabled) != CorruptionEffectsFlag::None)
+                state = "disabled";
+            else if (effectiveCorruption < corruptionEffect->MinCorruption)
+                state = "below threshold";
+            else if (PlayerConditionEntry const* playerCondition = sPlayerConditionStore.LookupEntry(corruptionEffect->PlayerConditionID))
+                state = ConditionMgr::IsPlayerMeetingCondition(target, playerCondition) ? "qualifies" : "condition failed";
+            else
+                state = "qualifies";
+
+            handler->PSendSysMessage("  row %u: min %.2f aura %d cond %d - %s, aura %s",
+                corruptionEffect->ID, corruptionEffect->MinCorruption, corruptionEffect->Aura,
+                corruptionEffect->PlayerConditionID, state,
+                target->HasAura(corruptionEffect->Aura) ? "APPLIED" : "absent");
+        }
+
+        if (!rows)
+            handler->SendSysMessage("CorruptionEffects.db2 holds no rows - no penalty can apply on this server. That is missing client data, not a core fault.");
 
         return true;
     }


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [x] Scripts — one new debug command, `.debug corruption`.
-  [ ] Database (SAI, creatures, etc).

`Player::UpdateCorruption` keeps the `CorruptionEffects.db2` threshold penalties in step with the
player's effective corruption. It had three defects, each of which left the penalties out of step.

**It re-applied live auras.** The loop ended in an unconditional `CastSpell(this, aura, true)`, so
every corruption rating change re-cast penalties that were already present — restarting their
durations and resetting their proc state. It now casts only what is missing and lets an already
applied aura recalculate its own amounts in place.

**It was never re-evaluated on an area change.** Each `CorruptionEffects` row carries a
`PlayerConditionID`, but the sync ran only from `UpdateRating(CR_CORRUPTION |
CR_CORRUPTION_RESISTANCE)` — a gear or rating-aura change. A player who walked into an area where the
condition stopped matching kept the penalty indefinitely; one who walked out never regained it.
`UpdateArea` now schedules a sync.

**It was never re-evaluated on resurrect.** `RemoveAllAurasOnDeath` strips the penalties, and neither
a rating change nor an area transition necessarily follows, so reviving where you fell left the
player uncorrupted until they happened to cross an area border. That is why a corpse run appeared to
fix it and `.revive` did not.

### Why the sync is coalesced rather than run at each mutation site

Syncing at every mutation site is wrong in the other direction. A bulk item rebuild strips every
item's corruption before re-applying it, so a per-mutation sync walks the total down to zero and
tears down each tier's aura on the way back up. The sync is instead coalesced behind a dirty flag and
runs once per `Player::Update` tick.

The two item-level rebuilds that did not bracket themselves with `SetCanModifyStats` now do, and
`UpdateItemLevelAreaBasedScaling` settles its derived stats afterwards — without that, the max health
it scales the player to was one rebuild stale.

`GetEffectiveCorruption` is split out of `UpdateCorruption` so callers that need the value do not
repeat the rating subtraction.

### `.debug corruption`

When a penalty fails to apply there are three gates that could have rejected it — the threshold, the
`PlayerConditionID`, or the row being flagged disabled — and no way to tell which. The alternative is
equipping corrupted gear and inferring the answer from what happens.

The command prints the selected player's effective corruption alongside the two ratings it derives
from, then every `CorruptionEffects` row with its threshold, aura, condition, the verdict on that
player, and whether the aura is actually applied. A server whose client data has no
`CorruptionEffects` rows at all reports that explicitly, since it is otherwise indistinguishable from
a core fault. RBAC-gated behind `RBAC_PERM_COMMAND_DEBUG` like the rest of the table.

### AI-assisted Pull Requests

- [x] AI tools were used. **Claude Code, model Claude Opus 5.** Used for tracing the three missed
      re-evaluation paths and drafting. Every line has been reviewed and is defensible by the author.

## Issues Addressed:
- Closes nothing tracked.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources.
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

The behaviour being matched is described by the client data itself: `CorruptionEffects.db2` carries
`MinCorruption`, an `Aura` and a `PlayerConditionID` per row, which is what the sync is made to
honour. Retail's own behaviour — penalties appearing and disappearing as corruption crosses a
threshold, and being suppressed in certain areas — is public knowledge from 8.3.

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author.
- [x] This pull request requires further testing and may have edge cases to be tested.

Built clean on Windows / VS 2022 x64 RelWithDebInfo, and verified in-game: penalties apply and remove
as corruption crosses each threshold, survive a gear swap, and return on resurrect.

**Not covered by that test:** the area-condition path. The re-evaluation on `UpdateArea` was reasoned
from the `PlayerConditionID` column and has not been exercised against an area where a corruption
condition actually changes state.

## How to Test the Changes:
- [x] This pull request requires further testing. Steps below.

1. `.debug corruption` on yourself with no corrupted gear — every row should report below-threshold.
2. Equip corrupted gear until you cross a threshold and re-run it. The row should flip to applied,
   and the penalty aura should be on you.
3. Swap another piece of gear without changing the total. On `main` the penalty's duration restarts;
   on this branch it does not.
4. Die and `.revive` in place. On `main` the penalties stay gone until you cross an area border; on
   this branch they return on the next tick.
5. Regression: this touches `Player::Update` and two item-level rebuild paths. Confirm max health and
   derived stats are correct after an item-level scaling change (a scaled instance, a timewalking
   zone).

## Known Issues and TODO List:
- [ ] The area-condition re-evaluation is untested in-game (see above).
- [ ] The sync runs once per `Player::Update` tick when dirty. That is one extra
      `CorruptionEffects` walk per affected player per tick; it has not been profiled under load.

---

This is one of six PRs splitting a previously oversized branch apart. It is **independent** of the
other five and can merge on its own; the corruption feature PR stacks on top of it.