### PR TITLE
core/Scripts: stop boost items from destroying full bags

### DIFF
--- a/src/server/scripts/Custom/custom_npcs.cpp
+++ b/src/server/scripts/Custom/custom_npcs.cpp
@@ -18,9 +18,11 @@
 #include "DatabaseEnv.h"
 #include "WorldSession.h"
 #include "ObjectMgr.h"
+#include "Bag.h"
 #include "Creature.h"
 #include "GameEventMgr.h"
 #include "Player.h"
+#include "Random.h"
 #include "Language.h"
 #include "ScriptedGossip.h"
 #include "ScriptedCreature.h"
@@ -29,6 +31,7 @@
 #include "CollectionMgr.h"
 #include "WorldSession.h"
 #include "Chat.h"
+#include <iterator>
 
 class npc_rate_xp_modifier : public CreatureScript
 {
@@ -207,7 +210,7 @@ public:
                 return false;
 
             ItemPosCountVec dest;
-            uint8 msg = player->CanStoreNewItem(NULL_BAG, NULL_SLOT, dest, 49661, 1);
+            uint8 msg = player->CanStoreNewItem(NULL_BAG, NULL_SLOT, dest, 69238, 1);
             if (msg == EQUIP_ERR_OK)
             {
                 Item* item = player->StoreNewItem(dest, 69238, true);
@@ -458,15 +461,21 @@ public:
             return false;
         }
         // Bags
-        for (int slot = INVENTORY_SLOT_BAG_START; slot < INVENTORY_SLOT_BAG_END; slot++)
-            if (Item* bag = player->GetItemByPos(INVENTORY_SLOT_BAG_0, slot))
+        for (uint8 slot = INVENTORY_SLOT_BAG_START; slot < INVENTORY_SLOT_BAG_END; slot++)
+        {
+            if (Item* equipped = player->GetItemByPos(INVENTORY_SLOT_BAG_0, slot))
+            {
+                Bag* bag = equipped->ToBag();
+                if (!bag || !bag->IsEmpty())
+                    continue;
+
                 player->DestroyItem(INVENTORY_SLOT_BAG_0, slot, true);
+            }
 
-        for (int slot = INVENTORY_SLOT_BAG_START; slot < INVENTORY_SLOT_BAG_END; slot++)
             player->EquipNewItem(slot, 142075, ItemContext::NONE, true);
+        }
 
-        player->GiveLevel(sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL));
-        player->InitTalentForLevel();
+        player->GiveLevel(lvlup);
         player->ModifyMoney(200000000);
         player->LearnSpell(71810, true); // Montura vermis
         player->EquipNewItem(EQUIPMENT_SLOT_NECK, 131736, ItemContext::NONE, true); // Cuello
@@ -484,28 +493,8 @@ public:
         player->LearnSpell(110406, true);
         player->LearnSpell(104381, true);
 
-        //   add end - level quests
-        bool IsPandarenNeutral = player->getRace() == RACE_PANDAREN_NEUTRAL;
-        std::vector<uint32> questsToAdd;
-        if (player->GetTeam() == HORDE || IsPandarenNeutral)
-        {
-            // quests for Pandaria map
-            questsToAdd.push_back(29611);   // The Art of War
-            questsToAdd.push_back(31853);   // All Aboard!
-            questsToAdd.push_back(29690);   // Into the Mists
-            if (player->getClass() == CLASS_DEATH_KNIGHT)
-                questsToAdd.push_back(13189);
-        }
-        if (player->GetTeam() == ALLIANCE || IsPandarenNeutral)
-        {
-            // quests for Pandaria map
-            questsToAdd.push_back(29547);   // The King's Command
-            questsToAdd.push_back(29548);   // The Mission
-            if (player->getClass() == CLASS_DEATH_KNIGHT)
-                questsToAdd.push_back(13188);
-        }
         // pandarens
