### PR TITLE
core/Anticheat: own detection state per session and fix the math

### DIFF
--- a/src/server/game/Anticheat/AnticheatData.cpp
+++ b/src/server/game/Anticheat/AnticheatData.cpp
@@ -19,114 +19,125 @@
 
 AnticheatData::AnticheatData()
 {
-    lastOpcode = 0;
-    totalReports = 0;
-    for (uint8 i = 0; i < MAX_REPORT_TYPES; i++)
-    {
-        typeReports[i] = 0;
-        tempReports[i] = 0;
-        tempReportsTimer[i] = 0;
-    }
-    average = 0;
-    creationTime = 0;
-    hasDailyReport = false;
+    Reset();
 }
 
 AnticheatData::~AnticheatData()
 {
 }
 
-void AnticheatData::SetDailyReportState(bool b)
+void AnticheatData::Reset()
 {
-    hasDailyReport = b;
+    ResetReports();
+    _lastOpcode = 0;
+    _lastMovementInfo = MovementInfo();
+    _hasDailyReport = false;
 }
 
-bool AnticheatData::GetDailyReportState()
+void AnticheatData::ResetReports()
 {
-    return hasDailyReport;
+    _totalReports = 0;
+    _average = 0;
+    _creationTime = 0;
+    for (uint8 i = 0; i < MAX_REPORT_TYPES; i++)
+    {
+        _typeReports[i] = 0;
+        _tempReports[i] = 0;
+        _tempReportsTimer[i] = 0;
+    }
+}
+
+void AnticheatData::SetDailyReportState(bool b)
+{
+    _hasDailyReport = b;
+}
+
+bool AnticheatData::GetDailyReportState() const
+{
+    return _hasDailyReport;
 }
 
 void AnticheatData::SetLastOpcode(uint32 opcode)
 {
-    lastOpcode = opcode;
+    _lastOpcode = opcode;
 }
 
 void AnticheatData::SetPosition(float x, float y, float z, float o)
 {
-    lastMovementInfo.pos = { x, y, z, o };
+    _lastMovementInfo.pos = { x, y, z, o };
 }
 
 uint32 AnticheatData::GetLastOpcode() const
 {
-    return lastOpcode;
+    return _lastOpcode;
 }
 
-const MovementInfo& AnticheatData::GetLastMovementInfo() const
+MovementInfo const& AnticheatData::GetLastMovementInfo() const
 {
-    return lastMovementInfo;
+    return _lastMovementInfo;
 }
 
-void AnticheatData::SetLastMovementInfo(MovementInfo& moveInfo)
+void AnticheatData::SetLastMovementInfo(MovementInfo const& moveInfo)
 {
-    lastMovementInfo = moveInfo;
+    _lastMovementInfo = moveInfo;
 }
 
 uint32 AnticheatData::GetTotalReports() const
 {
-    return totalReports;
+    return _totalReports;
 }
 
-void AnticheatData::SetTotalReports(uint32 _totalReports)
+void AnticheatData::SetTotalReports(uint32 totalReports)
 {
-    totalReports = _totalReports;
+    _totalReports = totalReports;
 }
 
 void AnticheatData::SetTypeReports(uint32 type, uint32 amount)
 {
-    typeReports[type] = amount;
+    _typeReports[type] = amount;
 }
 
 uint32 AnticheatData::GetTypeReports(uint32 type) const
 {
-    return typeReports[type];
+    return _typeReports[type];
 }
 
 float AnticheatData::GetAverage() const
 {
-    return average;
+    return _average;
 }
 
-void AnticheatData::SetAverage(float _average)
+void AnticheatData::SetAverage(float average)
 {
-    average = _average;
+    _average = average;
 }
 
 uint32 AnticheatData::GetCreationTime() const
 {
-    return creationTime;
+    return _creationTime;
 }
 
-void AnticheatData::SetCreationTime(uint32 _creationTime)
+void AnticheatData::SetCreationTime(uint32 creationTime)
 {
-    creationTime = _creationTime;
+    _creationTime = creationTime;
 }
 
 void AnticheatData::SetTempReports(uint32 amount, uint8 type)
 {
-    tempReports[type] = amount;
+    _tempReports[type] = amount;
 }
 
-uint32 AnticheatData::GetTempReports(uint8 type)
+uint32 AnticheatData::GetTempReports(uint8 type) const
 {
-    return tempReports[type];
+    return _tempReports[type];
 }
 
 void AnticheatData::SetTempReportsTimer(uint32 time, uint8 type)
 {
-    tempReportsTimer[type] = time;
+    _tempReportsTimer[type] = time;
 }
 
-uint32 AnticheatData::GetTempReportsTimer(uint8 type)
+uint32 AnticheatData::GetTempReportsTimer(uint8 type) const
 {
-    return tempReportsTimer[type];
+    return _tempReportsTimer[type];
 }

--- a/src/server/game/Anticheat/AnticheatData.h
+++ b/src/server/game/Anticheat/AnticheatData.h
@@ -18,57 +18,59 @@
 #ifndef SC_ACDATA_H
 #define SC_ACDATA_H
 
-#include "AnticheatMgr.h"
-#include "Player.h"
+#include "Define.h"
+#include "MovementInfo.h"
 
-#define MAX_REPORT_TYPES 6
+constexpr uint8 MAX_REPORT_TYPES = 6;
 
