### PR TITLE
core/Scripts: take weekend XP check off the XP award path

### DIFF
--- a/src/server/scripts/Custom/XpWeekend.cpp
+++ b/src/server/scripts/Custom/XpWeekend.cpp
@@ -1,43 +1,56 @@
 #include "Player.h"
 #include "ScriptMgr.h"
 #include "Chat.h"
-#include "World.h"
-#include "boost/date_time.hpp"
 #include "Config.h"
+#include "GameTime.h"
+#include <atomic>
+
+namespace
+{
+    constexpr uint32 WEEKEND_XP_MULTIPLIER = 2;
+
+    std::atomic<bool> _doubleXpActive{ false };
+
+    class XpWeekendWorld : public WorldScript
+    {
+    public:
+        XpWeekendWorld() : WorldScript("XpWeekendWorld") { }
+
+        void OnUpdate(uint32 /*diff*/) override
+        {
+            if (!sConfigMgr->GetBoolDefault("DynamicXP.Enable", true))
+            {
+                _doubleXpActive.store(false, std::memory_order_relaxed);
+                return;
+            }
+
+            tm const* localTime = GameTime::GetDateAndTime();
+            bool weekend = localTime->tm_wday == 0 || localTime->tm_wday == 6;
+            _doubleXpActive.store(weekend, std::memory_order_relaxed);
+        }
+    };
 
     class XpWeekend : public PlayerScript
     {
     public:
         XpWeekend() : PlayerScript("XpWeekend") { }
-        void OnGiveXP(Player* player, uint32& amount, Unit* victim)override
-        {
-            if (sConfigMgr->GetBoolDefault("DynamicXP.Enable", true))
-            {
-                boost::gregorian::date date(boost::gregorian::day_clock::local_day());
-                auto day = date.day_of_week();
-                if  (day == boost::date_time::Saturday ||
-                    day == boost::date_time::Sunday) {
 
-                    amount = amount * 2;
-                }
-            }
+        void OnGiveXP(Player* /*player*/, uint32& amount, Unit* /*victim*/) override
+        {
+            if (_doubleXpActive.load(std::memory_order_relaxed))
+                amount *= WEEKEND_XP_MULTIPLIER;
         }
-        void OnLogin(Player* player, bool firstLogin)
-        {
-            if (sConfigMgr->GetBoolDefault("DynamicXP.Enable", true))
-            {
-                boost::gregorian::date date(boost::gregorian::day_clock::local_day());
-                auto day = date.day_of_week();
-                if  (day == boost::date_time::Saturday ||
-                    day == boost::date_time::Sunday) {
 
-                    ChatHandler(player->GetSession()).PSendSysMessage("Double XP has started now! Call your friends and keep leveling faster!");
-                }
-            }
+        void OnLogin(Player* player, bool /*firstLogin*/) override
+        {
+            if (_doubleXpActive.load(std::memory_order_relaxed))
+                ChatHandler(player->GetSession()).PSendSysMessage("Double XP has started now! Call your friends and keep leveling faster!");
         }
     };
+}
 
 void AddSC_XpWeekend()
 {
+    new XpWeekendWorld();
     new XpWeekend();
 }


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

`XpWeekend::OnGiveXP` runs on every experience award, which on a populated realm is one of the hottest script hooks in the tree. Each call did a boost `property_tree` lookup plus a `std::string` allocation via `GetBoolDefault`, then constructed a `boost::gregorian::date` from `day_clock::local_day()` — which queries the OS clock and resolves the local timezone.

The weekend state changes at most once a day. It is now computed once per world update on the world thread and published through a `std::atomic<bool>` that the XP path reads with a relaxed load and no allocation.

`GameTime::GetDateAndTime()` replaces `day_clock`, since it is already broken down and refreshed by `UpdateGameTimers` on that same thread.

The config is read from the world update rather than cached at `OnConfigLoad`, because `World::LoadConfigSettings` runs *before* scripts are registered — an `OnConfigLoad` cache would never fire at startup and the feature would stay dead until a manual `.reload config`. Reading it from the update also keeps `.reload config` working.

`OnLogin` was missing `override`, and the doubling factor is now a named constant.

The existing `DynamicXP.Enable` default of `true` in code is preserved deliberately, so this PR does not change behaviour for anyone. Note that `worldserver.conf.dist` ships `DynamicXP.Enable = 0`, so the code default and the shipped config disagree — that mismatch predates this PR and is left alone.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Tool: Claude Code. Model: Claude Opus 5.** Used for the static analysis that found the issue and for drafting the change; the `WorldScript` hook ordering and the `GameTime` refresh point were verified against the source in this repository before submitting.

## Issues Addressed:
- Closes #255

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Not applicable — this is a defect in this repository's own custom code. Verified against the `WorldScript` hooks in `ScriptMgr.h`, `World::LoadConfigSettings`, and the cached time source in `GameTime.h`.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Compile-verified only: `worldserver` builds clean on Windows with Visual Studio 2022, `RelWithDebInfo`. **Not tested in-game.**

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. With `DynamicXP.Enable = 1` and the server clock set to a Saturday or Sunday, kill a mob and confirm XP is doubled and the login message appears.
2. Set the clock to a weekday, `.reload config`, and confirm XP is normal and no message appears on login.
3. Toggle `DynamicXP.Enable` and `.reload config` while online; confirm the change takes effect within one world update without a restart.

## Known Issues and TODO List:

- [ ] The state flips on the world update tick, so a weekend transition is applied within one tick rather than exactly at midnight. That matches the previous behaviour's granularity for practical purposes.
- [ ] `worldserver.conf.dist` ships `DynamicXP.Enable = 0` while the code default is `true`. Worth reconciling separately.