-        if (IsPandarenNeutral)
+        if (player->getRace() == RACE_PANDAREN_NEUTRAL)
         {
             // add "A New Fate" quest
             if (Quest const* quest = sObjectMgr->GetQuestTemplate(31450))
@@ -719,26 +708,45 @@ public:
             player->EquipNewItem(EQUIPMENT_SLOT_TRINKET2, 139334, ItemContext::NONE, true); // Trinket - Abalario Dps Agilidad
 
         }
-        if (player->getRace() == RACE_GOBLIN || RACE_ORC || RACE_UNDEAD_PLAYER || RACE_TAUREN || RACE_TROLL || RACE_BLOODELF || RACE_NIGHTBORNE || RACE_HIGHMOUNTAIN_TAUREN || RACE_ZANDALARI_TROLL || RACE_VULPERA || RACE_MAGHAR_ORC)
+        switch (player->getRace())
         {
-            player->TeleportTo(1, 1569.97f, -4397.41f, 16.0472f, 0.503f);
-        }
-        else
-        if (player->getRace() == RACE_DRAENEI || RACE_DWARF || RACE_HUMAN || RACE_NIGHTELF || RACE_GNOME || RACE_WORGEN || RACE_VOID_ELF || RACE_LIGHTFORGED_DRAENEI || RACE_DARK_IRON_DWARF || RACE_MECHAGNOME || RACE_KUL_TIRAN)
-        {
+            case RACE_GOBLIN:
+            case RACE_ORC:
+            case RACE_UNDEAD_PLAYER:
+            case RACE_TAUREN:
+            case RACE_TROLL:
+            case RACE_BLOODELF:
+            case RACE_NIGHTBORNE:
+            case RACE_HIGHMOUNTAIN_TAUREN:
+            case RACE_ZANDALARI_TROLL:
+            case RACE_VULPERA:
+            case RACE_MAGHAR_ORC:
+                player->TeleportTo(1, 1569.97f, -4397.41f, 16.0472f, 0.503f);
+                break;
+            case RACE_DRAENEI:
+            case RACE_DWARF:
+            case RACE_HUMAN:
+            case RACE_NIGHTELF:
+            case RACE_GNOME:
+            case RACE_WORGEN:
+            case RACE_VOID_ELF:
+            case RACE_LIGHTFORGED_DRAENEI:
+            case RACE_DARK_IRON_DWARF:
+            case RACE_MECHAGNOME:
+            case RACE_KUL_TIRAN:
                 player->TeleportTo(0, -8833.68f, 621.302f, 93.8017f, 0.733f);
-        }
-        else
-
-            if (player->getRace() == RACE_PANDAREN_NEUTRAL || RACE_PANDAREN_ALLIANCE || RACE_PANDAREN_HORDE)
-            {
+                break;
+            case RACE_PANDAREN_NEUTRAL:
+            case RACE_PANDAREN_ALLIANCE:
+            case RACE_PANDAREN_HORDE:
                 player->TeleportTo(860, 1466.09f, 3465.98f, 181.86f, 2.733f);
-            }
-       
-        player->SaveToDB();
-        player->SetLevel(lvlup);
-        player->InitTalentForLevel();
+                break;
+            default:
+                break;
+        }
+
         player->DestroyItemCount(item_id, 1, true);
+        player->SaveToDB();
 
         return true;
 
@@ -766,15 +774,21 @@ public:
         }
 
         // Bags
-        for (int slot = INVENTORY_SLOT_BAG_START; slot < INVENTORY_SLOT_BAG_END; slot++)
-            if (Item* bag = player->GetItemByPos(INVENTORY_SLOT_BAG_0, slot))
+        for (uint8 slot = INVENTORY_SLOT_BAG_START; slot < INVENTORY_SLOT_BAG_END; slot++)
+        {
+            if (Item* equipped = player->GetItemByPos(INVENTORY_SLOT_BAG_0, slot))
+            {
+                Bag* bag = equipped->ToBag();
+                if (!bag || !bag->IsEmpty())
+                    continue;
+
                 player->DestroyItem(INVENTORY_SLOT_BAG_0, slot, true);
+            }
 
-        for (int slot = INVENTORY_SLOT_BAG_START; slot < INVENTORY_SLOT_BAG_END; slot++)
             player->EquipNewItem(slot, 142075, ItemContext::NONE, true);
+        }
 
