### PR TITLE
DB/Fixes: Few Critter Fixes

### DIFF
--- a/sql/updates/world/2026_08_10_01_critter_fixes.sql
+++ b/sql/updates/world/2026_08_10_01_critter_fixes.sql
@@ -1,0 +1,49 @@
+-- Cow 2442 - Few changes to this creature, listed below.
+-- Changes the "Unit_Flags" to 512 (IMMUNE_TO_NPC - disables combat/assistance with NonPlayerCharacters (NPC)) - Players can now deal damage to it again.
+-- Changes the "Flags_Extra" to 2 (CIVILIAN - not aggro (ignore faction/reputation hostility))
+-- Changes the "Type" to 8 (This is because otherwise you would earn XP from killing it.)
+UPDATE `creature_template`
+SET `unit_flags` = 512, `flags_extra` = 66
+WHERE `entry` = 2442;
+-- ----------------------------------------
+
+
+-- Sheep 1933 - Change HealthModifier, level scaling, unit_flags (512)
+-- ----------------------------------------
+UPDATE `creature_template`
+SET `unit_flags` = 512
+WHERE `entry` = 1933;
+
+UPDATE `creature_template_scaling`
+SET `LevelScalingMin` = 3, `LevelScalingMax` = 3 
+WHERE `entry` = 1933;
+-- ----------------------------------------
+
+
+-- Rabbit 721 - Change HealthModifier and level scaling.
+-- ----------------------------------------
+UPDATE `creature_template`
+SET `unit_flags` = 512
+WHERE `entry` = 721;
+
+-- Reason we dont check for difficulty is because both should be min 1 and max 1 (Based on WoWhead.)
+UPDATE `creature_template_scaling`
+SET `LevelScalingMin` = 1, `LevelScalingMax` = 1 
+WHERE `entry` = 721;
+-- ----------------------------------------
+
+
+-- Small Frog 70495 - Change to critter type.
+-- Faction changed from Friendly to Prey (Like most other critters)
+-- ----------------------------------------
+UPDATE `creature_template`
+SET `unit_flags2` = 2048, `unit_flags` = 512, `faction` = 31
+WHERE `entry` = 70495;
+-- ----------------------------------------
+
+-- Small Frog 13321 - Change unit_flags to 512
+-- ----------------------------------------
+UPDATE `creature_template`
+SET `unit_flags` = 512, `type` = 8
+WHERE `entry` = 13321;
+-- ----------------------------------------


### PR DESCRIPTION
- Cow (2442) can now be killed, and wont give XP
- Sheep (1933) fixed level scaling.
- Rabbit (721) fixed level scaling.
- Small Frog (70495) fixed "faction", so you can damage it
- Small Frog (13321)

<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [ ] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test BFA-HavenCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub.

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
