### PR TITLE
core: synchronize every ConfigMgr access against reload

### DIFF
--- a/src/common/Configuration/Config.cpp
+++ b/src/common/Configuration/Config.cpp
@@ -22,7 +22,7 @@
 #include <boost/property_tree/ini_parser.hpp>
 #include <algorithm>
 #include <memory>
-#include <mutex>
+#include <shared_mutex>
 
 namespace bpt = boost::property_tree;
 
@@ -31,13 +31,13 @@ namespace
     std::string _filename;
     std::vector<std::string> _args;
     bpt::ptree _config;
-    std::mutex _configLock;
+    std::shared_mutex _configLock;
 }
 
 bool ConfigMgr::LoadInitial(std::string const& file, std::vector<std::string> args,
                             std::string& error)
 {
-    std::lock_guard<std::mutex> lock(_configLock);
+    std::unique_lock<std::shared_mutex> lock(_configLock);
 
     _filename = file;
     _args = args;
@@ -76,7 +76,16 @@ ConfigMgr* ConfigMgr::instance()
 
 bool ConfigMgr::Reload(std::string& error)
 {
-    return LoadInitial(_filename, std::move(_args), error);
+    std::string filename;
+    std::vector<std::string> args;
+
+    {
+        std::shared_lock<std::shared_mutex> lock(_configLock);
+        filename = _filename;
+        args = _args;
+    }
+
+    return LoadInitial(filename, std::move(args), error);
 }
 
 template<class T>
@@ -84,17 +93,18 @@ T ConfigMgr::GetValueDefault(std::string const& name, T def) const
 {
     try
     {
+        std::shared_lock<std::shared_mutex> lock(_configLock);
         return _config.get<T>(bpt::ptree::path_type(name, '/'));
     }
     catch (bpt::ptree_bad_path const&)
     {
         TC_LOG_WARN("server.loading", "Missing name %s in config file %s, add \"%s = %s\" to this file",
-            name.c_str(), _filename.c_str(), name.c_str(), std::to_string(def).c_str());
+            name.c_str(), GetFilename().c_str(), name.c_str(), std::to_string(def).c_str());
     }
     catch (bpt::ptree_bad_data const&)
     {
         TC_LOG_ERROR("server.loading", "Bad value defined for name %s in config file %s, going to use %s instead",
-            name.c_str(), _filename.c_str(), std::to_string(def).c_str());
+            name.c_str(), GetFilename().c_str(), std::to_string(def).c_str());
     }
 
     return def;
@@ -105,17 +115,18 @@ std::string ConfigMgr::GetValueDefault<std::string>(std::string const& name, std
 {
     try
     {
+        std::shared_lock<std::shared_mutex> lock(_configLock);
         return _config.get<std::string>(bpt::ptree::path_type(name, '/'));
     }
     catch (bpt::ptree_bad_path const&)
     {
         TC_LOG_WARN("server.loading", "Missing name %s in config file %s, add \"%s = %s\" to this file",
-            name.c_str(), _filename.c_str(), name.c_str(), def.c_str());
+            name.c_str(), GetFilename().c_str(), name.c_str(), def.c_str());
     }
     catch (bpt::ptree_bad_data const&)
     {
         TC_LOG_ERROR("server.loading", "Bad value defined for name %s in config file %s, going to use %s instead",
-            name.c_str(), _filename.c_str(), def.c_str());
+            name.c_str(), GetFilename().c_str(), def.c_str());
     }
 
     return def;
@@ -150,20 +161,21 @@ float ConfigMgr::GetFloatDefault(std::string const& name, float def) const
     return GetValueDefault(name, def);
 }
 
-std::string const& ConfigMgr::GetFilename()
+std::string ConfigMgr::GetFilename() const
 {
-    std::lock_guard<std::mutex> lock(_configLock);
+    std::shared_lock<std::shared_mutex> lock(_configLock);
     return _filename;
 }
 
-std::vector<std::string> const& ConfigMgr::GetArguments() const
+std::vector<std::string> ConfigMgr::GetArguments() const
 {
+    std::shared_lock<std::shared_mutex> lock(_configLock);
     return _args;
 }
 
 std::vector<std::string> ConfigMgr::GetKeysByString(std::string const& name)
 {
-    std::lock_guard<std::mutex> lock(_configLock);
+    std::shared_lock<std::shared_mutex> lock(_configLock);
 
     std::vector<std::string> keys;
 

--- a/src/common/Configuration/Config.h
+++ b/src/common/Configuration/Config.h
@@ -43,8 +43,8 @@ public:
     int64 GetInt64Default(std::string const& name, int64 def) const;
     float GetFloatDefault(std::string const& name, float def) const;
 
-    std::string const& GetFilename();
-    std::vector<std::string> const& GetArguments() const;
+    std::string GetFilename() const;
+    std::vector<std::string> GetArguments() const;
     std::vector<std::string> GetKeysByString(std::string const& name);
 
 private:


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

`ConfigMgr::LoadInitial` takes the lock and replaces the whole `ptree`, but the readers did not take it.

- `GetValueDefault` and its `std::string` specialization read `_config` unguarded, so a `.reload config` racing with any config read from any thread was undefined behaviour. Config is read from map threads, session threads and scripts.
- `Reload` read `_filename` and `_args` unguarded before handing them to `LoadInitial`.
- `GetFilename` locked but returned a *reference* into the guarded string; `GetArguments` returned a reference to the guarded vector without locking at all. Both handed callers a reference that a concurrent reload could invalidate.

Changes:

- Both accessors now return by value. No caller needed a reference — the two `Main.cpp` sites take `.c_str()` within the full expression and the three `ScriptReloadMgr` sites copy immediately. All five were checked.
- The mutex becomes a `std::shared_mutex`. Reads are frequent and concurrent while writes happen only at startup and on reload, so readers take a shared lock instead of serializing against each other.
- `Reload` copies the filename and arguments under a shared lock and releases it before calling `LoadInitial`, which takes the unique lock itself. This is what avoids the self-deadlock a naive fix would introduce.
- `GetValueDefault` takes its lock *inside* the `try` block, so unwinding releases it before the catch handlers call `GetFilename()`.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Tool: Claude Code. Model: Claude Opus 5.** Used for the static analysis that found the issue and for drafting the change; every reference to `_config`, `_filename` and `_args` in the translation unit and every caller of the two changed signatures were enumerated and checked by hand before submitting.

## Issues Addressed:
- Closes #249

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Not applicable — this is a thread-safety defect in this repository's own code.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Compile-verified only: `worldserver` and `bnetserver` both build clean on Windows with Visual Studio 2022, `RelWithDebInfo`. **Not tested in-game.** A data race is not reliably reproducible by hand, so the change is argued from the code rather than from a repro.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing.

1. Start `worldserver` with players online and traffic on several maps.
2. Run `.reload config` repeatedly while the realm is busy. Confirm no crash and that changed values take effect.
3. Confirm `bnetserver` still starts and reads its config normally (`GetFilename`/`GetArguments` signature change touches it).

## Known Issues and TODO List:

- [ ] `.reload config` still replaces the whole tree at once. Readers now never see a torn tree, but a reader can still observe a mix of old and new values across two separate `GetValueDefault` calls that straddle the reload. Making a reload atomic from a reader's point of view would need a different design and is out of scope here.