-        player->GiveLevel(sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL));
-        player->InitTalentForLevel();
+        player->GiveLevel(lvlup);
         player->ModifyMoney(200000000);
         player->LearnSpell(88331, true); // Montura Riendas del draco de piedra volcnico
         player->LearnSpell(33388, true); // Equitacion
@@ -788,28 +802,8 @@ public:
         player->LearnSpell(110406, true);
         player->LearnSpell(104381, true);
 
-        //   add end - level quests
-        bool IsPandarenNeutral = player->getRace() == RACE_PANDAREN_NEUTRAL;
-        std::vector<uint32> questsToAdd;
-        if (player->GetTeam() == HORDE || IsPandarenNeutral)
-        {
-            // quests for Pandaria map
-            questsToAdd.push_back(29611);   // The Art of War
-            questsToAdd.push_back(31853);   // All Aboard!
-            questsToAdd.push_back(29690);   // Into the Mists
-            if (player->getClass() == CLASS_DEATH_KNIGHT)
-                questsToAdd.push_back(13189);
-        }
-        if (player->GetTeam() == ALLIANCE || IsPandarenNeutral)
-        {
-            // quests for Pandaria map
-            questsToAdd.push_back(29547);   // The King's Command
-            questsToAdd.push_back(29548);   // The Mission
-            if (player->getClass() == CLASS_DEATH_KNIGHT)
-                questsToAdd.push_back(13188);
-        }
         // pandarens
-        if (IsPandarenNeutral)
+        if (player->getRace() == RACE_PANDAREN_NEUTRAL)
         {
             // add "A New Fate" quest
             if (Quest const* quest = sObjectMgr->GetQuestTemplate(31450))
@@ -1083,10 +1077,8 @@ public:
             player->AddItem(159625, 1);  // abalorio dps
             player->AddItem(159616, 1);  // abalorio dps 1
         }
-        player->SaveToDB();
-        player->SetLevel(lvlup);
-        player->InitTalentForLevel();
         player->DestroyItemCount(item_id, 1, true);
+        player->SaveToDB();
         return true;
 
     }
@@ -1353,7 +1345,7 @@ public:
                 80382  // Skycap'n Kragg
             };
 
-            int randomIdModel = rand() % (sizeof(list) / sizeof(list[0])); // random model
+            uint32 randomIdModel = urand(0, uint32(std::size(list)) - 1); // random model
             int value = list[randomIdModel]; // a random model taken from that list
 
             CloseGossipMenuFor(player);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

All six defects from #256, all in `src/server/scripts/Custom/custom_npcs.cpp`.

### 1. Bags were destroyed with everything in them

Both boost items (789001, 789002) unconditionally destroyed every equipped bag before equipping replacements. `DestroyItem` on a container destroys **its contents too**, so anyone using a boost item on an existing character lost everything carried in their bags, permanently. The `Item* bag` bound in the `if` was also unused.

The loop now fills empty bag slots and upgrades only bags that are already empty. **A bag holding items is left untouched.**

I considered moving the contents out first, as the issue suggests, and rejected it: the relocation can only fail when free space is short, which is exactly the case that matters. A half-completed relocation is worse than not touching the bag. The cost of this choice is that a character with full 16-slot bags keeps them instead of being upgraded — which seems clearly preferable to losing the contents. Happy to change this if maintainers prefer a mail-the-overflow approach.

### 2. Race conditionals were always true

```cpp
if (player->getRace() == RACE_GOBLIN || RACE_ORC || RACE_UNDEAD_PLAYER || ...)
```

