### PR TITLE
build(cmake): unbreak Linux configure and add a working Linux build workflow

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -1,0 +1,73 @@
+name: Build HavenCore (Linux)
+
+on:
+  push:
+    branches: [ "main", "corruption-system", "feature/**", "pr/**" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+# Supersede in-flight runs of the same ref: a full core build is expensive and
+# only the tip of a branch is worth the runner time.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [RelWithDebInfo]
+
+    env:
+      # Precompiled headers are on by default (USE_COREPCH/USE_SCRIPTPCH) and
+      # ccache misses on PCH timestamps without this. Same set as docker/Dockerfile.
+      CCACHE_SLOPPINESS: pch_defines,time_macros,include_file_mtime,include_file_ctime
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
+    - name: Install Dependencies
+      # Only the six Boost components dep/boost/CMakeLists.txt asks for --
+      # libboost-all-dev is roughly a gigabyte of packages we never link.
+      # libreadline-dev and zlib1g-dev are hard requirements: dep/readline and
+      # dep/zlib both abort configure without them.
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          build-essential cmake ninja-build pkg-config ccache \
+          libssl-dev libmysqlclient-dev libreadline-dev zlib1g-dev \
+          libboost-system-dev libboost-filesystem-dev libboost-thread-dev \
+          libboost-program-options-dev libboost-iostreams-dev libboost-regex-dev
+
+    - name: Restore ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: linux-${{ matrix.build_type }}
+        # One clean RelWithDebInfo build writes ~2G of objects, so anything
+        # smaller evicts itself before the next run can hit.
+        max-size: 5G
+        verbose: 1
+
+    - name: Configure CMake
+      # Flags mirror docker/Dockerfile, which is the known-good Linux recipe.
+      # TOOLS=0 because the extractors need client data no runner has, and
+      # enabling them drags in bzip2/CascLib for no benefit here.
+      run: >
+        cmake -S . -B build -G Ninja
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -DTOOLS=0
+        -DSCRIPTS=static
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+    - name: Build HavenCore
+      run: cmake --build build --parallel
+
+    - name: ccache statistics
+      if: always()
+      run: ccache --show-stats

--- a/dep/boost/CMakeLists.txt
+++ b/dep/boost/CMakeLists.txt
@@ -30,7 +30,11 @@ include (CheckCXXSourceCompiles)
 
 set(BOOST_REQUIRED_VERSION 1.72)
 
-cmake_policy(SET CMP0167 OLD)
+# CMP0167 only exists from CMake 3.30 on; setting it unguarded is a hard error
+# on older CMake, which breaks every distro still shipping 3.28 (Ubuntu 24.04).
+if(POLICY CMP0167)
+  cmake_policy(SET CMP0167 OLD)
+endif()
 
 find_package(Boost ${BOOST_REQUIRED_VERSION} REQUIRED system filesystem thread program_options iostreams regex)
 


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).
-  [x] **Build system / CI** (none of the above categories apply — no gameplay behaviour changes).

Two related build fixes. The second one is the reason the first is visible.

**1. `dep/boost/CMakeLists.txt` — guard `CMP0167`**

`cmake_policy(SET CMP0167 OLD)` is currently called unconditionally. That policy was introduced in **CMake 3.30**, and setting an unknown policy is a hard error on anything older:

```
CMake Error at dep/boost/CMakeLists.txt:33 (cmake_policy):
  Policy "CMP0167" is not known to this version of CMake.
-- Configuring incomplete, errors occurred!
```

Ubuntu 24.04 ships CMake **3.28.3**, so configure fails outright there. `docker/Dockerfile` installs the same apt `cmake` on `ubuntu:24.04`, so the documented Docker build is affected by the same mechanism — I have not run `docker compose build` to confirm, but the version is identical.

Wrapping the call in `if(POLICY CMP0167)` preserves the original behaviour on CMake 3.30+, where the policy exists and `OLD` is what selects the legacy `FindBoost` module. Below 3.30 it becomes a no-op, and Boost 1.83 resolves through `BoostConfig.cmake` regardless — the configure log shows all six components found by config mode.

**2. `.github/workflows/linux-build.yml` — a Linux build workflow that actually completes**

Beyond the policy error, the workflow could not have configured anyway:

| Problem | Cause |
|---|---|
| Missing `libreadline-dev` | `dep/readline/CMakeLists.txt` raises an explicit `FATAL_ERROR` without it |
| `TOOLS` defaults to ON | Pulls in `dep/bzip2` + `dep/CascLib`; `libbz2-dev` was not installed, and the extractors need client data no runner has |
| `zlib1g-dev` implicit | `dep/zlib` is `find_package(ZLIB REQUIRED)`; it resolved only by accident off the hosted runner image |

Other changes:

- Flags now mirror `docker/Dockerfile`, the known-good Linux recipe: `TOOLS=0`, `SCRIPTS=static`, `RelWithDebInfo` instead of a separate `Release` configuration, so CI validates what ships.
- Six Boost components instead of `libboost-all-dev` (~1GB of packages the core never links).
- ccache added, with the same `CCACHE_SLOPPINESS` set `docker/Dockerfile` uses, since both PCH options are on by default.
- The `ctest` step is removed. There is no test framework in this repository, so it only ever reported that no tests were found, hidden behind `continue-on-error`. Its `--build-config` flag was also inert under single-config Ninja.
- `submodules: recursive` removed — dependencies are vendored under `dep/` and there is no `.gitmodules`.
- Triggers extended beyond `main` and `concurrency` added so superseded runs are cancelled.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request.

**Claude Code, model Claude Opus 5.** Used for diagnosis, the workflow rewrite, and running the verification below. Both changes are small and I can justify each line; the `CMP0167` fix is the standard guarded idiom from the CMake docs.

## Issues Addressed:

- Closes

None — found while trying to get the Linux workflow to run.

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

**None of these apply.** There is no gameplay behaviour here, so there is nothing to source against retail. The authority for the `CMP0167` change is the CMake policy documentation (introduced in 3.30) and the configure error above.

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

**What I actually ran:** the full workflow locally under [`nektos/act`](https://github.com/nektos/act) on `catthehacker/ubuntu:act-latest`, end to end:

```
✅  Success - Main Install Dependencies   [11.77s]
✅  Success - Main Configure CMake        [2.06s]
✅  Success - Main Build HavenCore        [8m58.55s]
🏁  Job succeeded
```

1976 objects compiled on **GCC 13.3 / Ubuntu 24.04 / CMake 3.28.3**, no errors. This is the first evidence I am aware of that the experimental Linux port builds clean end to end.

**What I did not run, stated plainly:**

- **No in-game testing.** Neither change can affect runtime behaviour — one is a CMake policy guard, the other is a CI file — so there is nothing in-game to exercise.
- **No Windows/MSVC rebuild.** On CMake 3.30+ the guarded path is byte-for-byte the previous behaviour, so this should be a no-op there, but I have not reconfirmed it. Worth a maintainer with a VS2022 tree doing a configure pass.
- **No `docker compose build` run**, so the claim that Docker is affected by the same mechanism is inference from the CMake version, not an observation.
- **Not yet run on GitHub's hosted runners** — only under `act`. Hosted runners can carry a newer CMake than apt's on `PATH`; the guard makes the workflow correct in either direction, but the first real run is the proof.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes.

1. On a machine with CMake < 3.30 (e.g. Ubuntu 24.04, which has 3.28.3), check out `main` and run `cmake -S . -B build -G Ninja -DTOOLS=0` — configure fails with `Policy "CMP0167" is not known to this version of CMake`.
2. Check out this branch and run the same command — configure completes.
3. `cmake --build build --parallel` builds the core to completion.
4. Optionally run the whole workflow locally: `act -j build -P ubuntu-latest=catthehacker/ubuntu:act-latest`.
5. On Windows/VS2022 (CMake 3.30+), confirm configure is unchanged from before.

## Known Issues and TODO List:

- [ ] `max-size: 5G` for the ccache is a starting estimate. One clean `RelWithDebInfo` build writes ~2G of objects, so the original 2G filled to 99.97% and would evict itself before the next run could hit. 5G leaves headroom, but GitHub caps total cache at 10GB per repository and evicts LRU across it, so maintainers may want to tune this once several branches are running CI.
- [ ] 359 compiler warnings on GCC 13, none fatal and all pre-existing. Mostly `-Wdeprecated-declarations` (302), but also 24 `-Wenum-compare` and 3 `-Wreturn-type`. The latter two are worth a separate look — for example `src/server/scripts/Zandalar/Uldir/boss_zulreborn.cpp:491` compares `EncounterData` against `EncounterState`. Out of scope here; happy to open an issue.
- [ ] Consider whether the Windows build deserves a matching workflow.
