### PR TITLE
Core/LFG: Fix dungeon level restrictions when entrance triggers are m…

### DIFF
--- a/src/server/game/DungeonFinding/LFGMgr.cpp
+++ b/src/server/game/DungeonFinding/LFGMgr.cpp
@@ -252,21 +252,19 @@ void LFGMgr::LoadLFGDungeons(bool reload /* = false */)
     {
         LFGDungeonData& dungeon = itr->second;
 
-        // No teleport coords in database, load from areatriggers
+        // No teleport coords in database, try to load them from areatriggers.
+        // A missing entrance must not exclude the dungeon from the LFG cache;
+        // otherwise its lock status (level, expansion, etc.) is never sent to the client.
         if (dungeon.type != LFG_TYPE_RANDOM && dungeon.x == 0.0f && dungeon.y == 0.0f && dungeon.z == 0.0f)
         {
-            AreaTriggerTeleportStruct const* at = sObjectMgr->GetMapEntranceTrigger(dungeon.map);
-            if (!at)
+            if (AreaTriggerTeleportStruct const* at = sObjectMgr->GetMapEntranceTrigger(dungeon.map))
             {
-                //TC_LOG_ERROR("sql.sql", "Failed to load dungeon %s (Id: %u), cant find areatrigger for map %u", dungeon.name.c_str(), dungeon.id, dungeon.map);
-                continue;
+                dungeon.map = at->target_mapId;
+                dungeon.x = at->target_X;
+                dungeon.y = at->target_Y;
+                dungeon.z = at->target_Z;
+                dungeon.o = at->target_Orientation;
             }
-
-            dungeon.map = at->target_mapId;
-            dungeon.x = at->target_X;
-            dungeon.y = at->target_Y;
-            dungeon.z = at->target_Z;
-            dungeon.o = at->target_Orientation;
         }
 
         if (dungeon.type != LFG_TYPE_RANDOM)


### PR DESCRIPTION
## Changes Proposed

This PR fixes an issue in the Dungeon Finder where certain dungeons were incorrectly presented as available to players who did not meet their level requirements.

The issue was traced to `LFGMgr::LoadLFGDungeons()`, where dungeons without valid teleport coordinates or a corresponding map entrance trigger were excluded from the LFG dungeon cache entirely.

Because these dungeons were absent from the cache, the existing eligibility checks in `LFGMgr::GetLockedDungeons()` never evaluated them and therefore never reported the appropriate lock status to the client.

This PR changes that behavior so that missing teleport information does not prevent a dungeon from participating in normal LFG eligibility processing.

- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

---

- Closes #8 

## Issue

Dungeon Finder correctly becomes available to players at level 15.

However, testing with a level 15 character showed that the Dungeon Finder was presenting high-level Battle for Azeroth dungeons alongside the appropriate low-level dungeons.

For example, a level 15 character was presented with:

- Deadmines — Level 15-60
- Ragefire Chasm — Level 15-60
- Siege of Boralus — Level 120
- Kings' Rest — Level 121

Deadmines and Ragefire Chasm are appropriate for the character.

Siege of Boralus and Kings' Rest should not be available to a level 15 character.

The issue was therefore not the level at which Dungeon Finder becomes available. The problem was that the server was failing to report some level-inappropriate dungeons as locked.

---

## Investigation

The first possibility investigated was incorrect dungeon level data.

This was ruled out.

Debugging confirmed that HavenCore was loading the correct level requirements for the affected dungeons.

### Siege of Boralus

```text
LFG Dungeon ID: 1700
Map: 1822
Minimum Level: 120
Maximum Level: 120
```

### Kings' Rest

```text
LFG Dungeon ID: 1784
Map: 1762
Minimum Level: 121
Maximum Level: 121
```

The existing level filtering in `LFGMgr::GetLockedDungeons()` was also inspected.

HavenCore already contains the correct checks:

```cpp
else if (dungeon->minlevel > level)
    lockStatus = LFG_LOCKSTATUS_TOO_LOW_LEVEL;
else if (dungeon->maxlevel < level)
    lockStatus = LFG_LOCKSTATUS_TOO_HIGH_LEVEL;
```

Therefore, the problem was not the level comparison itself.

Additional debugging was added to determine which dungeons were actually reaching `GetLockedDungeons()`.

This revealed that Siege of Boralus and Kings' Rest were never being evaluated by `GetLockedDungeons()` at all.

The problem was then traced back to `LFGMgr::LoadLFGDungeons()`.

---

## Root Cause

During `LoadLFGDungeons()`, HavenCore attempts to populate missing teleport coordinates for non-random dungeons using their map entrance AreaTrigger.

The previous logic was effectively:

```cpp
AreaTriggerTeleportStruct const* at = sObjectMgr->GetMapEntranceTrigger(dungeon.map);

if (!at)
{
    continue;
}
```

If a dungeon:

1. Did not have teleport coordinates supplied through `lfg_dungeon_template`, and
2. Did not have a corresponding map entrance trigger available,

the loader executed `continue`.

The problem is that the dungeon was added to the LFG cache **after** this block.

The relevant cache population occurs later:

```cpp
if (dungeon.type != LFG_TYPE_RANDOM)
    CachedDungeonMapStore[dungeon.randomId].insert(dungeon.id);

CachedDungeonMapStore[0].insert(dungeon.id);
```

As a result, executing `continue` did much more than skip teleport-coordinate initialization.

It prevented the dungeon from being inserted into the LFG cache entirely.

---

## Resulting Failure

This created the following sequence:

1. The client knows that the dungeon exists through its DB2 data.
2. The client knows the dungeon's level requirement.
3. HavenCore loads the dungeon's `LFGDungeons` record.
4. The dungeon has no configured teleport coordinates.
5. HavenCore attempts to obtain an entrance trigger for the map.
6. No entrance trigger is found.
7. `LoadLFGDungeons()` executes `continue`.
8. The dungeon is never inserted into `CachedDungeonMapStore`.
9. `GetLockedDungeons()` never evaluates the dungeon.
10. The existing minimum/maximum level checks are never executed for it.
11. No `LFG_LOCKSTATUS_TOO_LOW_LEVEL` result is generated.
12. The client incorrectly presents the dungeon as available.

This explains why the client could correctly display:

```text
Siege of Boralus (120)
Kings' Rest (121)
```

while still allowing them to appear as available to a level 15 character.

The level information itself was correct.

The server simply never evaluated those dungeons when constructing the player's lock information.

---

## Fix

The fix separates two independent concerns:

- Whether HavenCore knows how to teleport into a dungeon.
- Whether the dungeon should participate in LFG eligibility checks.

A missing entrance trigger should prevent automatic coordinate initialization, but it should **not remove the dungeon from the LFG cache**.

The updated logic attempts to obtain the entrance trigger:

```cpp
if (dungeon.type != LFG_TYPE_RANDOM &&
    dungeon.x == 0.0f &&
    dungeon.y == 0.0f &&
    dungeon.z == 0.0f)
{
    if (AreaTriggerTeleportStruct const* at = sObjectMgr->GetMapEntranceTrigger(dungeon.map))
    {
        dungeon.map = at->target_mapId;
        dungeon.x = at->target_X;
        dungeon.y = at->target_Y;
        dungeon.z = at->target_Z;
        dungeon.o = at->target_Orientation;
    }
}
```

If an entrance trigger exists, its destination information is applied as before.

If no entrance trigger exists, coordinate assignment is skipped, but processing of the dungeon continues.

The dungeon therefore still reaches:

```cpp
if (dungeon.type != LFG_TYPE_RANDOM)
    CachedDungeonMapStore[dungeon.randomId].insert(dungeon.id);

CachedDungeonMapStore[0].insert(dungeon.id);
```

This allows `GetLockedDungeons()` to evaluate the dungeon normally.

---

## Behavior After Fix

The processing path is now:

```text
Load LFG dungeon
        |
        v
Does it need teleport coordinates?
        |
        +---- No ----> Continue
        |
       Yes
        |
        v
Is an entrance trigger available?
        |
   +----+----+
   |         |
  Yes        No
   |         |
   v         v
Load       Leave coordinates
coords     unchanged
   |         |
   +----+----+
        |
        v
Add dungeon to LFG cache
        |
        v
GetLockedDungeons()
        |
        v
Evaluate expansion / level /
item level / other restrictions
        |
        v
Send correct lock status
to the client
```

Teleport availability and LFG eligibility are therefore no longer incorrectly coupled.

---

## Testing

Testing was performed using a level 15 character.

### Before Fix

The Dungeon Finder displayed:

```text
Deadmines             15-60    Available
Ragefire Chasm        15-60    Available
Siege of Boralus      120      Incorrectly available
Kings' Rest           121      Incorrectly available
```

Debugging confirmed that Siege of Boralus and Kings' Rest were being skipped during `LoadLFGDungeons()` because HavenCore could not find map entrance triggers for them.

They consequently never reached the existing level checks in `GetLockedDungeons()`.

### After Fix

Using the same level 15 character:

```text
Deadmines             Available
Ragefire Chasm        Available
Siege of Boralus      No longer incorrectly available
Kings' Rest           No longer incorrectly available
```

The existing minimum/maximum level filtering now correctly handles the affected dungeons.

The fix was successfully compiled and tested in-game.

---

## Scope of Fix

This is intentionally a generalized fix rather than a workaround for Siege of Boralus and Kings' Rest.

Debugging showed that many LFG entries can encounter the missing-entrance-trigger path.

The previous behavior potentially prevented any such dungeon from participating in the normal LFG lock-status calculation.

This PR therefore does **not**:

- Hard-code Siege of Boralus
- Hard-code Kings' Rest
- Change their minimum or maximum levels
- Modify the level 15 Dungeon Finder unlock
- Add special level checks for BFA dungeons
- Hide specific dungeons through SQL
- Change DB2 dungeon level information

Instead, it corrects the underlying LFG cache construction so the existing eligibility system can perform its intended checks.

---

## Teleport Data

This PR does **not** attempt to repair missing dungeon teleport coordinates or missing AreaTrigger data.

A dungeon without valid teleport information may still require a separate data fix before HavenCore can correctly teleport a group into that instance.

This PR specifically fixes the incorrect behavior where missing teleport information also prevented the dungeon from participating in LFG eligibility and lock-status processing.

Missing teleport data and player eligibility are separate issues and should be handled independently.

---

## Files Changed

```text
src/server/game/DungeonFinding/LFGMgr.cpp
```

No other core files are required for this fix.

---

## Database Changes

None.

---

## Client Changes

None.

---

## Summary

Previously:

```text
Missing entrance trigger
        ↓
Dungeon skipped
        ↓
Dungeon omitted from LFG cache
        ↓
GetLockedDungeons() never sees dungeon
        ↓
Level restriction never evaluated
        ↓
No TOO_LOW_LEVEL lock sent
        ↓
Dungeon incorrectly appears available
```

After this PR:

```text
Missing entrance trigger
        ↓
Teleport coordinates remain unavailable
        ↓
Dungeon still enters LFG cache
        ↓
GetLockedDungeons() evaluates dungeon
        ↓
Existing level restrictions are applied
        ↓
Correct lock status sent to client
```

This preserves the existing LFG eligibility implementation while ensuring that missing teleport data cannot bypass it.