Only the first term is a comparison; the rest are bare enum constants and `RACE_ORC = 2` is non-zero, so the expression was unconditionally true. **Every** player, Alliance included, was teleported to Orgrimmar, and the Alliance and Pandaren branches were dead code.

Rewritten as a `switch` on `getRace()` so each race is a real case label and this class of typo cannot recur. All 25 playable races are covered by the three groups, so the `default` branch is unreachable in practice; it does nothing rather than guessing a destination for a future race.

### 3. `SetLevel` ran after `SaveToDB` and contradicted `GiveLevel`

`SaveToDB()` ran *before* the level change, so the new level was not persisted by that save. `SetLevel` is the raw field setter and overwrote the level that `GiveLevel` had just established, without the matching stat, talent and skill recalculation.

`GiveLevel` now takes the item's own `lvlup` constant and the redundant trailing `SetLevel`/`InitTalentForLevel` are gone; `SaveToDB()` moved to the end so the level and the consumed item land in the same save.

**Deviation from the issue's suggested direction, on purpose.** The issue suggested keeping `GiveLevel(CONFIG_MAX_PLAYER_LEVEL)` and simply dropping `SetLevel`. That would silently turn the 110 boost item into a 120 boost on a 120-max realm, because `SetLevel(lvlup)` was running last and `lvlup` is what the character actually ended up at. Using `GiveLevel(lvlup)` keeps the observed end level identical while fixing the stats and the persistence. It also keeps the two items distinct, which their differing gear sets (Legion vs BfA) show was the intent.

### 4. `questsToAdd` was built and discarded

The vector was populated in both items and never read. Removed. **The quests it named are still not granted** — whether a level 110/120 boosted character should receive those Pandaria breadcrumb quests is a gameplay decision, not a defect fix, so I have left it to maintainers rather than enabling never-tested behaviour in a bugfix PR.

### 5. `rand()` replaced with the project RNG

`npc_transmorpher_beacon` used `rand() % N`, which has modulo bias and, on MSVC, per-thread state that was never seeded here. Now `urand(0, std::size(list) - 1)`.

### 6. `CanStoreNewItem` checked the wrong item

`npc_anachronos::OnGossipSelect` checked space for item `49661` but stored item `69238`. The check now tests `69238`.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Tool: Claude Code. Model: Claude Opus 5.** Used for the static analysis that found the issues and for drafting the change; the race enum values, `Player::GiveLevel` and the `Bag::IsEmpty` path were verified against the source in this repository before submitting.

## Issues Addressed:
- Closes #256

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Not applicable — these are defects in this repository's own custom code. `RACE_ORC = 2` confirmed at `src/server/game/Miscellaneous/RaceMask.h:28`; `GiveLevel` behaviour confirmed at `src/server/game/Entities/Player/Player.cpp:2649`.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Compile-verified only: `worldserver` builds clean on Windows with Visual Studio 2022, `RelWithDebInfo`. **Not tested in-game.**

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. **Item loss (the important one).** On a throwaway character, equip bags, put identifiable items in them, use item 789001. Confirm the bags and their contents survive. Repeat with 789002.
2. On a character with empty bag slots, use a boost item and confirm the new bags are equipped into the free slots.
3. Use 789001 on an Alliance character and confirm arrival in Stormwind, on a Horde character for Orgrimmar, and on a Pandaren for the Vale.
4. Use a boost item, then relog without any other save, and confirm the level persisted.
5. Talk to `npc_anachronos` with a full inventory and confirm the gossip does not silently fail or duplicate.

## Known Issues and TODO List:

- [ ] Bags that already contain items are not upgraded. If a mail-the-overflow policy is preferred, that is a follow-up.
- [ ] The Pandaria breadcrumb quests named in the removed `questsToAdd` vector are still not granted. Maintainers should decide whether they are wanted.
- [ ] Item 789001's guard is still `getLevel() == max_lvl`, so a character already above 110 can use it and be de-levelled to 110. That behaviour is unchanged by this PR and was not in scope.
