### PR TITLE
DB: Update Quest POI (fixes #152 #182 #140)

### DIFF
--- a/sql/updates/world/2026_08_12_00_quest_POI.sql
+++ b/sql/updates/world/2026_08_12_00_quest_POI.sql
@@ -1,0 +1,150 @@
+-- 
+-- 26393 A Swift Message - has quest_objective
+--  
+
+DELETE FROM quest_poi
+WHERE QuestID = 26393;
+
+DELETE FROM quest_poi_points
+WHERE QuestID = 26393;
+
+INSERT INTO `quest_poi` (`QuestID`, `BlobIndex`, `Idx1`, `ObjectiveIndex`, `QuestObjectiveID`, `QuestObjectID`, `MapID`, `UiMapID`, `Priority`, `Flags`, `WorldEffectID`, `PlayerConditionID`, `SpawnTrackingID`, `AlwaysAllowMergingBlobs`, `VerifiedBuild`) VALUES (26393, 0, 0, -1, 0, 0, 0, 37, 0, 1, 0, 0, 0, 0, 35662);
+INSERT INTO `quest_poi` (`QuestID`, `BlobIndex`, `Idx1`, `ObjectiveIndex`, `QuestObjectiveID`, `QuestObjectID`, `MapID`, `UiMapID`, `Priority`, `Flags`, `WorldEffectID`, `PlayerConditionID`, `SpawnTrackingID`, `AlwaysAllowMergingBlobs`, `VerifiedBuild`) VALUES (26393, 0, 1, 0, 265992, 0, 0, 37, 0, 1, 0, 0, 13073, 0, 35662);
+INSERT INTO `quest_poi` (`QuestID`, `BlobIndex`, `Idx1`, `ObjectiveIndex`, `QuestObjectiveID`, `QuestObjectID`, `MapID`, `UiMapID`, `Priority`, `Flags`, `WorldEffectID`, `PlayerConditionID`, `SpawnTrackingID`, `AlwaysAllowMergingBlobs`, `VerifiedBuild`) VALUES (26393, 0, 2, 32, 0, 0, 0, 37, 0, 0, 0, 0, 13073, 0, 35662);
+
+INSERT INTO `quest_poi_points` (`QuestID`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES (26393, 0, 0, -9435, 88, 35662);
+INSERT INTO `quest_poi_points` (`QuestID`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES (26393, 1, 0, -9435, 88, 35662);
+
+
+-- 
+-- 28819 The Rear is Clear - Simple turn in quest with no quest_objective
+-- 
+
+DELETE FROM quest_poi
+WHERE QuestID = 28819;
+
+DELETE FROM quest_poi_points
+WHERE QuestID = 28819;
+
+INSERT INTO `quest_poi` (`QuestID`, `BlobIndex`, `Idx1`, `ObjectiveIndex`, `QuestObjectiveID`, `QuestObjectID`, `MapID`, `UiMapID`, `Priority`, `Flags`, `WorldEffectID`, `PlayerConditionID`, `SpawnTrackingID`, `AlwaysAllowMergingBlobs`, `VerifiedBuild`) VALUES (28819, 0, 0, -1, 0, 0, 0, 425, 0, 1, 0, 0, 0, 0, 35662);
+
+-- Quest giver
+INSERT INTO `quest_poi_points` (`QuestID`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES (28819, 1, 0, -8827, -158, 35662);
+-- Quest turn in
+INSERT INTO `quest_poi_points` (`QuestID`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES (28819, 0, 0, -8913, -137, 35662);
+
+
+-- 
+-- 54 Report to Goldshire
+-- 
+
+DELETE FROM quest_poi
+WHERE QuestID = 54;
+
+DELETE FROM quest_poi_points
+WHERE QuestID = 54;
+
+INSERT INTO `quest_poi` (`QuestID`, `BlobIndex`, `Idx1`, `ObjectiveIndex`, `QuestObjectiveID`, `QuestObjectID`, `MapID`, `UiMapID`, `Priority`, `Flags`, `WorldEffectID`, `PlayerConditionID`, `SpawnTrackingID`, `AlwaysAllowMergingBlobs`, `VerifiedBuild`) VALUES (54, 0, 0, -1, 0, 0, 0, 37, 0, 1, 0, 0, 0, 0, 35662);
+INSERT INTO `quest_poi` (`QuestID`, `BlobIndex`, `Idx1`, `ObjectiveIndex`, `QuestObjectiveID`, `QuestObjectID`, `MapID`, `UiMapID`, `Priority`, `Flags`, `WorldEffectID`, `PlayerConditionID`, `SpawnTrackingID`, `AlwaysAllowMergingBlobs`, `VerifiedBuild`) VALUES (54, 0, 1, 0, 252181, 0, 0, 37, 0, 1, 0, 0, 0, 0, 35662);
+INSERT INTO `quest_poi` (`QuestID`, `BlobIndex`, `Idx1`, `ObjectiveIndex`, `QuestObjectiveID`, `QuestObjectID`, `MapID`, `UiMapID`, `Priority`, `Flags`, `WorldEffectID`, `PlayerConditionID`, `SpawnTrackingID`, `AlwaysAllowMergingBlobs`, `VerifiedBuild`) VALUES (54, 0, 2, 32, 0, 0, 0, 37, 0, 0, 0, 0, 0, 0, 35662);
+
+-- POI on login/relog
+INSERT INTO `quest_poi_points` (`QuestID`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES (54, 0, 0, -9465, 74, 35662);
+-- POI on accept quest
+INSERT INTO `quest_poi_points` (`QuestID`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES (54, 1, 0, -9465, 74, 35662);
+
+
+-- 
+-- 8325 Reclaiming Sunstrider Isle
+-- 
+
+DELETE FROM quest_poi
+WHERE QuestID = 8325;
+
+-- POI UiMapID incorrect
+INSERT INTO `quest_poi` (`QuestID`, `BlobIndex`, `Idx1`, `ObjectiveIndex`, `QuestObjectiveID`, `QuestObjectID`, `MapID`, `UiMapID`, `Priority`, `Flags`, `WorldEffectID`, `PlayerConditionID`, `SpawnTrackingID`, `AlwaysAllowMergingBlobs`, `VerifiedBuild`) VALUES (8325, 0, 0, -1, 0, 0, 530, 467, 0, 1, 0, 0, 0, 0, 35662);
+INSERT INTO `quest_poi` (`QuestID`, `BlobIndex`, `Idx1`, `ObjectiveIndex`, `QuestObjectiveID`, `QuestObjectID`, `MapID`, `UiMapID`, `Priority`, `Flags`, `WorldEffectID`, `PlayerConditionID`, `SpawnTrackingID`, `AlwaysAllowMergingBlobs`, `VerifiedBuild`) VALUES (8325, 0, 1, 0, 256221, 15274, 530, 467, 0, 1, 0, 0, 0, 0, 35662);
+INSERT INTO `quest_poi` (`QuestID`, `BlobIndex`, `Idx1`, `ObjectiveIndex`, `QuestObjectiveID`, `QuestObjectID`, `MapID`, `UiMapID`, `Priority`, `Flags`, `WorldEffectID`, `PlayerConditionID`, `SpawnTrackingID`, `AlwaysAllowMergingBlobs`, `VerifiedBuild`) VALUES (8325, 0, 2, 32, 0, 0, 530, 467, 0, 0, 0, 0, 120146, 0, 35662);
+
+
+--  
+-- 8326 Unfortunate Measures
+-- 
+
+DELETE FROM quest_poi
+WHERE QuestID = 8326;
+
+DELETE FROM quest_poi_points
+WHERE QuestID = 8326;
+
+INSERT INTO 
+`quest_poi` (`QuestID`, `BlobIndex`, `Idx1`, `ObjectiveIndex`, `QuestObjectiveID`, `QuestObjectID`, `MapID`, `UiMapID`, `Priority`, `Flags`, `WorldEffectID`, `PlayerConditionID`, `SpawnTrackingID`, `AlwaysAllowMergingBlobs`, `VerifiedBuild`)
+VALUES
+(8326, 0, 0, -1, 0, 0, 530, 467, 0, 1, 0, 0, 0, 0, 35662),
+(8326, 0, 1, 0, 256445, 0, 530, 467, 0, 1, 0, 0, 0, 0, 35662),
+(8326, 0, 2, 32, 0, 0, 530, 467, 0, 0, 0, 0, 0, 0, 35662);
+
+INSERT INTO `quest_poi_points` (`QuestID`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES (8326, 1, 0, 10439, -6405, 35662);
+INSERT INTO `quest_poi_points` (`QuestID`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES (8326, 1, 1, 10480, -6382, 35662);
+INSERT INTO `quest_poi_points` (`QuestID`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES (8326, 1, 2, 10409, -6388, 35662);
+INSERT INTO `quest_poi_points` (`QuestID`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES (8326, 1, 3, 10530, -6425, 35662);
+INSERT INTO `quest_poi_points` (`QuestID`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES (8326, 1, 4, 10496, -6478, 35662);
+INSERT INTO `quest_poi_points` (`QuestID`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES (8326, 1, 5, 10444, -6495, 35662);
+INSERT INTO `quest_poi_points` (`QuestID`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES (8326, 1, 6, 10357, -6499, 35662);
+
+
+--  
+-- 8895 Delivery to the North Sanctum
+--
+
+DELETE FROM quest_poi
+WHERE QuestID = 8895;
+
+DELETE FROM quest_poi_points
+WHERE QuestID = 8895;
+
+INSERT INTO `quest_poi` (`QuestID`, `BlobIndex`, `Idx1`, `ObjectiveIndex`, `QuestObjectiveID`, `QuestObjectID`, `MapID`, `UiMapID`, `Priority`, `Flags`, `WorldEffectID`, `PlayerConditionID`, `SpawnTrackingID`, `AlwaysAllowMergingBlobs`, `VerifiedBuild`) VALUES (8895, 0, 0, -1, 0, 0, 530, 94, 0, 1, 0, 0, 0, 0, 35662);
+INSERT INTO `quest_poi` (`QuestID`, `BlobIndex`, `Idx1`, `ObjectiveIndex`, `QuestObjectiveID`, `QuestObjectID`, `MapID`, `UiMapID`, `Priority`, `Flags`, `WorldEffectID`, `PlayerConditionID`, `SpawnTrackingID`, `AlwaysAllowMergingBlobs`, `VerifiedBuild`) VALUES (8895, 0, 1, 0, 259937, 0, 530, 94, 0, 1, 0, 0, 0, 0, 35662);
+INSERT INTO `quest_poi` (`QuestID`, `BlobIndex`, `Idx1`, `ObjectiveIndex`, `QuestObjectiveID`, `QuestObjectID`, `MapID`, `UiMapID`, `Priority`, `Flags`, `WorldEffectID`, `PlayerConditionID`, `SpawnTrackingID`, `AlwaysAllowMergingBlobs`, `VerifiedBuild`) VALUES (8895, 0, 2, 32, 0, 0, 530, 94, 0, 0, 0, 0, 122183, 0, 35662);
+
+INSERT INTO `quest_poi_points` (`QuestID`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES (8895, 0, 0, 9297, -6682, 35662);
+INSERT INTO `quest_poi_points` (`QuestID`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES (8895, 1, 0, 9521, -6815, 35662);
+
+--  
+-- 9705 Package Recovery
+--
+
+DELETE FROM quest_poi
+WHERE QuestID = 9705;
+
+DELETE FROM quest_poi_points
+WHERE QuestID = 9705;
+
+INSERT INTO `quest_poi` (`QuestID`, `BlobIndex`, `Idx1`, `ObjectiveIndex`, `QuestObjectiveID`, `QuestObjectID`, `MapID`, `UiMapID`, `Priority`, `Flags`, `WorldEffectID`, `PlayerConditionID`, `SpawnTrackingID`, `AlwaysAllowMergingBlobs`, `VerifiedBuild`) VALUES (9705, 0, 0, -1, 0, 0, 530, 94, 0, 1, 0, 0, 0, 0, 35662);
+INSERT INTO `quest_poi` (`QuestID`, `BlobIndex`, `Idx1`, `ObjectiveIndex`, `QuestObjectiveID`, `QuestObjectID`, `MapID`, `UiMapID`, `Priority`, `Flags`, `WorldEffectID`, `PlayerConditionID`, `SpawnTrackingID`, `AlwaysAllowMergingBlobs`, `VerifiedBuild`) VALUES (9705, 0, 1, 0, 260518, 0, 530, 94, 0, 1, 0, 0, 0, 0, 35662);
+INSERT INTO `quest_poi` (`QuestID`, `BlobIndex`, `Idx1`, `ObjectiveIndex`, `QuestObjectiveID`, `QuestObjectID`, `MapID`, `UiMapID`, `Priority`, `Flags`, `WorldEffectID`, `PlayerConditionID`, `SpawnTrackingID`, `AlwaysAllowMergingBlobs`, `VerifiedBuild`) VALUES (9705, 0, 2, 32, 0, 0, 530, 110, 0, 0, 0, 0, 146333, 0, 35662);
+
+
+INSERT INTO `quest_poi_points` (`QuestID`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES (9705, 0, 0, 9984, -6478, 35662);
+INSERT INTO `quest_poi_points` (`QuestID`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES (9705, 1, 0, 9984, -6478, 35662);
+
+-- Quest start and end should not be same NPC
+DELETE FROM `creature_queststarter` WHERE  `id`=15301 AND `quest`=9705;
+
+
+--  
+-- 8350 Completing the Delivery
+--
+
+DELETE FROM quest_poi
+WHERE QuestID = 8350;
+
+DELETE FROM quest_poi_points
+WHERE QuestID = 8350;
+
+INSERT INTO `quest_poi` (`QuestID`, `BlobIndex`, `Idx1`, `ObjectiveIndex`, `QuestObjectiveID`, `QuestObjectID`, `MapID`, `UiMapID`, `Priority`, `Flags`, `WorldEffectID`, `PlayerConditionID`, `SpawnTrackingID`, `AlwaysAllowMergingBlobs`, `VerifiedBuild`) VALUES (8350, 0, 0, -1, 0, 0, 530, 94, 0, 1, 0, 0, 0, 0, 35662);
+INSERT INTO `quest_poi` (`QuestID`, `BlobIndex`, `Idx1`, `ObjectiveIndex`, `QuestObjectiveID`, `QuestObjectID`, `MapID`, `UiMapID`, `Priority`, `Flags`, `WorldEffectID`, `PlayerConditionID`, `SpawnTrackingID`, `AlwaysAllowMergingBlobs`, `VerifiedBuild`) VALUES (8350, 0, 1, 0, 257507, 0, 530, 94, 0, 1, 0, 0, 121069, 0, 35662);
+INSERT INTO `quest_poi` (`QuestID`, `BlobIndex`, `Idx1`, `ObjectiveIndex`, `QuestObjectiveID`, `QuestObjectID`, `MapID`, `UiMapID`, `Priority`, `Flags`, `WorldEffectID`, `PlayerConditionID`, `SpawnTrackingID`, `AlwaysAllowMergingBlobs`, `VerifiedBuild`) VALUES (8350, 0, 2, 32, 0, 0, 530, 94, 0, 0, 0, 0, 0, 0, 35662);
+
+INSERT INTO `quest_poi_points` (`QuestID`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES (8350, 0, 0, 9477, -6859, 35662);
+INSERT INTO `quest_poi_points` (`QuestID`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES (8350, 1, 0, 9477, -6859, 35662);


### PR DESCRIPTION
26393 A Swift Message
28819 The Rear is Clear
54 Report to Goldshire
8325 Reclaiming Sunstrider Isle
8326 Unfortunate Measures #182 #140 
8895 Delivery to the North Sanctum #152
9705 Package Recovery
8350 Completing the Delivery #152

<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [ ] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test BFA-HavenCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub.

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