-class AnticheatData
+class TC_GAME_API AnticheatData
 {
 public:
     AnticheatData();
     ~AnticheatData();
 
+    void Reset();
+    void ResetReports();
+
     void SetLastOpcode(uint32 opcode);
     uint32 GetLastOpcode() const;
 
-    const MovementInfo& GetLastMovementInfo() const;
-    void SetLastMovementInfo(MovementInfo& moveInfo);
+    MovementInfo const& GetLastMovementInfo() const;
+    void SetLastMovementInfo(MovementInfo const& moveInfo);
 
     void SetPosition(float x, float y, float z, float o);
 
     uint32 GetTotalReports() const;
-    void SetTotalReports(uint32 _totalReports);
+    void SetTotalReports(uint32 totalReports);
 
     uint32 GetTypeReports(uint32 type) const;
     void SetTypeReports(uint32 type, uint32 amount);
 
     float GetAverage() const;
-    void SetAverage(float _average);
+    void SetAverage(float average);
 
     uint32 GetCreationTime() const;
     void SetCreationTime(uint32 creationTime);
 
     void SetTempReports(uint32 amount, uint8 type);
-    uint32 GetTempReports(uint8 type);
+    uint32 GetTempReports(uint8 type) const;
 
     void SetTempReportsTimer(uint32 time, uint8 type);
-    uint32 GetTempReportsTimer(uint8 type);
+    uint32 GetTempReportsTimer(uint8 type) const;
 
     void SetDailyReportState(bool b);
-    bool GetDailyReportState();
+    bool GetDailyReportState() const;
+
 private:
-    uint32 lastOpcode;
-    MovementInfo lastMovementInfo;
-    //bool disableACCheck;
-    //uint32 disableACCheckTimer;
-    uint32 totalReports;
-    uint32 typeReports[MAX_REPORT_TYPES];
-    float average;
-    uint32 creationTime;
-    uint32 tempReports[MAX_REPORT_TYPES];
-    uint32 tempReportsTimer[MAX_REPORT_TYPES];
-    bool hasDailyReport;
+    uint32 _lastOpcode;
+    MovementInfo _lastMovementInfo;
+    uint32 _totalReports;
+    uint32 _typeReports[MAX_REPORT_TYPES];
+    float _average;
+    uint32 _creationTime;
+    uint32 _tempReports[MAX_REPORT_TYPES];
+    uint32 _tempReportsTimer[MAX_REPORT_TYPES];
+    bool _hasDailyReport;
 };
 
 #endif

--- a/src/server/game/Anticheat/AnticheatMgr.cpp
+++ b/src/server/game/Anticheat/AnticheatMgr.cpp
@@ -26,9 +26,20 @@
 #include "Optional.h"
 #include "PacketUtilities.h"
 #include "Player.h"
+#include "StringFormat.h"
 #include "World.h"
+#include "WorldSession.h"
+#include <cmath>
 
