### PR TITLE
Fix Classic Jewelcrafting progression, Prospecting and trainer requirements

### DIFF
--- a/src/server/game/Entities/Creature/Trainer.cpp
+++ b/src/server/game/Entities/Creature/Trainer.cpp
@@ -127,8 +127,6 @@ namespace Trainer
         if (!player->IsSpellFitByClassAndRace(trainerSpell->SpellId))
             return SpellState::Unavailable;
 
-        // BFA uses expansion-specific profession skill lines. Classic Jewelcrafting
-        // trainer data can still reference the generic Jewelcrafting parent skill.
         uint32 const reqSkillLine = trainerSpell->ReqSkillLine == SKILL_JEWELCRAFTING
             ? SKILL_JEWELCRAFTING_2
             : trainerSpell->ReqSkillLine;

--- a/src/server/game/Entities/Creature/Trainer.cpp
+++ b/src/server/game/Entities/Creature/Trainer.cpp
@@ -53,7 +53,7 @@ namespace Trainer
             WorldPackets::NPC::TrainerListSpell& trainerListSpell = trainerList.Spells.back();
             trainerListSpell.SpellID = trainerSpell.SpellId;
             trainerListSpell.MoneyCost = int32(trainerSpell.MoneyCost * reputationDiscount);
-            trainerListSpell.ReqSkillLine = trainerSpell.ReqSkillLine;
+            trainerListSpell.ReqSkillLine = trainerSpell.ReqSkillLine == SKILL_JEWELCRAFTING ? SKILL_JEWELCRAFTING_2 : trainerSpell.ReqSkillLine;
             trainerListSpell.ReqSkillRank = trainerSpell.ReqSkillRank;
             std::copy(trainerSpell.ReqAbility.begin(), trainerSpell.ReqAbility.end(), trainerListSpell.ReqAbility.begin());
             trainerListSpell.Usable = AsUnderlyingType(GetSpellState(player, &trainerSpell));
@@ -127,8 +127,14 @@ namespace Trainer
         if (!player->IsSpellFitByClassAndRace(trainerSpell->SpellId))
             return SpellState::Unavailable;
 
+        // BFA uses expansion-specific profession skill lines. Classic Jewelcrafting
+        // trainer data can still reference the generic Jewelcrafting parent skill.
+        uint32 const reqSkillLine = trainerSpell->ReqSkillLine == SKILL_JEWELCRAFTING
+            ? SKILL_JEWELCRAFTING_2
+            : trainerSpell->ReqSkillLine;
+
         // check skill requirement
