### PR TITLE
core/Scripts: fix solocraft scaling state, null deref and config key

### DIFF
--- a/src/server/scripts/Custom/solocraft.cpp
+++ b/src/server/scripts/Custom/solocraft.cpp
@@ -16,6 +16,7 @@
 */
 
 #include <map>
+#include <mutex>
 #include "Config.h"
 #include "Chat.h"
 #include "Log.h"
@@ -49,8 +50,18 @@ namespace {
             }
         }
 
+        void OnLogout(Player *player) override
+        {
+            float difficulty;
+            if (!TakeDifficulty(player, difficulty))
+                return;
+
+            ApplyStatModifiers(player, difficulty, false);
+        }
+
     private:
         std::map<ObjectGuid, float> _unitDifficulty;
+        std::mutex _unitDifficultyLock;
 
         // Get difficulty values from config
         const float D5 = sConfigMgr->GetFloatDefault("Solocraft.Dungeon", 5.0);
@@ -59,7 +70,7 @@ namespace {
         const float D10 = sConfigMgr->GetFloatDefault("Solocraft.Raid10", 10.0);
         const float D25 = sConfigMgr->GetFloatDefault("Solocraft.Raid25", 25.0);
         const float D30 = sConfigMgr->GetFloatDefault("Solocraft.Raid30", 30.0);
-		const float D40 = sConfigMgr->GetFloatDefault("Solocraft.Raid30", 40.0);
+        const float D40 = sConfigMgr->GetFloatDefault("Solocraft.Raid40", 40.0);
 
         // Set the instance difficulty
         float CalculateDifficulty(Map *map, Player *player)
@@ -69,20 +80,30 @@ namespace {
         {
                 if (map->IsRaid())
                 {
-                    switch (map->GetMapDifficulty()->MaxPlayers)
+                    MapDifficultyEntry const* mapDifficulty = map->GetMapDifficulty();
+                    if (!mapDifficulty)
                     {
-                    case 10:
-                        difficulty = D10; break;
-                    case 25:
-                        difficulty = D25; break;
-                    case 30:
-                        difficulty = D30; break;
-					case 40:
-						difficulty = D40; break;
-                    default:
-                        TC_LOG_WARN("scripts.solocraft.player.instance", "[SoloCraft] Unrecognized max players %d, defaulting to 10 man difficulty",
-                            map->GetMapDifficulty()->MaxPlayers);
+                        TC_LOG_WARN("scripts.solocraft.player.instance", "[SoloCraft] Map %u has no difficulty %u entry, defaulting to 10 man difficulty",
+                            map->GetId(), uint32(map->GetDifficultyID()));
                         difficulty = D10;
+                    }
+                    else
+                    {
+                        switch (mapDifficulty->MaxPlayers)
+                        {
+                        case 10:
+                            difficulty = D10; break;
+                        case 25:
+                            difficulty = D25; break;
+                        case 30:
+                            difficulty = D30; break;
+                        case 40:
+                            difficulty = D40; break;
+                        default:
+                            TC_LOG_WARN("scripts.solocraft.player.instance", "[SoloCraft] Unrecognized max players %d, defaulting to 10 man difficulty",
+                                mapDifficulty->MaxPlayers);
+                            difficulty = D10;
+                        }
                     }
                 }
                 else if (map->IsDungeon())
@@ -127,12 +148,12 @@ namespace {
                 ChatHandler(player->GetSession()).PSendSysMessage(ss.str().c_str(), map->GetMapName(), numInGroup, difficulty + 1.0);
 
                 // Adjust player stats
-                _unitDifficulty[player->GetGUID()] = difficulty;
-                for (int32 i = STAT_STRENGTH; i < MAX_STATS; ++i)
                 {
-                    // Buff the player
-                    player->HandleStatModifier(UnitMods(UNIT_MOD_STAT_START + i), TOTAL_PCT, difficulty * 100.0, true);
+                    std::lock_guard<std::mutex> guard(_unitDifficultyLock);
+                    _unitDifficulty[player->GetGUID()] = difficulty;
                 }
+
+                ApplyStatModifiers(player, difficulty, true);
 
                 // Set player health
                 player->SetFullHealth();
@@ -146,22 +167,37 @@ namespace {
 
         void ClearBuffs(Player *player, Map *map)
         {
+            float difficulty;
+            if (!TakeDifficulty(player, difficulty))
+                return;
+
+            // Inform the player
+            std::ostringstream ss;
+            ss << "|cffFF0000[SoloCraft] |cffFF8000" << player->GetName() << " exited to %s - Reverting Difficulty Offset: %0.2f.";
+            ChatHandler(player->GetSession()).PSendSysMessage(ss.str().c_str(), map->GetMapName(), difficulty + 1.0);
+
+            // Clear the buffs
+            ApplyStatModifiers(player, difficulty, false);
+        }
+
+        bool TakeDifficulty(Player *player, float &difficulty)
+        {
+            std::lock_guard<std::mutex> guard(_unitDifficultyLock);
+
             std::map<ObjectGuid, float>::iterator unitDifficultyIterator = _unitDifficulty.find(player->GetGUID());
-            if (unitDifficultyIterator != _unitDifficulty.end())
+            if (unitDifficultyIterator == _unitDifficulty.end())
+                return false;
+
+            difficulty = unitDifficultyIterator->second;
+            _unitDifficulty.erase(unitDifficultyIterator);
+            return true;
+        }
+
+        void ApplyStatModifiers(Player *player, float difficulty, bool apply)
+        {
+            for (int32 i = STAT_STRENGTH; i < MAX_STATS; ++i)
             {
-                float difficulty = unitDifficultyIterator->second;
-                _unitDifficulty.erase(unitDifficultyIterator);
-
-                // Inform the player
-                std::ostringstream ss;
-                ss << "|cffFF0000[SoloCraft] |cffFF8000" << player->GetName() << " exited to %s - Reverting Difficulty Offset: %0.2f.";
-                ChatHandler(player->GetSession()).PSendSysMessage(ss.str().c_str(), map->GetMapName(), difficulty + 1.0);
-
-                // Clear the buffs
-                for (int32 i = STAT_STRENGTH; i < MAX_STATS; ++i)
-                {
-                    player->HandleStatModifier(UnitMods(UNIT_MOD_STAT_START + i), TOTAL_PCT, difficulty * 100.0, false);
-                }
+                player->HandleStatModifier(UnitMods(UNIT_MOD_STAT_START + i), TOTAL_PCT, difficulty * 100.0, apply);
             }
         }
     };


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Four defects in `solocraft_player_instance_handler` (`src/server/scripts/Custom/solocraft.cpp`):

**Wrong config key.** `D40` read `Solocraft.Raid30`, so the configured `Solocraft.Raid40` value was never used and 40 man raids scaled with the 30 man offset.

**Null dereference.** `Map::GetMapDifficulty()` forwards to `DB2Manager::GetMapDifficultyData` and returns `nullptr` when the map has no row for its active difficulty. It was dereferenced twice with no check, crashing the map thread. It now falls back to the 10 man offset and logs the map and difficulty id.

**Leaked scaling state on logout.** `_unitDifficulty` was erased on map change but never on logout. The stat modifiers live on the `Player` object and do not survive it, so a character that logged out inside an instance kept its entry and had the modifier re-applied with `apply=false` on its next zone change — leaving it permanently debuffed until restart. `OnLogout` now takes the entry and removes the modifiers.

**Unsynchronized shared container.** `_unitDifficulty` is a single shared `std::map` reached from `OnMapChanged`, which `ScriptMgr` dispatches from `Map::AddPlayerToMap` on the owning map thread — and `MapManager::Update` runs two maps concurrently. Access is now guarded by a mutex, and the lock is released before calling back into `Player` so the stat path stays outside the critical section.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Tool: Claude Code. Model: Claude Opus 5.** Used for the static analysis that found the issues and for drafting the change; the dispatch path and the config key were verified against the source and `worldserver.conf.dist` in this repository before submitting.

## Issues Addressed:
- Closes #253

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Not applicable — this is a defect in this repository's own custom code. Verified by reading `ScriptMgr::OnPlayerEnterMap`, `Map::AddPlayerToMap`, `Map::GetMapDifficulty` and `worldserver.conf.dist`.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Compile-verified only: `worldserver` builds clean on Windows with Visual Studio 2022, `RelWithDebInfo`. **Not tested in-game.**

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. Set `Solocraft.Raid40` to a distinctive value, enter a 40 man raid, and confirm the applied scaling matches it rather than the `Solocraft.Raid30` value.
2. Enter an instance, log out inside it, log back in and zone somewhere else. Confirm stats are correct rather than permanently reduced.
3. Enter a map whose active difficulty has no `MapDifficulty` row. Confirm the server logs the warning and stays up instead of crashing.

## Known Issues and TODO List:

- [ ] The 10 man fallback for a missing `MapDifficulty` entry is a safe default, not a researched one. If a better default per map type is known it should replace it.