-#define CLIMB_ANGLE 1.9f
+namespace
+{
+    constexpr uint32 DEEPRUN_TRAM_MAP_ID = 369;
+    constexpr float CLIMB_MAX_SLOPE_DEGREES = 85.0f;
+    constexpr float CLIMB_MAX_SLOPE_RADIANS = CLIMB_MAX_SLOPE_DEGREES * float(M_PI) / 180.0f;
+    constexpr float CLIMB_MIN_DISTANCE_2D = 0.1f;
+    constexpr uint32 TEMP_REPORT_WINDOW_MS = 3000;
+    constexpr uint32 TEMP_REPORTS_BEFORE_REPORT = 3;
+}
 
 AnticheatMgr::AnticheatMgr()
 {
@@ -36,30 +47,26 @@ AnticheatMgr::AnticheatMgr()
 
 AnticheatMgr::~AnticheatMgr()
 {
-    m_Players.clear();
 }
 
-void AnticheatMgr::JumpHackDetection(Player* player, MovementInfo /* movementInfo */,uint32 opcode)
+void AnticheatMgr::JumpHackDetection(Player* player, AnticheatData& data, uint32 opcode)
 {
     if ((sWorld->getIntConfig(CONFIG_ANTICHEAT_DETECTIONS_ENABLED) & JUMP_HACK_DETECTION) == 0)
         return;
 
-    uint32 key = player->GetGUID().GetCounter();
-
-    if (m_Players[key].GetLastOpcode() == CMSG_MOVE_JUMP && opcode == CMSG_MOVE_JUMP)
+    if (data.GetLastOpcode() == CMSG_MOVE_JUMP && opcode == CMSG_MOVE_JUMP)
     {
-        BuildReport(player,JUMP_HACK_REPORT);
-        TC_LOG_DEBUG("entities.player.character", "AnticheatMgr:: Jump-Hack detected player GUID (low) %u",player->GetGUID().GetCounter());
+        BuildReport(player, data, JUMP_HACK_REPORT);
+        TC_LOG_DEBUG("entities.player.character", "AnticheatMgr:: Jump-Hack detected player GUID (low) %u", player->GetGUID().GetCounter());
     }
 }
 
-void AnticheatMgr::WalkOnWaterHackDetection(Player* player, MovementInfo /* movementInfo */)
+void AnticheatMgr::WalkOnWaterHackDetection(Player* player, AnticheatData& data)
 {
     if ((sWorld->getIntConfig(CONFIG_ANTICHEAT_DETECTIONS_ENABLED) & WALK_WATER_HACK_DETECTION) == 0)
         return;
 
-    uint32 key = player->GetGUID().GetCounter();
-    if (!m_Players[key].GetLastMovementInfo().HasMovementFlag(MOVEMENTFLAG_WATERWALKING))
+    if (!data.GetLastMovementInfo().HasMovementFlag(MOVEMENTFLAG_WATERWALKING))
         return;
 
     // if we are a ghost we can walk on water
@@ -71,18 +78,16 @@ void AnticheatMgr::WalkOnWaterHackDetection(Player* player, MovementInfo /* move
         player->HasAuraType(SPELL_AURA_WATER_WALK))
         return;
 
-    TC_LOG_DEBUG("entities.player.character", "AnticheatMgr:: Walk on Water - Hack detected player GUID (low) %u",player->GetGUID().GetCounter());
-    BuildReport(player,WALK_WATER_HACK_REPORT);
-
+    TC_LOG_DEBUG("entities.player.character", "AnticheatMgr:: Walk on Water - Hack detected player GUID (low) %u", player->GetGUID().GetCounter());
+    BuildReport(player, data, WALK_WATER_HACK_REPORT);
 }
 
-void AnticheatMgr::FlyHackDetection(Player* player, MovementInfo /* movementInfo */)
+void AnticheatMgr::FlyHackDetection(Player* player, AnticheatData& data)
 {
     if ((sWorld->getIntConfig(CONFIG_ANTICHEAT_DETECTIONS_ENABLED) & FLY_HACK_DETECTION) == 0)
         return;
 
-    uint32 key = player->GetGUID().GetCounter();
-    if (!m_Players[key].GetLastMovementInfo().HasMovementFlag(MOVEMENTFLAG_FLYING))
+    if (!data.GetLastMovementInfo().HasMovementFlag(MOVEMENTFLAG_FLYING))
         return;
 
     if (player->HasAuraType(SPELL_AURA_FLY) ||
@@ -90,18 +95,16 @@ void AnticheatMgr::FlyHackDetection(Player* player, MovementInfo /* movementInfo
         player->HasAuraType(SPELL_AURA_MOD_INCREASE_FLIGHT_SPEED))
         return;
 
-    TC_LOG_DEBUG("entities.player.character", "AnticheatMgr:: Fly-Hack detected player GUID (low) %u",player->GetGUID().GetCounter());
-    BuildReport(player,FLY_HACK_REPORT);
+    TC_LOG_DEBUG("entities.player.character", "AnticheatMgr:: Fly-Hack detected player GUID (low) %u", player->GetGUID().GetCounter());
+    BuildReport(player, data, FLY_HACK_REPORT);
 }
 
-void AnticheatMgr::TeleportPlaneHackDetection(Player* player, MovementInfo movementInfo)
+void AnticheatMgr::TeleportPlaneHackDetection(Player* player, AnticheatData& data, MovementInfo const& movementInfo)
 {
     if ((sWorld->getIntConfig(CONFIG_ANTICHEAT_DETECTIONS_ENABLED) & TELEPORT_PLANE_HACK_DETECTION) == 0)
         return;
 
-    uint32 key = player->GetGUID().GetCounter();
-
-    if (m_Players[key].GetLastMovementInfo().pos.GetPositionZ() != 0 ||
+    if (data.GetLastMovementInfo().pos.GetPositionZ() != 0 ||
         movementInfo.pos.GetPositionZ() != 0)
         return;
 
@@ -116,12 +119,12 @@ void AnticheatMgr::TeleportPlaneHackDetection(Player* player, MovementInfo movem
     // we are not really walking there
     if (z_diff > 1.0f)
     {
-        TC_LOG_DEBUG("entities.player.character", "AnticheatMgr:: Teleport To Plane - Hack detected player GUID (low) %u",player->GetGUID().GetCounter());
-        BuildReport(player,TELEPORT_PLANE_HACK_REPORT);
+        TC_LOG_DEBUG("entities.player.character", "AnticheatMgr:: Teleport To Plane - Hack detected player GUID (low) %u", player->GetGUID().GetCounter());
+        BuildReport(player, data, TELEPORT_PLANE_HACK_REPORT);
     }
 }
 
-void AnticheatMgr::StartHackDetection(Player* player, MovementInfo movementInfo, uint32 opcode)
+void AnticheatMgr::StartHackDetection(Player* player, MovementInfo const& movementInfo, uint32 opcode)
 {
     if (!sWorld->getBoolConfig(CONFIG_ANTICHEAT_ENABLE))
         return;
@@ -129,36 +132,34 @@ void AnticheatMgr::StartHackDetection(Player* player, MovementInfo movementInfo,
     if (player->IsGameMaster() || player->GetSession()->GetSecurity() > SEC_PLAYER)
         return;
 
-    uint32 key = player->GetGUID().GetCounter();
+    AnticheatData& data = player->GetSession()->GetAnticheatData();
 
     if (player->IsInFlight() || player->GetTransport() || player->GetVehicle())
     {
-        m_Players[key].SetLastMovementInfo(movementInfo);
-        m_Players[key].SetLastOpcode(opcode);
+        data.SetLastMovementInfo(movementInfo);
+        data.SetLastOpcode(opcode);
         return;
     }
 
-    SpeedHackDetection(player,movementInfo);
-    FlyHackDetection(player,movementInfo);
-    WalkOnWaterHackDetection(player,movementInfo);
-    JumpHackDetection(player,movementInfo,opcode);
-    TeleportPlaneHackDetection(player, movementInfo);
-    ClimbHackDetection(player,movementInfo,opcode);
+    SpeedHackDetection(player, data, movementInfo);
+    FlyHackDetection(player, data);
+    WalkOnWaterHackDetection(player, data);
+    JumpHackDetection(player, data, opcode);
+    TeleportPlaneHackDetection(player, data, movementInfo);
+    ClimbHackDetection(player, data, movementInfo, opcode);
 
-    m_Players[key].SetLastMovementInfo(movementInfo);
-    m_Players[key].SetLastOpcode(opcode);
+    data.SetLastMovementInfo(movementInfo);
+    data.SetLastOpcode(opcode);
 }
 
 // basic detection
-void AnticheatMgr::ClimbHackDetection(Player *player, MovementInfo movementInfo, uint32 opcode)
+void AnticheatMgr::ClimbHackDetection(Player* player, AnticheatData& data, MovementInfo const& movementInfo, uint32 opcode)
 {
     if ((sWorld->getIntConfig(CONFIG_ANTICHEAT_DETECTIONS_ENABLED) & CLIMB_HACK_DETECTION) == 0)
         return;
 
-    uint32 key = player->GetGUID().GetCounter();
-
     if (opcode != CMSG_MOVE_HEARTBEAT ||
-        m_Players[key].GetLastOpcode() != CMSG_MOVE_HEARTBEAT)
+        data.GetLastOpcode() != CMSG_MOVE_HEARTBEAT)
         return;
 
     // in this case we don't care if they are "legal" flags, they are handled in another parts of the Anticheat Manager.
@@ -167,34 +168,34 @@ void AnticheatMgr::ClimbHackDetection(Player *player, MovementInfo movementInfo,
         player->IsFalling())
         return;
 
-    Position playerPos;
+    Position const& lastPos = data.GetLastMovementInfo().pos;
 
-    float deltaZ = fabs(playerPos.GetPositionZ() - movementInfo.pos.GetPositionZ());
-    float deltaXY = movementInfo.pos.GetExactDist2d(&playerPos);
+    float deltaZ = std::fabs(lastPos.GetPositionZ() - movementInfo.pos.GetPositionZ());
+    float deltaXY = movementInfo.pos.GetExactDist2d(lastPos);
 
-    float angle = Position::NormalizeOrientation(tan(deltaZ/deltaXY));
+    if (deltaXY < CLIMB_MIN_DISTANCE_2D)
+        return;
 
-    if (angle > CLIMB_ANGLE)
+    float angle = std::atan2(deltaZ, deltaXY);
+
+    if (angle > CLIMB_MAX_SLOPE_RADIANS)
     {
         TC_LOG_DEBUG("entities.player.character", "AnticheatMgr:: Climb-Hack detected player GUID (low) %u", player->GetGUID().GetCounter());
-        BuildReport(player,CLIMB_HACK_REPORT);
+        BuildReport(player, data, CLIMB_HACK_REPORT);
     }
 }
 
-void AnticheatMgr::SpeedHackDetection(Player* player,MovementInfo movementInfo)
+void AnticheatMgr::SpeedHackDetection(Player* player, AnticheatData& data, MovementInfo const& movementInfo)
 {
     if ((sWorld->getIntConfig(CONFIG_ANTICHEAT_DETECTIONS_ENABLED) & SPEED_HACK_DETECTION) == 0)
         return;
 
-    uint32 key = player->GetGUID().GetCounter();
-
     // We also must check the map because the movementFlag can be modified by the client.
     // If we just check the flag, they could always add that flag and always skip the speed hacking detection.
-    // 369 == DEEPRUN TRAM
-    if (m_Players[key].GetLastMovementInfo().HasMovementFlag(!movementInfo.transport.guid.IsEmpty()) && player->GetMapId() == 369)
+    if (!movementInfo.transport.guid.IsEmpty() && player->GetMapId() == DEEPRUN_TRAM_MAP_ID)
         return;
 
-    uint32 distance2D = (uint32)movementInfo.pos.GetExactDist2d(&m_Players[key].GetLastMovementInfo().pos);
+    uint32 distance2D = (uint32)movementInfo.pos.GetExactDist2d(&data.GetLastMovementInfo().pos);
     uint8 moveType = 0;
 
     // we need to know HOW is the player moving
@@ -212,19 +213,19 @@ void AnticheatMgr::SpeedHackDetection(Player* player,MovementInfo movementInfo)
     uint32 speedRate = (uint32)(player->GetSpeed(UnitMoveType(moveType)) + movementInfo.jump.xyspeed);
 
     // how long the player took to move to here.
-    uint32 timeDiff = getMSTimeDiff(m_Players[key].GetLastMovementInfo().time,movementInfo.time);
+    uint32 timeDiff = getMSTimeDiff(data.GetLastMovementInfo().time, movementInfo.time);
 
     if (!timeDiff)
         timeDiff = 1;
 
     // this is the distance doable by the player in 1 sec, using the time done to move to this point.
-    uint32 clientSpeedRate = distance2D * 1000 / timeDiff;
+    uint32 clientSpeedRate = distance2D * IN_MILLISECONDS / timeDiff;
 
     // we did the (uint32) cast to accept a margin of tolerance
     if (clientSpeedRate > speedRate)
     {
-        BuildReport(player,SPEED_HACK_REPORT);
-        TC_LOG_DEBUG("entities.player.character", "AnticheatMgr:: Speed-Hack detected player GUID (low) %u",player->GetGUID().GetCounter());
+        BuildReport(player, data, SPEED_HACK_REPORT);
+        TC_LOG_DEBUG("entities.player.character", "AnticheatMgr:: Speed-Hack detected player GUID (low) %u", player->GetGUID().GetCounter());
     }
 }
 
@@ -235,14 +236,26 @@ void AnticheatMgr::StartScripts()
 
 void AnticheatMgr::HandlePlayerLogin(Player* player)
 {
-    // we must delete this to prevent errors in case of crash
-    CharacterDatabase.PExecute("DELETE FROM players_reports_status WHERE guid=%u",player->GetGUID().GetCounter());
-    // we initialize the pos of lastMovementPosition var.
-    m_Players[player->GetGUID().GetCounter()].SetPosition(player->GetPositionX(),player->GetPositionY(),player->GetPositionZ(),player->GetOrientation());
-    QueryResult resultDB = CharacterDatabase.PQuery("SELECT * FROM daily_players_reports WHERE guid=%u;",player->GetGUID().GetCounter());
+    AnticheatData& data = player->GetSession()->GetAnticheatData();
+    data.Reset();
 
-    if (resultDB)
-        m_Players[player->GetGUID().GetCounter()].SetDailyReportState(true);
+    // we must delete this to prevent errors in case of crash
+    CharacterDatabase.PExecute("DELETE FROM players_reports_status WHERE guid=%u", player->GetGUID().GetCounter());
+    // we initialize the pos of lastMovementPosition var.
+    data.SetPosition(player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(), player->GetOrientation());
+
+    ObjectGuid guid = player->GetGUID();
+    std::string query = Trinity::StringFormat("SELECT guid FROM daily_players_reports WHERE guid=%u", guid.GetCounter());
+
+    player->GetSession()->GetQueryProcessor().AddCallback(
+        CharacterDatabase.AsyncQuery(query.c_str()).WithCallback([guid](QueryResult result)
+    {
+        if (!result)
+            return;
+
+        if (Player* found = ObjectAccessor::FindConnectedPlayer(guid))
+            found->GetSession()->GetAnticheatData().SetDailyReportState(true);
+    }));
 }
 
 void AnticheatMgr::HandlePlayerLogout(Player* player)
@@ -250,29 +263,41 @@ void AnticheatMgr::HandlePlayerLogout(Player* player)
     // TO-DO Make a table that stores the cheaters of the day, with more detailed information.
 
     // We must also delete it at logout to prevent have data of offline players in the db when we query the database (IE: The GM Command)
-    CharacterDatabase.PExecute("DELETE FROM players_reports_status WHERE guid=%u",player->GetGUID().GetCounter());
-    // Delete not needed data from the memory.
-    m_Players.erase(player->GetGUID().GetCounter());
+    CharacterDatabase.PExecute("DELETE FROM players_reports_status WHERE guid=%u", player->GetGUID().GetCounter());
+
+    player->GetSession()->GetAnticheatData().Reset();
 }
 
 void AnticheatMgr::SavePlayerData(Player* player)
 {
-    CharacterDatabase.PExecute("REPLACE INTO players_reports_status (guid,average,total_reports,speed_reports,fly_reports,jump_reports,waterwalk_reports,teleportplane_reports,climb_reports,creation_time) VALUES (%u,%f,%u,%u,%u,%u,%u,%u,%u,%u);",player->GetGUID().GetCounter(),m_Players[player->GetGUID().GetCounter()].GetAverage(),m_Players[player->GetGUID().GetCounter()].GetTotalReports(), m_Players[player->GetGUID().GetCounter()].GetTypeReports(SPEED_HACK_REPORT),m_Players[player->GetGUID().GetCounter()].GetTypeReports(FLY_HACK_REPORT),m_Players[player->GetGUID().GetCounter()].GetTypeReports(JUMP_HACK_REPORT),m_Players[player->GetGUID().GetCounter()].GetTypeReports(WALK_WATER_HACK_REPORT),m_Players[player->GetGUID().GetCounter()].GetTypeReports(TELEPORT_PLANE_HACK_REPORT),m_Players[player->GetGUID().GetCounter()].GetTypeReports(CLIMB_HACK_REPORT),m_Players[player->GetGUID().GetCounter()].GetCreationTime());
+    AnticheatData const& data = player->GetSession()->GetAnticheatData();
+
+    CharacterDatabase.PExecute("REPLACE INTO players_reports_status (guid,average,total_reports,speed_reports,fly_reports,jump_reports,waterwalk_reports,teleportplane_reports,climb_reports,creation_time) VALUES (%u,%f,%u,%u,%u,%u,%u,%u,%u,%u);",
+        player->GetGUID().GetCounter(),
+        data.GetAverage(),
+        data.GetTotalReports(),
+        data.GetTypeReports(SPEED_HACK_REPORT),
+        data.GetTypeReports(FLY_HACK_REPORT),
+        data.GetTypeReports(JUMP_HACK_REPORT),
+        data.GetTypeReports(WALK_WATER_HACK_REPORT),
+        data.GetTypeReports(TELEPORT_PLANE_HACK_REPORT),
+        data.GetTypeReports(CLIMB_HACK_REPORT),
+        data.GetCreationTime());
 }
 
-uint32 AnticheatMgr::GetTotalReports(uint32 lowGUID)
+uint32 AnticheatMgr::GetTotalReports(Player* player)
 {
-    return m_Players[lowGUID].GetTotalReports();
+    return player->GetSession()->GetAnticheatData().GetTotalReports();
 }
 
-float AnticheatMgr::GetAverage(uint32 lowGUID)
+float AnticheatMgr::GetAverage(Player* player)
 {
-    return m_Players[lowGUID].GetAverage();
+    return player->GetSession()->GetAnticheatData().GetAverage();
 }
 
-uint32 AnticheatMgr::GetTypeReports(uint32 lowGUID, uint8 type)
+uint32 AnticheatMgr::GetTypeReports(Player* player, uint8 type)
 {
-    return m_Players[lowGUID].GetTypeReports(type);
+    return player->GetSession()->GetAnticheatData().GetTypeReports(type);
 }
 
 bool AnticheatMgr::MustCheckTempReports(uint8 type)
@@ -283,60 +308,69 @@ bool AnticheatMgr::MustCheckTempReports(uint8 type)
     return true;
 }
 
-void AnticheatMgr::BuildReport(Player* player,uint8 reportType)
+void AnticheatMgr::BuildReport(Player* player, AnticheatData& data, uint8 reportType)
 {
-    uint32 key = player->GetGUID().GetCounter();
-
     if (MustCheckTempReports(reportType))
     {
         uint32 actualTime = getMSTime();
 
-        if (!m_Players[key].GetTempReportsTimer(reportType))
-            m_Players[key].SetTempReportsTimer(actualTime,reportType);
+        if (!data.GetTempReportsTimer(reportType))
+            data.SetTempReportsTimer(actualTime, reportType);
 
-        if (getMSTimeDiff(m_Players[key].GetTempReportsTimer(reportType),actualTime) < 3000)
+        if (getMSTimeDiff(data.GetTempReportsTimer(reportType), actualTime) < TEMP_REPORT_WINDOW_MS)
         {
-            m_Players[key].SetTempReports(m_Players[key].GetTempReports(reportType)+1,reportType);
+            data.SetTempReports(data.GetTempReports(reportType) + 1, reportType);
 
-            if (m_Players[key].GetTempReports(reportType) < 3)
+            if (data.GetTempReports(reportType) < TEMP_REPORTS_BEFORE_REPORT)
                 return;
-        } else
+        }
+        else
         {
-            m_Players[key].SetTempReportsTimer(actualTime,reportType);
-            m_Players[key].SetTempReports(1,reportType);
+            data.SetTempReportsTimer(actualTime, reportType);
+            data.SetTempReports(1, reportType);
             return;
         }
     }
 
     // generating creationTime for average calculation
-    if (!m_Players[key].GetTotalReports())
-        m_Players[key].SetCreationTime(getMSTime());
+    if (!data.GetTotalReports())
+        data.SetCreationTime(getMSTime());
 
     // increasing total_reports
-    m_Players[key].SetTotalReports(m_Players[key].GetTotalReports()+1);
+    data.SetTotalReports(data.GetTotalReports() + 1);
     // increasing specific cheat report
-    m_Players[key].SetTypeReports(reportType,m_Players[key].GetTypeReports(reportType)+1);
+    data.SetTypeReports(reportType, data.GetTypeReports(reportType) + 1);
 
     // diff time for average calculation
-    uint32 diffTime = getMSTimeDiff(m_Players[key].GetCreationTime(),getMSTime()) / IN_MILLISECONDS;
+    uint32 diffTime = getMSTimeDiff(data.GetCreationTime(), getMSTime()) / IN_MILLISECONDS;
 
     if (diffTime > 0)
     {
         // Average == Reports per second
-        float average = float(m_Players[key].GetTotalReports()) / float(diffTime);
-        m_Players[key].SetAverage(average);
+        float average = float(data.GetTotalReports()) / float(diffTime);
+        data.SetAverage(average);
     }
 
-    if (sWorld->getIntConfig(CONFIG_ANTICHEAT_MAX_REPORTS_FOR_DAILY_REPORT) < m_Players[key].GetTotalReports())
+    if (sWorld->getIntConfig(CONFIG_ANTICHEAT_MAX_REPORTS_FOR_DAILY_REPORT) < data.GetTotalReports())
     {
-        if (!m_Players[key].GetDailyReportState())
+        if (!data.GetDailyReportState())
         {
-            CharacterDatabase.PExecute("REPLACE INTO daily_players_reports (guid,average,total_reports,speed_reports,fly_reports,jump_reports,waterwalk_reports,teleportplane_reports,climb_reports,creation_time) VALUES (%u,%f,%u,%u,%u,%u,%u,%u,%u,%u);",player->GetGUID().GetCounter(),m_Players[player->GetGUID().GetCounter()].GetAverage(),m_Players[player->GetGUID().GetCounter()].GetTotalReports(), m_Players[player->GetGUID().GetCounter()].GetTypeReports(SPEED_HACK_REPORT),m_Players[player->GetGUID().GetCounter()].GetTypeReports(FLY_HACK_REPORT),m_Players[player->GetGUID().GetCounter()].GetTypeReports(JUMP_HACK_REPORT),m_Players[player->GetGUID().GetCounter()].GetTypeReports(WALK_WATER_HACK_REPORT),m_Players[player->GetGUID().GetCounter()].GetTypeReports(TELEPORT_PLANE_HACK_REPORT),m_Players[player->GetGUID().GetCounter()].GetTypeReports(CLIMB_HACK_REPORT),m_Players[player->GetGUID().GetCounter()].GetCreationTime());
-            m_Players[key].SetDailyReportState(true);
+            CharacterDatabase.PExecute("REPLACE INTO daily_players_reports (guid,average,total_reports,speed_reports,fly_reports,jump_reports,waterwalk_reports,teleportplane_reports,climb_reports,creation_time) VALUES (%u,%f,%u,%u,%u,%u,%u,%u,%u,%u);",
+                player->GetGUID().GetCounter(),
+                data.GetAverage(),
+                data.GetTotalReports(),
+                data.GetTypeReports(SPEED_HACK_REPORT),
+                data.GetTypeReports(FLY_HACK_REPORT),
+                data.GetTypeReports(JUMP_HACK_REPORT),
+                data.GetTypeReports(WALK_WATER_HACK_REPORT),
+                data.GetTypeReports(TELEPORT_PLANE_HACK_REPORT),
+                data.GetTypeReports(CLIMB_HACK_REPORT),
+                data.GetCreationTime());
+            data.SetDailyReportState(true);
         }
     }
 
-    if (m_Players[key].GetTotalReports() > sWorld->getIntConfig(CONFIG_ANTICHEAT_REPORTS_INGAME_NOTIFICATION))
+    if (data.GetTotalReports() > sWorld->getIntConfig(CONFIG_ANTICHEAT_REPORTS_INGAME_NOTIFICATION))
     {
         std::string str = "";
         str = "|cFFFFFC00[AC]|cFF00FFFF[|cFF60FF00" + std::string(player->GetName().c_str()) + "|cFF00FFFF] Possible cheater!";
@@ -398,41 +432,23 @@ void AnticheatMgr::AnticheatGlobalCommand(ChatHandler* handler)
     }
 }
 
-void AnticheatMgr::AnticheatDeleteCommand(uint32 guid)
+void AnticheatMgr::AnticheatDeleteCommand(Player* player)
 {
-    if (!guid)
-    {
-        for (AnticheatPlayersDataMap::iterator it = m_Players.begin(); it != m_Players.end(); ++it)
-        {
-            (*it).second.SetTotalReports(0);
-            (*it).second.SetAverage(0);
-            (*it).second.SetCreationTime(0);
-            for (uint8 i = 0; i < MAX_REPORT_TYPES; i++)
-            {
-                (*it).second.SetTempReports(0,i);
-                (*it).second.SetTempReportsTimer(0,i);
-                (*it).second.SetTypeReports(i,0);
-            }
-        }
-        CharacterDatabase.PExecute("DELETE FROM players_reports_status;");
-    }
-    else
-    {
-        m_Players[guid].SetTotalReports(0);
-        m_Players[guid].SetAverage(0);
-        m_Players[guid].SetCreationTime(0);
-        for (uint8 i = 0; i < MAX_REPORT_TYPES; i++)
-        {
-            m_Players[guid].SetTempReports(0,i);
-            m_Players[guid].SetTempReportsTimer(0,i);
-            m_Players[guid].SetTypeReports(i,0);
-        }
-        CharacterDatabase.PExecute("DELETE FROM players_reports_status WHERE guid=%u;",guid);
-    }
+    player->GetSession()->GetAnticheatData().ResetReports();
+
+    CharacterDatabase.PExecute("DELETE FROM players_reports_status WHERE guid=%u;", player->GetGUID().GetCounter());
+}
+
+void AnticheatMgr::AnticheatDeleteAllCommand()
+{
+    for (auto const& sessionPair : sWorld->GetAllSessions())
+        sessionPair.second->GetAnticheatData().ResetReports();
+
+    CharacterDatabase.PExecute("DELETE FROM players_reports_status;");
 }
 
 void AnticheatMgr::ResetDailyReportStates()
 {
-     for (AnticheatPlayersDataMap::iterator it = m_Players.begin(); it != m_Players.end(); ++it)
-         m_Players[(*it).first].SetDailyReportState(false);
+    for (auto const& sessionPair : sWorld->GetAllSessions())
+        sessionPair.second->GetAnticheatData().SetDailyReportState(false);
 }

--- a/src/server/game/Anticheat/AnticheatMgr.h
+++ b/src/server/game/Anticheat/AnticheatMgr.h
@@ -26,7 +26,6 @@
 #include "Player.h"
 
 class Player;
-class AnticheatData;
 
 enum ReportTypes
 {
@@ -36,8 +35,6 @@ enum ReportTypes
     JUMP_HACK_REPORT,
     TELEPORT_PLANE_HACK_REPORT,
     CLIMB_HACK_REPORT,
-
-   // MAX_REPORT_TYPES
 };
 
 enum DetectionTypes
@@ -49,9 +46,6 @@ enum DetectionTypes
     TELEPORT_PLANE_HACK_DETECTION   = 16,
     CLIMB_HACK_DETECTION            = 32
 };
-
-// GUIDLow is the key.
-typedef std::map<uint32, AnticheatData> AnticheatPlayersDataMap;
 
 class TC_GAME_API AnticheatMgr
 {
@@ -65,10 +59,7 @@ class TC_GAME_API AnticheatMgr
            return instance;
         }
 
-        void StartHackDetection(Player* player, MovementInfo movementInfo, uint32 opcode);
-        void DeletePlayerReport(Player* player, bool login);
-        void DeletePlayerData(Player* player);
-        void CreatePlayerData(Player* player);
+        void StartHackDetection(Player* player, MovementInfo const& movementInfo, uint32 opcode);
         void SavePlayerData(Player* player);
 
         void StartScripts();
@@ -76,27 +67,26 @@ class TC_GAME_API AnticheatMgr
         void HandlePlayerLogin(Player* player);
         void HandlePlayerLogout(Player* player);
 
-        uint32 GetTotalReports(uint32 lowGUID);
-        float GetAverage(uint32 lowGUID);
-        uint32 GetTypeReports(uint32 lowGUID, uint8 type);
+        uint32 GetTotalReports(Player* player);
+        float GetAverage(Player* player);
+        uint32 GetTypeReports(Player* player, uint8 type);
 
         void AnticheatGlobalCommand(ChatHandler* handler);
-        void AnticheatDeleteCommand(uint32 guid);
+        void AnticheatDeleteCommand(Player* player);
+        void AnticheatDeleteAllCommand();
 
         void ResetDailyReportStates();
     private:
-        void SpeedHackDetection(Player* player, MovementInfo movementInfo);
-        void FlyHackDetection(Player* player, MovementInfo movementInfo);
-        void WalkOnWaterHackDetection(Player* player, MovementInfo movementInfo);
-        void JumpHackDetection(Player* player, MovementInfo movementInfo,uint32 opcode);
-        void TeleportPlaneHackDetection(Player* player, MovementInfo);
-        void ClimbHackDetection(Player* player,MovementInfo movementInfo,uint32 opcode);
+        void SpeedHackDetection(Player* player, AnticheatData& data, MovementInfo const& movementInfo);
+        void FlyHackDetection(Player* player, AnticheatData& data);
+        void WalkOnWaterHackDetection(Player* player, AnticheatData& data);
+        void JumpHackDetection(Player* player, AnticheatData& data, uint32 opcode);
+        void TeleportPlaneHackDetection(Player* player, AnticheatData& data, MovementInfo const& movementInfo);
+        void ClimbHackDetection(Player* player, AnticheatData& data, MovementInfo const& movementInfo, uint32 opcode);
 
-        void BuildReport(Player* player,uint8 reportType);
+        void BuildReport(Player* player, AnticheatData& data, uint8 reportType);
 
         bool MustCheckTempReports(uint8 type);
-
-        AnticheatPlayersDataMap m_Players;                        ///< Player data
 };
 
 #define sAnticheatMgr AnticheatMgr::instance()

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -23,6 +23,7 @@
 #define __WORLDSESSION_H
 
 #include "Common.h"
+#include "AnticheatData.h"
 #include "AsyncCallbackProcessor.h"
 #include "AuthDefines.h"
 #include "DatabaseEnvFwd.h"
@@ -2079,8 +2080,12 @@ class TC_GAME_API WorldSession
         QueryCallbackProcessor& GetQueryProcessor() { return _queryProcessor; }
         TransactionCallback& AddTransactionCallback(TransactionCallback&& callback);
 
+        AnticheatData& GetAnticheatData() { return _anticheatData; }
+
     private:
         void ProcessQueryCallbacks();
+
+        AnticheatData _anticheatData;
 
         QueryResultHolderFuture _realmAccountLoginCallback;
         QueryResultHolderFuture _accountLoginCallback;

--- a/src/server/scripts/Commands/cs_anticheat.cpp
+++ b/src/server/scripts/Commands/cs_anticheat.cpp
@@ -155,7 +155,7 @@ public:
         strCommand = command;
 
         if (strCommand.compare("deleteall") == 0)
-            sAnticheatMgr->AnticheatDeleteCommand(0);
+            sAnticheatMgr->AnticheatDeleteAllCommand();
         else
         {
             normalizePlayerName(strCommand);
@@ -163,7 +163,7 @@ public:
             if (!player)
                 handler->PSendSysMessage("Player doesn't exist");
             else
-                sAnticheatMgr->AnticheatDeleteCommand(player->GetGUID().GetCounter());
+                sAnticheatMgr->AnticheatDeleteCommand(player);
         }
 
         return true;
@@ -178,7 +178,6 @@ public:
 
         char* command = strtok((char*)args, " ");
 
-        uint32 guid = 0;
         Player* player = NULL;
 
         if (command)
@@ -187,30 +186,25 @@ public:
 
             normalizePlayerName(strCommand);
             player = ObjectAccessor::FindPlayerByName(strCommand.c_str()); // get player by name
-
-            if (player)
-                guid = player->GetGUID().GetCounter();
         }else
         {
             player = handler->getSelectedPlayer();
-            if (player)
-                guid = player->GetGUID().GetCounter();
         }
 
-        if (!guid)
+        if (!player)
         {
             handler->PSendSysMessage("There is no player.");
             return true;
         }
 
-        float average = sAnticheatMgr->GetAverage(guid);
-        uint32 total_reports = sAnticheatMgr->GetTotalReports(guid);
-        uint32 speed_reports = sAnticheatMgr->GetTypeReports(guid,0);
-        uint32 fly_reports = sAnticheatMgr->GetTypeReports(guid,1);
-        uint32 jump_reports = sAnticheatMgr->GetTypeReports(guid,3);
-        uint32 waterwalk_reports = sAnticheatMgr->GetTypeReports(guid,2);
-        uint32 teleportplane_reports = sAnticheatMgr->GetTypeReports(guid,4);
-        uint32 climb_reports = sAnticheatMgr->GetTypeReports(guid,5);
+        float average = sAnticheatMgr->GetAverage(player);
+        uint32 total_reports = sAnticheatMgr->GetTotalReports(player);
+        uint32 speed_reports = sAnticheatMgr->GetTypeReports(player, SPEED_HACK_REPORT);
+        uint32 fly_reports = sAnticheatMgr->GetTypeReports(player, FLY_HACK_REPORT);
+        uint32 jump_reports = sAnticheatMgr->GetTypeReports(player, JUMP_HACK_REPORT);
+        uint32 waterwalk_reports = sAnticheatMgr->GetTypeReports(player, WALK_WATER_HACK_REPORT);
+        uint32 teleportplane_reports = sAnticheatMgr->GetTypeReports(player, TELEPORT_PLANE_HACK_REPORT);
+        uint32 climb_reports = sAnticheatMgr->GetTypeReports(player, CLIMB_HACK_REPORT);
 
         handler->PSendSysMessage("Information about player %s",player->GetName().c_str());
         handler->PSendSysMessage("Average: %f || Total Reports: %u ",average,total_reports);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

This is one change because all three issues live in the same functions — splitting them would only produce guaranteed merge conflicts.

### Data race on the shared player map (#248)

`AnticheatMgr` kept every player's state in one unsynchronized `std::map` keyed by GUID counter. Movement opcodes are `PROCESS_THREADSAFE`, so `MapSessionFilter::Process` admits them into `Map::Update` and they run on the **map update thread pool**, where `MapManager::Update` runs two maps concurrently. Every movement packet reached `m_Players[key]`, and `std::map::operator[]` *inserts* — so players on different maps structurally modified the same tree at once. `HandlePlayerLogout` erased from it, `SavePlayerData` touched it ten times from `Player::SaveToDB`, and `ResetDailyReportStates` iterated it from the world thread while map threads inserted.

`AnticheatData` now lives on `WorldSession`. A session's packets are drained by whichever map its player is on, so the state gains the same thread affinity as the rest of the object graph and the shared container is gone. It is reset on login so a second character on the same session cannot inherit the previous one's reports. The two cross-thread callers that remain — `ResetDailyReportStates` and the delete-all command — walk the session map from the world thread and no longer race an insert.

To let `WorldSession` hold it, `AnticheatData.h` no longer includes `AnticheatMgr.h` and `Player.h`; it needs only `MovementInfo.h`, which broke the include cycle.

### Per-packet cost (#251)

`MovementInfo` was taken **by value** through seven frames on every movement packet and is now passed by const reference. The detections receive the already-resolved `AnticheatData`, removing roughly fifteen map lookups per packet. The blocking `PQuery` in `HandlePlayerLogin` is now an async query through the session query processor.

### Broken detection math (#254)

`ClimbHackDetection` measured against a **default-constructed** `Position`, so every delta was computed against the world origin rather than the player's previous position, and it divided by `deltaXY` with no zero check. It now uses the stored last position, skips samples with no horizontal movement, and takes `atan2` instead of `tan` — which was returning a tangent where an angle was expected.

The old `1.9f` threshold cannot be produced by an angle in radians (`atan2` maxes at π/2 ≈ 1.5708), so once the math is corrected the detection could never fire. Rather than leave it dead, the threshold is now an explicit 85° slope limit expressed in degrees and converted.

`SpeedHackDetection` called `HasMovementFlag` with the result of `!transport.guid.IsEmpty()`, passing a `bool` where a flag mask belongs — so it tested `MOVEMENTFLAG_FORWARD`. It now checks the transport directly.

### Cleanup

Report type indices at the GM command call site were bare integers and now use the `ReportTypes` enumerators; the mapping is unchanged and was checked value by value. `DeletePlayerReport`, `DeletePlayerData` and `CreatePlayerData` were declared but never defined or called, and are removed.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Tool: Claude Code. Model: Claude Opus 5.** Used for the static analysis that found the issues and for drafting the change; the dispatch path, every `sAnticheatMgr` call site and the report-type index mapping were verified against the source in this repository before submitting.

## Issues Addressed:
- Closes #248
- Closes #251
- Closes #254

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Not applicable — these are defects in this repository's own code. Verified by tracing dispatch through `MapSessionFilter::Process` and `Map::AddPlayerToMap`.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Compile-verified only: `worldserver` builds clean on Windows with Visual Studio 2022, `RelWithDebInfo`. **Not tested in-game.**

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing.

1. With `Anticheat.Enable = 1`, move several characters across several maps at once and confirm the server stays up and reports accumulate per character.
2. Relog a character and confirm `.anticheat player <name>` shows a clean slate rather than the previous character's counters.
3. Run `.anticheat player`, `.anticheat global`, `.anticheat delete <name>` and `.anticheat delete deleteall` and confirm each still reports and clears correctly.
4. **Climb detection needs a judgement call from a maintainer**: it has been dead since it was written, so enabling it is effectively a new detection. Test with a legitimate player on steep terrain before trusting it — 85° is a starting threshold, not a measured one.

## Known Issues and TODO List:

- [ ] The climb threshold (85°) is a chosen value, not one derived from live behaviour. It should be tuned against real terrain before the detection is relied on for enforcement.
- [ ] The SQL in `AnticheatMgr` is left as raw statements in this PR; converting it to prepared statements is #252 and is handled separately so this PR stays reviewable.
