### PR TITLE
core/Scripts: remove full player save storm on every logout

### DIFF
--- a/src/server/scripts/Custom/custom_player_script.cpp
+++ b/src/server/scripts/Custom/custom_player_script.cpp
@@ -398,19 +398,6 @@ public:
     }
 };
 
-/* Save all players on logout */
-// fixes bug where players are rolled back to previous level on logout
-class PlayerSavingOnLogoutFix : public PlayerScript
-{
-public:
-    PlayerSavingOnLogoutFix() : PlayerScript("PlayerSavingOnLogoutFix") { }
-
-    void OnLogout(Player* player) override
-    {
-        ObjectAccessor::SaveAllPlayers();
-    }
-};
-
 class PlayerScript_Weekly_Spells : public PlayerScript
 {
 public:
@@ -559,7 +546,6 @@ void AddSC_custom_player_script()
     RegisterPlayerScript(OnBfaArrival);             // TEMP FIX! remove it when lordaeron battle is properly fixed.
     RegisterPlayerScript(On120Arrival);             // TEMP FIX! remove it when bfa starting is properly fixed.
     RegisterPlayerScript(WorgenRunningWild);
-    RegisterPlayerScript(PlayerSavingOnLogoutFix);
 	new PlayerScript_Weekly_Spells();
 	RegisterPlayerScript(player_level_rewards);
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Removes `PlayerSavingOnLogoutFix` from `custom_player_script.cpp`.

The hook called `ObjectAccessor::SaveAllPlayers()` from `OnPlayerLogout`, so one player logging out wrote a full character save for **every** other player online, on the world thread. The cost scales with population.

It also could not do what its name claims. `ScriptMgr::OnPlayerLogout` fires from `WorldSession::LogoutPlayer` at `WorldSession.cpp:617`, *after* the logging-out player has already been persisted by `_player->SaveToDB()` at `WorldSession.cpp:591`. The hook runs too late to protect the player it was written for.

Protection against losing progress on an unclean shutdown already exists: the periodic autosave in `Player::Update` (`Player.cpp:1315-1325`), tuned with `PlayerSaveInterval` (`World.cpp:712`, default 15 minutes). Lowering that config value is the correct lever, and it is left untouched by this PR.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Tool: Claude Code. Model: Claude Opus 5.** Used for the static analysis that found the issue and for drafting the change; every claim about call ordering was verified against the source in this repository before submitting.

## Issues Addressed:
- Closes #250

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Not applicable — this is a defect in this repository's own custom code. The reasoning is derived from the call ordering in `WorldSession::LogoutPlayer` and the autosave path in `Player::Update`, both cited above.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Compile-verified only: `worldserver` builds clean on Windows with Visual Studio 2022, `RelWithDebInfo`. **Not tested in-game.**

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. With several characters online, log one out and confirm the other characters are no longer written to `characters` at that moment.
2. Confirm the logging-out character is still saved correctly (its state persists across relog).
3. Confirm periodic autosave still runs on the `PlayerSaveInterval` cadence.

## Known Issues and TODO List:

- [ ] Servers that were relying on this hook as a de facto "save everyone often" mechanism should set `PlayerSaveInterval` to the interval they actually want.