-        if (trainerSpell->ReqSkillLine && player->GetBaseSkillValue(trainerSpell->ReqSkillLine) < trainerSpell->ReqSkillRank)
+        if (reqSkillLine && player->GetBaseSkillValue(reqSkillLine) < trainerSpell->ReqSkillRank)
             return SpellState::Unavailable;
 
         for (int32 reqAbility : trainerSpell->ReqAbility)

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -5683,6 +5683,7 @@ bool Player::UpdateGatherSkill(uint32 SkillId, uint32 SkillValue, uint32 RedLeve
         case SKILL_LEGION_HERBALISM:
         case SKILL_KUL_TIRAN_HERBALISM:
         case SKILL_JEWELCRAFTING:
+        case SKILL_JEWELCRAFTING_2:
         case SKILL_INSCRIPTION:
             return UpdateSkillPro(SkillId, SkillGainChance(SkillValue, RedLevel+100, RedLevel+50, RedLevel+25)*Multiplicator, gathering_skill_gain);
         case SKILL_SKINNING:
@@ -30316,8 +30317,14 @@ TrainerSpellState Player::GetTrainerSpellState(TrainerSpell const* trainer_spell
     if (hasSpell)
         return TRAINER_SPELL_GRAY;
 
+    // BFA uses expansion-specific profession skill lines. Classic Jewelcrafting
+    // trainer data can still reference the generic Jewelcrafting parent skill.
+    uint32 const reqSkillLine = trainer_spell->ReqSkillLine == SKILL_JEWELCRAFTING
+        ? SKILL_JEWELCRAFTING_2
+        : trainer_spell->ReqSkillLine;
+
     // check skill requirement
-    if (trainer_spell->ReqSkillLine && GetBaseSkillValue(trainer_spell->ReqSkillLine) < trainer_spell->ReqSkillRank)
+    if (reqSkillLine && GetBaseSkillValue(reqSkillLine) < trainer_spell->ReqSkillRank)
         return TRAINER_SPELL_RED;
 
     // check level requirement

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -6847,7 +6847,7 @@ SpellCastResult Spell::CheckItems(uint32* param1 /*= nullptr*/, uint32* param2 /
                     return SPELL_FAILED_CANT_BE_PROSPECTED;
                 //Check for enough skill in jewelcrafting
                 uint32 item_prospectingskilllevel = item->GetTemplate()->GetRequiredSkillRank();
-                if (item_prospectingskilllevel > player->GetSkillValue(SKILL_JEWELCRAFTING))
+                if (item_prospectingskilllevel > player->GetSkillValue(SKILL_JEWELCRAFTING_2))
                     return SPELL_FAILED_LOW_CASTLEVEL;
                 //make sure the player has the required ores in inventory
                 if (item->GetCount() < 5)

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -5136,9 +5136,10 @@ void Spell::EffectProspecting(SpellEffIndex /*effIndex*/)
 
     if (sWorld->getBoolConfig(CONFIG_SKILL_PROSPECTING))
     {
-        uint32 SkillValue = player->GetPureSkillValue(SKILL_JEWELCRAFTING);
-        uint32 reqSkillValue = itemTarget->GetTemplate()->GetRequiredSkillRank();
-        player->UpdateGatherSkill(SKILL_JEWELCRAFTING, SkillValue, reqSkillValue);
+        uint32 const jewelcraftingSkill = SKILL_JEWELCRAFTING_2;
+        uint32 const skillValue = player->GetPureSkillValue(jewelcraftingSkill);
+        uint32 const reqSkillValue = itemTarget->GetTemplate()->GetRequiredSkillRank();
+        player->UpdateGatherSkill(jewelcraftingSkill, skillValue, reqSkillValue);
     }
 
     player->SendLoot(itemTarget->GetGUID(), LOOT_PROSPECTING);


### PR DESCRIPTION
## Changes Proposed:

This PR fixes several issues affecting Classic Jewelcrafting profession progression, Prospecting, and trainer recipe requirements in BFA-HavenCore.

The underlying issue is that BFA uses expansion-specific profession skill lines, while several Jewelcrafting code paths were still using the generic parent Jewelcrafting skill.

## For Classic Jewelcrafting:

SKILL_JEWELCRAFTING   = 755   // Generic parent skill
SKILL_JEWELCRAFTING_2 = 2524  // Classic Jewelcrafting

This resulted in the parent skill and the player's actual Classic Jewelcrafting skill becoming disconnected during normal gameplay.

## This PR proposes changes to:

[x] Core (units, players, creatures, game systems).
[x]  Scripts (bosses, spell scripts, creature scripts).
Database (SAI, creatures, etc).

- Closes #128 


## Issues Addressed
1. Prospecting increases the wrong Jewelcrafting skill

When Prospecting ore, the existing code awarded profession progression to the generic Jewelcrafting parent skill:

uint32 SkillValue = player->GetPureSkillValue(SKILL_JEWELCRAFTING);
player->UpdateGatherSkill(SKILL_JEWELCRAFTING, SkillValue, reqSkillValue);

Testing confirmed the problem.

Before Prospecting:

SKILL_JEWELCRAFTING (755)    = 4
SKILL_JEWELCRAFTING_2 (2524) = 1

After multiple successful Prospecting attempts:

SKILL_JEWELCRAFTING (755)    = 15
SKILL_JEWELCRAFTING_2 (2524) = 1

The player's visible Classic Jewelcrafting profession did not increase even though Prospecting was awarding skill points.

## Fix

Prospecting now uses the expansion-specific Classic Jewelcrafting skill:

SKILL_JEWELCRAFTING_2

and obtains the player's actual Classic Jewelcrafting value before calling UpdateGatherSkill().

2. UpdateGatherSkill() did not support Classic Jewelcrafting

After changing Prospecting to correctly use SKILL_JEWELCRAFTING_2, another issue became apparent.

Player::UpdateGatherSkill() contained handling for:

SKILL_JEWELCRAFTING

but not:

SKILL_JEWELCRAFTING_2

As a result, passing the correct Classic Jewelcrafting skill into UpdateGatherSkill() did not award progression.

## Fix

SKILL_JEWELCRAFTING_2 is now included in the appropriate UpdateGatherSkill() profession skill-up path.

This allows Prospecting to use the same existing skill-up probability calculations while awarding progression to the correct BFA profession skill line.

3. Prospecting requirements checked the generic parent skill

The Prospecting cast validation in Spell.cpp checked:

player->GetSkillValue(SKILL_JEWELCRAFTING)

This meant Prospecting eligibility was determined using generic Jewelcrafting skill 755 instead of the player's Classic Jewelcrafting skill 2524.

A character could therefore have sufficient Classic Jewelcrafting skill but still fail a Prospecting requirement because the unused parent skill was too low.

## Fix

Prospecting requirements now check:

player->GetSkillValue(SKILL_JEWELCRAFTING_2)

This keeps Prospecting eligibility and Prospecting progression on the same profession skill line.

4. Jewelcrafting trainers checked the wrong skill for recipe requirements

Trainer testing exposed another instance of the same parent/child profession issue.

The test character had:

SKILL_JEWELCRAFTING (755)    = 1
SKILL_JEWELCRAFTING_2 (2524) = 7

A trainer recipe requiring Jewelcrafting skill 5 was displayed as unavailable and could not be learned.

Manually changing the generic parent skill to match the Classic skill:

SKILL_JEWELCRAFTING (755)    = 7
SKILL_JEWELCRAFTING_2 (2524) = 7

immediately allowed the recipe to be learned.

This confirmed that the trainer requirement was evaluating the generic parent skill rather than the player's actual Classic Jewelcrafting progression.

## Fix

When Jewelcrafting trainer data references:

SKILL_JEWELCRAFTING

the trainer requirement is resolved to:

SKILL_JEWELCRAFTING_2

for Classic Jewelcrafting.

The correction is applied to both the trainer spell availability check and the requirement information supplied to the trainer interface.

The corresponding legacy trainer-state path in Player.cpp is also handled so both trainer paths use the same Jewelcrafting requirement.

## Normal Jewelcrafting Crafting

Normal Jewelcrafting recipe crafting was tested separately and was already correctly increasing Classic Jewelcrafting.

For example:

Before crafting:

755  = 15
2524 = 1

After crafting a low-level Jewelcrafting recipe:

755  = 15
2524 = 2

This confirmed that normal crafting already uses the correct expansion-specific profession skill.

No changes were made to the normal Jewelcrafting crafting progression path.

Parent and Expansion-Specific Skills

This fix intentionally does not force:

SKILL_JEWELCRAFTING (755)

and:

SKILL_JEWELCRAFTING_2 (2524)

to remain numerically synchronized.

Classic Jewelcrafting progression belongs to the expansion-specific skill line.

Instead, the affected Jewelcrafting systems have been corrected to use the appropriate Classic Jewelcrafting skill rather than masking the problem by artificially updating the generic parent skill.

## Files Changed
src/server/game/Entities/Player/Player.cpp
Adds SKILL_JEWELCRAFTING_2 to the appropriate UpdateGatherSkill() path.
Corrects the legacy trainer-state Jewelcrafting requirement to use Classic Jewelcrafting.

src/server/game/Entities/Creature/Trainer.cpp
Resolves generic Jewelcrafting trainer requirements to SKILL_JEWELCRAFTING_2.
Corrects server-side trainer spell availability checks.
Supplies the appropriate Classic Jewelcrafting requirement to the trainer interface.

src/server/game/Spells/Spell.cpp
Changes Prospecting skill requirement validation from generic Jewelcrafting to SKILL_JEWELCRAFTING_2.

src/server/game/Spells/SpellEffects.cpp
Changes Prospecting skill progression from generic Jewelcrafting to SKILL_JEWELCRAFTING_2.
Uses the player's actual Classic Jewelcrafting value for the existing gathering skill-up calculation.

## Testing Performed

Testing was performed on a locally compiled BFA-HavenCore server.

# Normal crafting
 Classic Jewelcrafting recipes can be crafted.
 Crafting increases SKILL_JEWELCRAFTING_2.
 Normal crafting did not require modification.

# Prospecting

Tested using low-level Classic ores including Copper Ore and Tin Ore.

 Prospecting completes successfully.
 Prospecting uses Classic Jewelcrafting 2524.
 Prospecting increases SKILL_JEWELCRAFTING_2.
 UpdateGatherSkill() correctly handles SKILL_JEWELCRAFTING_2.
 Generic Jewelcrafting 755 is no longer incorrectly increased by Prospecting.
 Prospecting skill requirements use the Classic Jewelcrafting skill.

# Trainer recipes

Tested with deliberately different parent and Classic profession values:

755  = 1
2524 = 7
 A recipe requiring Jewelcrafting 5 can be learned.
 Trainer availability is based on Classic Jewelcrafting 2524.
 Increasing the generic parent skill manually is no longer required.
 Trainer requirement display and server-side availability use the corrected skill.


## Result

Classic Jewelcrafting now consistently uses its expansion-specific profession skill where required.

The corrected behavior is:

Craft Jewelcrafting item
        ↓
Classic Jewelcrafting (2524) increases

Prospect ore
        ↓
Prospecting requirement checks Classic Jewelcrafting (2524)
        ↓
Classic Jewelcrafting (2524) receives skill progression

Learn trainer recipe
        ↓
Recipe skill requirement checks Classic Jewelcrafting (2524)
        ↓
Recipe becomes available at the correct profession skill

The generic parent Jewelcrafting skill 755 no longer needs to be manually synchronized with Classic Jewelcrafting for these systems to function correctly.