### PR TITLE
Fix Issue #72 Part 2, Pet battle inconsistencies.

### DIFF
--- a/src/server/game/Achievements/AchievementMgr.cpp
+++ b/src/server/game/Achievements/AchievementMgr.cpp
@@ -606,7 +606,10 @@ bool PlayerAchievementMgr::ModifierTreeSatisfied(uint32 modifierTreeId) const
 
 void PlayerAchievementMgr::SendCriteriaUpdate(Criteria const* criteria, CriteriaProgress const* progress, uint32 timeElapsed, bool timedCompleted) const
 {
-    WorldPackets::Achievement::CriteriaUpdate criteriaUpdate;
+    OpcodeServer opcode = criteria->Entry->Type == CRITERIA_TYPE_COLLECT_BATTLEPET && (criteria->FlagsCu & CRITERIA_FLAG_CU_ACCOUNT)
+        ? SMSG_ACCOUNT_CRITERIA_UPDATE
+        : SMSG_CRITERIA_UPDATE;
+    WorldPackets::Achievement::CriteriaUpdate criteriaUpdate(opcode);
 
     criteriaUpdate.CriteriaID = criteria->ID;
     criteriaUpdate.Quantity = progress->Counter;

--- a/src/server/game/Achievements/CriteriaHandler.cpp
+++ b/src/server/game/Achievements/CriteriaHandler.cpp
@@ -519,11 +519,15 @@ void CriteriaHandler::UpdateCriteria(CriteriaTypes type, uint64 miscValue1 /*= 0
                 SetCriteriaProgress(criteria, 1, referencePlayer, PROGRESS_ACCUMULATE);
                 break;
             case CRITERIA_TYPE_COLLECT_BATTLEPET:
-                if (miscValue1)
-                    SetCriteriaProgress(criteria, miscValue1, referencePlayer, PROGRESS_ACCUMULATE);
-                else
-                    SetCriteriaProgress(criteria, referencePlayer->GetBattlePets()->size(), referencePlayer, PROGRESS_SET);
+            {
+                std::set<uint32> collectedSpecies;
+                for (auto const& battlePet : *referencePlayer->GetBattlePets())
+                    if (battlePet.second)
+                        collectedSpecies.insert(battlePet.second->Species);
+
+                SetCriteriaProgress(criteria, collectedSpecies.size(), referencePlayer, PROGRESS_SET);
                 break;
+            }
             // std case: increment at miscValue1
             case CRITERIA_TYPE_MONEY_FROM_VENDORS:
             case CRITERIA_TYPE_GOLD_SPENT_FOR_TALENTS:

--- a/src/server/game/BattlePets/BattlePet.cpp
+++ b/src/server/game/BattlePets/BattlePet.cpp
@@ -183,8 +183,6 @@ void BattlePet::AddToPlayer(Player* player, CharacterDatabaseTransaction& trans)
     statement->setUInt64(21, JournalID.GetCounter());
     trans->Append(statement);
 
-    player->UpdateCriteria(CRITERIA_TYPE_COLLECT_BATTLEPET, 1);
-
     needSave = false;
 }
 
@@ -228,7 +226,6 @@ ObjectGuid::LowType BattlePet::AddToPlayer(Player* player)
     statement->setUInt64(21, JournalID.GetCounter());
     CharacterDatabase.Execute(statement);
 
-    player->UpdateCriteria(CRITERIA_TYPE_COLLECT_BATTLEPET, 1);
     needSave = false;
     return guidlow;
 }

--- a/src/server/game/BattlePets/PetBattle.cpp
+++ b/src/server/game/BattlePets/PetBattle.cpp
@@ -25,6 +25,11 @@
 #include "ScriptMgr.h"
 #include "WildBattlePet.h"
 
+namespace
+{
+    constexpr uint8 PET_BATTLE_TRAP_STATUS_TOO_MANY_PETS = 5;
+}
+
 PetBattleEventUpdate::PetBattleEventUpdate()
 {
     UpdateType = 0;
@@ -459,7 +464,7 @@ uint8 PetBattleTeam::CanCatchOpponentTeamFrontPet()
     /// Max 3 same pet for player
     if (CapturedSpeciesCount.find(targetPet->Species) != CapturedSpeciesCount.end())
         if (CapturedSpeciesCount[targetPet->Species] > 2)
-            return 0;
+            return PET_BATTLE_TRAP_STATUS_TOO_MANY_PETS;
 
     /// todo more check
 
@@ -939,6 +944,7 @@ void PetBattle::Finish(uint32 winnerTeamID, bool aborted, bool ignoreAbandonPena
                 Pets[Teams[currentTeamID]->CapturedPet]->Slot = PET_BATTLE_NULL_SLOT;
                 Pets[Teams[currentTeamID]->CapturedPet]->AddToPlayer(player);
                 player->_battlePets.emplace(Pets[Teams[currentTeamID]->CapturedPet]->JournalID, Pets[Teams[currentTeamID]->CapturedPet]);
+                player->UpdateCriteria(CRITERIA_TYPE_COLLECT_BATTLEPET);
                 player->GetSession()->SendBattlePetUpdates(Pets[Teams[currentTeamID]->CapturedPet].get(), true);
 
                 if (auto speciesInfo = sBattlePetSpeciesStore.LookupEntry(Pets[Teams[currentTeamID]->CapturedPet]->Species))

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -20,6 +20,7 @@
 #include "AreaTriggerTemplate.h"
 #include "AreaTriggerPackets.h"
 #include "BattlefieldMgr.h"
+#include "BattlePet.h"
 #include "CellImpl.h"
 #include "CinematicMgr.h"
 #include "CreatureGroups.h"
@@ -1852,6 +1853,20 @@ TempSummon* Map::SummonCreature(uint32 entry, Position const& pos, SummonPropert
     summon->SetHomePosition(pos);
 
     summon->InitStats(duration);
+
+    if (properties && SummonTitle(properties->Title) == SummonTitle::Companion)
+        if (Player* player = summoner ? summoner->ToPlayer() : nullptr)
+            if (std::shared_ptr<BattlePet> battlePet = player->GetBattlePet(player->GetSummonedBattlePetGUID()))
+                if (BattlePetSpeciesEntry const* species = sBattlePetSpeciesStore.LookupEntry(battlePet->Species))
+                    if (spellId == 118301 || spellId == species->SummonSpellID)
+                    {
+                        summon->m_battlePetInstance.reset();
+                        summon->RemoveNpcFlag(UNIT_NPC_FLAG_WILD_BATTLE_PET);
+                        summon->SetBattlePetCompanionGUID(battlePet->JournalID);
+                        summon->SetWildBattlePetLevel(battlePet->Level);
+                        summon->SetFaction(player->getFaction());
+                        summon->SetFullHealth();
+                    }
 
     summon->SetVisibleBySummonerOnly(visibleBySummonerOnly);
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -3491,6 +3491,12 @@ void Player::LearnSpell(uint32 spell_id, bool dependent, int32 fromSkill /*= 0*/
         packet.SpellID.push_back(spell_id);
         packet.SuppressMessaging = suppressMessaging;
         GetSession()->SendPacket(packet.Write());
+
+        if (spell_id == 119467) // Battle Pet Training
+        {
+            GetSession()->SendBattlePetJournal();
+            GetSession()->SendPetBattleSlotUpdates(true);
+        }
     }
 
     // learn all disabled higher ranks and required spells (recursive)
@@ -31231,6 +31237,7 @@ bool Player::AddBattlePetWithSpeciesId(BattlePetSpeciesEntry const* entry, uint1
     pet->Health = pet->InfoMaxHealth;
     auto guidlow = pet->AddToPlayer(this);
     _battlePets.emplace(pet->JournalID, pet);
+    UpdateCriteria(CRITERIA_TYPE_COLLECT_BATTLEPET);
 
     if (sendUpdate)
     {

--- a/src/server/game/Handlers/BattlePetHandler.cpp
+++ b/src/server/game/Handlers/BattlePetHandler.cpp
@@ -157,6 +157,7 @@ void WorldSession::HandleCageBattlePet(WorldPackets::BattlePet::BattlePetGuidRea
     SendBattlePetDeleted(packet.BattlePetGUID);
     battlePet->Remove(nullptr);
     _player->_battlePets.erase(packet.BattlePetGUID);
+    _player->UpdateCriteria(CRITERIA_TYPE_COLLECT_BATTLEPET);
 }
 
 void WorldSession::HandleBattlePetSetSlot(WorldPackets::BattlePet::SetBattleSlot& packet)
@@ -230,6 +231,13 @@ void WorldSession::HandlePetBattleRequestWild(WorldPackets::BattlePet::RequestWi
 
     Creature* wildBattlePet = ObjectAccessor::GetCreature(*_player, battleRequest->OpponentGuid);
     if (!wildBattlePet)
+    {
+        SendPetBattleRequestFailed(BATTLE_PET_REQUEST_TARGET_NOT_CAPTURABLE);
+        sPetBattleSystem->RemoveRequest(battleRequest->RequesterGuid);
+        return;
+    }
+
+    if (wildBattlePet->IsSummon() || !wildBattlePet->GetBattlePetCompanionGUID().IsEmpty() || wildBattlePet->GetOwnerGUID().IsPlayer())
     {
         SendPetBattleRequestFailed(BATTLE_PET_REQUEST_TARGET_NOT_CAPTURABLE);
         sPetBattleSystem->RemoveRequest(battleRequest->RequesterGuid);
@@ -630,6 +638,7 @@ void WorldSession::HandleBattlePetDelete(WorldPackets::BattlePet::BattlePetGuidR
     SendBattlePetDeleted(packet.BattlePetGUID);
     battlePet->Remove(nullptr);
     _player->_battlePets.erase(packet.BattlePetGUID);
+    _player->UpdateCriteria(CRITERIA_TYPE_COLLECT_BATTLEPET);
 }
 
 void WorldSession::HandleBattlePetRequestJournal(WorldPackets::BattlePet::NullCmsg& /*packet*/)
@@ -888,7 +897,7 @@ void WorldSession::SendPetBattleInitialUpdate(PetBattle* petBattle)
         WorldPackets::BattlePet::PetBattlePlayerUpdate playerUpdate;
         playerUpdate.CharacterID = ownerGuid;
         playerUpdate.TrapAbilityID = petBattle->Teams[i]->GetCatchAbilityID();
-        playerUpdate.TrapStatus = i == PET_BATTLE_TEAM_1 ? 5 : 2;
+        playerUpdate.TrapStatus = petBattle->Teams[i]->GetTeamTrapStatus();
         playerUpdate.RoundTimeSecs = isPVP ? pvpMaxRoundTime : 0;
         playerUpdate.InputFlags = PETBATTLE_TEAM_INPUT_FLAG_LOCK_PET_SWAP | PETBATTLE_TEAM_INPUT_FLAG_LOCK_ABILITIES_2;
 

--- a/src/server/game/Handlers/NPCHandler.cpp
+++ b/src/server/game/Handlers/NPCHandler.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "WorldSession.h"
+#include "BattlePet.h"
 #include "Battleground.h"
 #include "BattlegroundMgr.h"
 #include "Common.h"
@@ -165,6 +166,9 @@ void WorldSession::SendTrainerListLegacy(ObjectGuid guid, uint32 index)
             continue;
 
         TrainerSpellState state = _player->GetTrainerSpellState(tSpell);
+        if (BattlePetSpeciesEntry const* species = sDB2Manager.GetSpeciesBySpell(tSpell->SpellID))
+            if (_player->GetBattlePetCountForSpecies(species->ID) >= MAX_BATTLE_PET_PER_SPECIES)
+                state = TRAINER_SPELL_RED;
 
         WorldPackets::NPC::TrainerListSpell spell;
         spell.SpellID = tSpell->SpellID;
@@ -284,6 +288,10 @@ void WorldSession::HandleTrainerBuySpellOpcodeLegacy(WorldPackets::NPC::TrainerB
         //SendTrainerBuyFailed(packet.TrainerGUID, packet.SpellID, 0);
         return;
     }
+
+    if (BattlePetSpeciesEntry const* species = sDB2Manager.GetSpeciesBySpell(trainerSpell->SpellID))
+        if (_player->GetBattlePetCountForSpecies(species->ID) >= MAX_BATTLE_PET_PER_SPECIES)
+            return;
 
     // can't be learn, cheat? Or double learn with lags...
     if (_player->GetTrainerSpellState(trainerSpell) != TRAINER_SPELL_GREEN)

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -4681,6 +4681,9 @@ bool Map::IsLFR() const
 
 void Map::AddBattlePet(Creature* creature)
 {
+    if (creature->IsSummon())
+        return;
+
     if (sWildBattlePetMgr->IsBattlePet(creature->GetEntry()))
         m_wildBattlePetPool[creature->GetZoneId()][creature->GetEntry()].ToBeReplaced.insert(creature);
     else if (creature->IsWildBattlePet())

--- a/src/server/game/Server/Packets/AchievementPackets.h
+++ b/src/server/game/Server/Packets/AchievementPackets.h
@@ -77,7 +77,8 @@ namespace WorldPackets
         class CriteriaUpdate final : public ServerPacket
         {
         public:
-            CriteriaUpdate() : ServerPacket(SMSG_CRITERIA_UPDATE, 4 + 8 + 16 + 4 + 4 + 4 + 4) { }
+            explicit CriteriaUpdate(OpcodeServer opcode = SMSG_CRITERIA_UPDATE)
+                : ServerPacket(opcode, 4 + 8 + 16 + 4 + 4 + 4 + 4) { }
 
             WorldPacket const* Write() override;
 

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -2054,6 +2054,14 @@ void Spell::EffectSummonType(SpellEffIndex effIndex)
         return;
 
     uint32 entry = effectInfo->MiscValue;
+    std::shared_ptr<BattlePet> summonedBattlePet;
+    if (m_spellInfo->Id == 118301)
+        if (Player* player = m_originalCaster ? m_originalCaster->ToPlayer() : nullptr)
+            if ((summonedBattlePet = player->GetBattlePet(player->GetSummonedBattlePetGUID())))
+                if (BattlePetSpeciesEntry const* species = sBattlePetSpeciesStore.LookupEntry(summonedBattlePet->Species))
+                    if (species->CreatureID)
+                        entry = species->CreatureID;
+
     if (!entry)
         return;
 
@@ -2143,13 +2151,31 @@ void Spell::EffectSummonType(SpellEffIndex effIndex)
                 }
             case SummonTitle::Companion:
                 {
-                    summon = m_caster->GetMap()->SummonCreature(entry, *destTarget, properties, duration, m_originalCaster, m_spellInfo->Id, 0, personalSpawn, this);
+                    Position summonPosition = *destTarget;
+                    std::list<Creature*> nearbyCreatures;
+                    m_originalCaster->GetCreatureListInGrid(nearbyCreatures, 3.0f);
+                    bool spawnPositionOccupied = std::any_of(nearbyCreatures.begin(), nearbyCreatures.end(), [&summonPosition](Creature const* creature)
+                    {
+                        return !creature->GetBattlePetCompanionGUID().IsEmpty() && creature->GetExactDist2d(summonPosition) < 0.75f;
+                    });
+
+                    if (spawnPositionOccupied)
+                    {
+                        float distance = std::max(m_originalCaster->GetExactDist2d(summonPosition), 1.5f);
+                        summonPosition = m_originalCaster->GetNearPosition(distance, float(M_PI * 0.75));
+                    }
+
+                    m_originalCaster->UpdateGroundPositionZ(summonPosition.m_positionX, summonPosition.m_positionY, summonPosition.m_positionZ);
+                    summon = m_caster->GetMap()->SummonCreature(entry, summonPosition, properties, duration, m_originalCaster, m_spellInfo->Id, 0, personalSpawn, this);
                     if (!summon || !summon->HasUnitTypeMask(UNIT_MASK_MINION))
                         return;
 
-                    summon->SelectLevel();       // some summoned creaters have different from 1 DB data for level/hp
+                    if (!summonedBattlePet)
+                        summon->SelectLevel();       // some summoned creaters have different from 1 DB data for level/hp
                     summon->SetNpcFlags(NPCFlags(summon->GetCreatureTemplate()->npcflag & 0xFFFFFFFF));
                     summon->SetNpcFlags2(NPCFlags2(summon->GetCreatureTemplate()->npcflag >> 32));
+                    if (summonedBattlePet)
+                        summon->RemoveNpcFlag(UNIT_NPC_FLAG_WILD_BATTLE_PET);
 
                     summon->AddUnitFlag(UnitFlags(UNIT_FLAG_IMMUNE_TO_PC | UNIT_FLAG_IMMUNE_TO_NPC));
 
@@ -6177,6 +6203,7 @@ void Spell::EffectUncageBattlePet(SpellEffIndex /*effIndex*/)
 
     plr->_battlePets.emplace(BattlePetPtr->JournalID, BattlePetPtr);
     plr->GetSession()->SendBattlePetUpdates();
+    plr->UpdateCriteria(CRITERIA_TYPE_COLLECT_BATTLEPET);
 
     plr->DestroyItem(m_CastItem->GetBagSlot(), m_CastItem->GetSlot(), true);
     m_CastItem = nullptr;


### PR DESCRIPTION
> [!NOTE]
>PR #83 has been merged. This follow-up has been rebased onto the updated main branch and now contains only the Part >2 changes.

## Changes Proposed:

This PR completes the server-side battle pet fixes discovered while testing [#72](https://github.com/Hextv/BFA-HavenCore/issues/72).

The first PR focuses on Pet Journal lifecycle and persistence. This follow-up fixes the remaining collection, capture, trainer and summoned companion problems:

- Collector achievements did not count unique species or refresh consistently.
- Wild pet capture did not return the correct status when already owning three copies.
- Trainer-learned pets could bypass the three-pet limit.
- Learning Battle Pet Training did not unlock the first battle-pet slot immediately.
- Captured pets could summon with the wrong creature, model, family, level or state.
- Summoned companions could be registered and tracked as wild battle pets.
- Summoned companions could be selected as pet-battle targets.
- Companion spawn positions could overlap or appear above the ground.

The changes use the existing battle pet, achievement, trainer and summon systems while keeping the implementation limited to the affected paths.

This PR proposes changes to:

- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools were used partially in preparing this pull request. ChatGPT and OpenAI Codex (GPT-5) were used during troubleshooting and to help prepare the final minimal code changes. The implementation was reviewed, compiled and tested by the author.

## Issues Addressed:

- Relates to [**Battle pets cannot be caged or dismissed #72**](https://github.com/Hextv/BFA-HavenCore/issues/72)
- Depends on [**Fix Issue #72, Battle pets cannot be caged or dismissed #83**](https://github.com/Hextv/BFA-HavenCore/pull/83)

This is the second of two planned pull requests for the issue.

## SOURCE:

The changes have been validated through:

- [x] Live research (checked on live servers, e.g. Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g. forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Retail behavior and BFA-era sources were used to compare collection progress, capture restrictions and summoned companion behavior.

## Tests Performed:

This PR has been:

- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Tested on Windows with new and existing characters. A clean Release build of `worldserver` completed successfully.

The final PR2 commit contains 11 changed files with 93 additions and 13 deletions. `git diff --check` completed successfully.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue.
- [x] This pull request requires further testing. Test achievements, capture limits, trainers and summoned companions as described below.

1. Disable GM mode before testing achievement progress:

   `.gm off`

2. Learn several different battle pets and verify that `Plenty of Pets` counts unique species rather than total journal entries.

3. Add and remove pets through Learn, Capture, Cage, Uncage and Release. Verify that collector progress updates immediately in both directions.

4. Enter a wild pet battle against a species where the account already owns three copies.

   Verify that:

   - The trap is unavailable.
   - The trap tooltip reports that three copies are already owned.
   - No fourth pet is added to the journal.

5. Visit a battle pet trainer and obtain three copies of one of the trainer's pet species.

   Verify that:

   - The trainer entry becomes unavailable when the list is opened.
   - A fourth copy cannot be learned.
   - Removing one copy makes the pet available again when the trainer list is reopened.

6. Learn Battle Pet Training on a character that does not have it.

   Verify that the first battle-pet slot unlocks immediately without requiring a relog.

7. Summon normal pets and pets captured from wild battles.

   Verify that:

   - The correct species and model are summoned.
   - The correct pet family and journal level are displayed.
   - The companion is alive and friendly.
   - The companion nameplate uses the normal friendly companion color.
   - The companion is not tracked by `Track Pets`.
   - The companion cannot be used as a wild pet-battle target.
   - Summoning different journal entries selects the correct individual pet.

8. Summon a companion where another battle pet already occupies the normal summon position.

   Verify that the new pet uses the alternate position at the same distance from the player and is placed correctly on the ground.

## Known Issues and TODO List:

The following client-facing issues remain and require separate investigation:

- A successful wild pet capture can display a second trap throw even though only one pet is captured.
- The client caches an already-open battle pet trainer list. Changes to money, training or journal ownership can leave the displayed entries stale until the trainer window is closed and reopened. Server-side purchase validation remains correct.
- Custom battle pet names persist correctly in the Pet Journal, but summoned pets continue to display the species name on their world nameplate and target frame.
- The Pet Battle interface is positioned differently from the reference client.

These issues are excluded because no clean and verified server-side correction was established.