### PR TITLE
DB: Jimb McHannigan, Mama Celeste, Two-Shoed Lou

### DIFF
--- a/sql/updates/world/2026_08_13_00_fix_mama_jimb_two_shoed.sql
+++ b/sql/updates/world/2026_08_13_00_fix_mama_jimb_two_shoed.sql
@@ -1,0 +1,16 @@
+-- Two-Shoed Lou (42405) - Not attackable now (Was attackable before / unit_flags IMMUNE_TO_PC added)
+UPDATE `creature_template`
+SET `unit_flags` = 33536
+WHERE `entry` = 42405;
+
+
+-- Jimb "Candles" McHannigan (42498) - Not attackable now (Was attackable before / unit_flags IMMUNE_TO_PC added)
+UPDATE `creature_template`
+SET `unit_flags` = 33536
+WHERE `entry` = 42498;
+
+
+-- Mama Celeste (42497) - Not attackable now (Was attackable before / unit_flags IMMUNE_TO_PC added)
+UPDATE `creature_template`
+SET `unit_flags` = 33536
+WHERE `entry` = 42497;


### PR DESCRIPTION
Related Issue -> https://github.com/Hextv/BFA-HavenCore/issues/133
- Mama Celeste (42497) - Now not attackable.
- Jimb "Candles" McHannigan (42498) - Now not attackable.
- Two-Shoed Lou (42405) - Now not attackable.