### PR TITLE
CPP: Fixes Inscription and Enchanting Professions

### DIFF
--- a/src/server/game/Entities/Creature/Trainer.cpp
+++ b/src/server/game/Entities/Creature/Trainer.cpp
@@ -53,7 +53,7 @@ namespace Trainer
             WorldPackets::NPC::TrainerListSpell& trainerListSpell = trainerList.Spells.back();
             trainerListSpell.SpellID = trainerSpell.SpellId;
             trainerListSpell.MoneyCost = int32(trainerSpell.MoneyCost * reputationDiscount);
-            trainerListSpell.ReqSkillLine = trainerSpell.ReqSkillLine == SKILL_JEWELCRAFTING ? SKILL_JEWELCRAFTING_2 : trainerSpell.ReqSkillLine;
+            trainerListSpell.ReqSkillLine = trainerSpell.ReqSkillLine;
             trainerListSpell.ReqSkillRank = trainerSpell.ReqSkillRank;
             std::copy(trainerSpell.ReqAbility.begin(), trainerSpell.ReqAbility.end(), trainerListSpell.ReqAbility.begin());
             trainerListSpell.Usable = AsUnderlyingType(GetSpellState(player, &trainerSpell));
@@ -127,12 +127,16 @@ namespace Trainer
         if (!player->IsSpellFitByClassAndRace(trainerSpell->SpellId))
             return SpellState::Unavailable;
 
-        uint32 const reqSkillLine = trainerSpell->ReqSkillLine == SKILL_JEWELCRAFTING
-            ? SKILL_JEWELCRAFTING_2
-            : trainerSpell->ReqSkillLine;
-
         // check skill requirement
-        if (reqSkillLine && player->GetBaseSkillValue(reqSkillLine) < trainerSpell->ReqSkillRank)
+        uint32 requiredSkillLine = trainerSpell->ReqSkillLine;
+
+        // Classic Enchanting progression is stored on the expansion-specific
+        // child skill line, while trainer requirements can reference the
+        // parent Enchanting skill line.
+        if (requiredSkillLine == SKILL_ENCHANTING)
+            requiredSkillLine = SKILL_ENCHANTING_2;
+
+        if (requiredSkillLine && player->GetBaseSkillValue(requiredSkillLine) < trainerSpell->ReqSkillRank)
             return SpellState::Unavailable;
 
         for (int32 reqAbility : trainerSpell->ReqAbility)

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -5803,17 +5803,24 @@ bool Player::UpdateSkillPro(uint16 skillId, int32 chance, uint32 step)
 
     SetSkillRank(itr->second.pos, new_value);
 
-    if (SkillLineEntry const* skillLine = sSkillLineStore.LookupEntry(skillId))
+    // Classic Inscription progression is resolved from the expansion-specific
+    // recipe skill line to the parent skill, so explicitly send the skill-up
+    // chat notification for that parent skill. Other professions already
+    // receive their native client notification and must not be duplicated.
+    if (skillId == SKILL_INSCRIPTION)
     {
-        LocaleConstant locale = GetSession()->GetSessionDbcLocale();
+        if (SkillLineEntry const* skillLine = sSkillLineStore.LookupEntry(skillId))
+        {
+            LocaleConstant locale = GetSession()->GetSessionDbcLocale();
 
-        std::ostringstream skillMessage;
-        skillMessage << "Your skill in " << skillLine->DisplayName->Str[locale]
-                     << " has increased to " << new_value << ".";
+            std::ostringstream skillMessage;
+            skillMessage << "Your skill in " << skillLine->DisplayName->Str[locale]
+                         << " has increased to " << new_value << ".";
 
-        WorldPackets::Chat::Chat packet;
-        packet.Initialize(CHAT_MSG_SKILL, LANG_UNIVERSAL, this, this, skillMessage.str());
-        SendDirectMessage(packet.Write());
+            WorldPackets::Chat::Chat packet;
+            packet.Initialize(CHAT_MSG_SKILL, LANG_UNIVERSAL, this, this, skillMessage.str());
+            SendDirectMessage(packet.Write());
+        }
     }
 
     if (itr->second.uState != SKILL_NEW)

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -5641,19 +5641,27 @@ bool Player::UpdateCraftSkill(uint32 spellid)
     {
         if (_spell_idx->second->SkillupSkillLineID)
         {
-            uint32 SkillValue = GetPureSkillValue(_spell_idx->second->SkillupSkillLineID);
+            uint32 skillId = _spell_idx->second->SkillupSkillLineID;
+
+            // Classic Inscription recipes reference the expansion-specific
+            // child skill line in DB2, while the player stores/progresses
+            // Inscription on the parent skill line.
+            if (skillId == SKILL_INSCRIPTION_2)
+                skillId = SKILL_INSCRIPTION;
+
+            uint32 SkillValue = GetPureSkillValue(skillId);
 
             // Alchemy Discoveries here
             SpellInfo const* spellEntry = sSpellMgr->GetSpellInfo(spellid);
             if (spellEntry && spellEntry->Mechanic == MECHANIC_DISCOVERY)
             {
-                if (uint32 discoveredSpell = GetSkillDiscoverySpell(_spell_idx->second->SkillupSkillLineID, spellid, this))
+                if (uint32 discoveredSpell = GetSkillDiscoverySpell(skillId, spellid, this))
                     LearnSpell(discoveredSpell, false);
             }
 
             uint32 craft_skill_gain = _spell_idx->second->NumSkillUps * sWorld->getIntConfig(CONFIG_SKILL_GAIN_CRAFTING);
 
-            return UpdateSkillPro(_spell_idx->second->SkillupSkillLineID, SkillGainChance(SkillValue,
+            return UpdateSkillPro(skillId, SkillGainChance(SkillValue,
                 _spell_idx->second->TrivialSkillLineRankHigh,
                 (_spell_idx->second->TrivialSkillLineRankHigh + _spell_idx->second->TrivialSkillLineRankLow)/2,
                 _spell_idx->second->TrivialSkillLineRankLow),
@@ -5794,6 +5802,20 @@ bool Player::UpdateSkillPro(uint16 skillId, int32 chance, uint32 step)
         new_value = max;
 
     SetSkillRank(itr->second.pos, new_value);
+
+    if (SkillLineEntry const* skillLine = sSkillLineStore.LookupEntry(skillId))
+    {
+        LocaleConstant locale = GetSession()->GetSessionDbcLocale();
+
+        std::ostringstream skillMessage;
+        skillMessage << "Your skill in " << skillLine->DisplayName->Str[locale]
+                     << " has increased to " << new_value << ".";
+
+        WorldPackets::Chat::Chat packet;
+        packet.Initialize(CHAT_MSG_SKILL, LANG_UNIVERSAL, this, this, skillMessage.str());
+        SendDirectMessage(packet.Write());
+    }
+
     if (itr->second.uState != SKILL_NEW)
         itr->second.uState = SKILL_CHANGED;
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:

This PR fixes Classic Inscription skill progression, corrects Enchanting trainer skill requirements, and restores profession skill-up notifications without producing duplicate messages for professions that already receive them natively.

The underlying issue is the use of parent profession skill lines alongside expansion-specific child skill lines.

### Inscription

Inscription is learned and displayed by the client using:

```text
SKILL_INSCRIPTION = 773
```

However, some Classic Inscription recipes reference:

```text
SKILL_INSCRIPTION_2 = 2514
```

in their `SkillupSkillLineID`.

For example, Classic Inscription recipe spell `52843` reported:

```text
SkillLine            = 773
SkillupSkillLineID   = 2514
TrivialSkillLineLow  = 45
TrivialSkillLineHigh = 75
NumSkillUps          = 1
```

The player normally stores and displays Inscription progression using skill `773`.

Because `Player::UpdateCraftSkill()` used `SkillupSkillLineID` directly, these recipes attempted to increase skill `2514`, which the normally trained character did not possess.

The fix resolves:

```text
SKILL_INSCRIPTION_2 (2514)
```

to:

```text
SKILL_INSCRIPTION (773)
```

before obtaining the current skill value and applying crafting progression.

This allows Classic Inscription recipes to increase the same profession skill that is learned from the trainer and displayed by the client.

Milling was tested separately and already progresses `SKILL_INSCRIPTION` correctly, so no Milling-specific change is required.

### Inscription Skill-Up Notification

During testing, Inscription skill increases were correctly applied but did not produce the normal player-facing skill-up message.

A native `CHAT_MSG_SKILL` notification is now sent when the resolved Inscription parent skill successfully increases.

Example:

```text
Your skill in Inscription has increased to 7.
```

The message uses the localized `SkillLineEntry` name and the client's native skill chat type.

### Enchanting

Regression testing of Enchanting exposed another parent/child skill-line mismatch.

Enchanting uses:

```text
SKILL_ENCHANTING   = 333
SKILL_ENCHANTING_2 = 2494
```

Normal Enchanting crafting correctly progresses the expansion-specific skill `2494`.

For example, during testing the character had:

```text
333  = 1/300
2494 = 10/300
```

and the Professions window correctly displayed:

```text
Enchanting 10/300
```

However, trainer recipe requirements were evaluated directly against parent skill `333`.

This caused recipes to remain unavailable even when the player's displayed and progressing Enchanting skill met the requirement.

For example, **Lesser Magic Wand** requires:

```text
Enchanting (10)
```

but could not be trained with:

```text
333  = 1
2494 = 10
```

The trainer requirement check now resolves:

```text
SKILL_ENCHANTING
```

to:

```text
SKILL_ENCHANTING_2
```

before evaluating the player's required skill rank.

After this change, Lesser Magic Wand became immediately trainable at actual Enchanting skill 10 without manually modifying parent skill `333`.

### Duplicate Skill-Up Notification

Enchanting regression testing also showed that sending `CHAT_MSG_SKILL` generically from `Player::UpdateSkillPro()` caused Enchanting skill-up messages to appear twice.

Enchanting already receives its normal client skill-up notification.

The supplemental notification added for Inscription is therefore now restricted specifically to:

```text
SKILL_INSCRIPTION
```

This preserves the missing Inscription notification while avoiding duplicate messages for Enchanting and other professions that already receive their native notification.

This PR proposes changes to:

- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

## Issues Addressed:

- Classic Inscription recipes referencing `SKILL_INSCRIPTION_2` do not increase the player's actual Inscription profession.
- Inscription crafting progression must resolve child skill `2514` to stored parent skill `773`.
- Inscription skill gains did not display the normal skill-up chat notification.
- Enchanting trainer requirements incorrectly evaluate parent skill `333` instead of the actual progressing Enchanting skill `2494`.
- Enchanting recipes can remain unavailable even though the Professions window shows that the required skill has been reached.
- A generic supplemental `CHAT_MSG_SKILL` notification caused duplicate Enchanting skill-up messages.
- The supplemental skill notification is now limited to Inscription, where it is required.

## SOURCE:

The changes have been validated through:

- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The behavior was validated directly against the current BFA-HavenCore implementation and DB2 skill-line data through in-game testing.

### Inscription

Observed Classic Inscription recipe data:

```text
spell=52843
abilitySkillLine=773
skillupSkillLineID=2514
low=45
high=75
numSkillUps=1
```

After resolving the recipe skill line:

```text
rawSkill=2514
resolvedSkill=773
current=3
max=75
chance=1000
gained=1
newValue=4
```

The recipe successfully increased the player's actual Inscription profession.

Milling was independently verified to progress the stored parent skill:

```text
773: 1 -> 2
```

without requiring skill `2514` to exist on the character.

### Enchanting

Observed Enchanting skill state during testing:

```text
333  = 1/300
2494 = 10/300
```

The client correctly displayed:

```text
Enchanting 10/300
```

Normal Enchanting crafting continued to increase `2494`.

Before the trainer fix, **Lesser Magic Wand**, requiring Enchanting 10, remained unavailable because the trainer requirement was evaluated against parent skill `333`.

After resolving the trainer requirement to `SKILL_ENCHANTING_2`, Lesser Magic Wand became trainable without manually modifying either skill.

## Tests Performed:

This PR has been:

- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Testing was performed on Windows using a locally compiled RelWithDebInfo build.

### Inscription Testing

- Learned Inscription normally from a profession trainer.
- Confirmed Inscription appears correctly in the Professions window.
- Confirmed Milling is available normally.
- Confirmed normally trained Inscription uses skill `773`.
- Crafted Classic Inscription recipes.
- Confirmed recipes referencing `SkillupSkillLineID = 2514` now increase skill `773`.
- Confirmed skill `2514` does not need to be manually created on the character.
- Confirmed Milling increases Inscription skill.
- Confirmed crafting skill increases persist after save/logout.
- Confirmed Milling skill increases persist after save/logout.
- Confirmed successful Inscription skill gains display a blue `CHAT_MSG_SKILL` notification.
- Confirmed the skill name in the notification is obtained from the localized `SkillLineEntry`.

### Enchanting Testing

- Learned Enchanting normally from a profession trainer.
- Confirmed Enchanting appears correctly in the Professions window.
- Crafted low-level Enchanting items.
- Confirmed normal Enchanting crafting progresses skill `2494`.
- Confirmed the parent skill `333` remains separate from normal crafting progression.
- Confirmed Disenchant continues to function normally.
- Progressed Enchanting to skill 10 through normal crafting.
- Confirmed the client displayed Enchanting 10/300.
- Confirmed Lesser Magic Wand remained unavailable before the trainer fix because parent skill `333` remained at 1.
- Applied the Enchanting trainer skill-line resolution.
- Confirmed Lesser Magic Wand became trainable at actual Enchanting skill 10.
- Confirmed no manual modification of skill `333` was required.
- Confirmed Enchanting skill-up messages display only once.
- Confirmed restricting the supplemental notification to Inscription removes the duplicate Enchanting message.
- Confirmed Inscription continues to receive its required skill-up notification.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

### Inscription

1. Create or use a character without Inscription.

2. Learn Inscription normally from a profession trainer.

3. Confirm Inscription appears normally in the Professions window and Milling is available.

4. If desired, verify the stored profession skills:

```sql
SELECT guid, skill, value, max
FROM character_skills
WHERE guid = <character_guid>
  AND skill IN (773, 2514);
```

Normally trained Classic Inscription should use skill `773`.

5. Learn or use a Classic Inscription recipe that awards profession skill.

Recipe spell `52843` was used during testing.

6. Craft the recipe.

7. Confirm the player's Inscription skill increases.

8. Confirm a single blue skill-up notification appears:

```text
Your skill in Inscription has increased to <new skill>.
```

9. Mill a low-level herb that can award Inscription skill.

10. Confirm Milling also increases the same Inscription profession.

11. Save/logout and verify that the increased skill persists.

### Enchanting

1. Create or use a character without Enchanting.

2. Learn Enchanting normally from a profession trainer.

3. Confirm Enchanting appears correctly in the Professions window.

4. Craft low-level Enchanting items until the profession reaches skill 10.

5. If desired, verify the stored skill values:

```sql
SELECT guid, skill, value, max
FROM character_skills
WHERE guid = <character_guid>
  AND skill IN (333, 2494);
```

A typical result during testing was:

```text
333  = 1/300
2494 = 10/300
```

6. Confirm the Professions window displays Enchanting 10/300.

7. Visit an Enchanting trainer offering **Lesser Magic Wand**.

8. Confirm the recipe requiring:

```text
Enchanting (10)
```

is available for training based on the player's actual progressing Enchanting skill.

9. Train Lesser Magic Wand.

10. Craft another Enchanting item that awards profession skill.

11. Confirm Enchanting increases normally.

12. Confirm only one blue skill-up notification appears in chat.

13. Confirm Disenchant continues to function normally.

### Regression Testing

Because these changes touch shared profession and trainer paths, additional profession regression testing is recommended.

At minimum, verify that previously working profession behavior remains unchanged for:

- Skinning
- Mining
- Jewelcrafting
- Inscription
- Enchanting

For each tested profession, confirm:

- Profession learning still works.
- Profession skill progression still works.
- Trainer requirements behave correctly.
- Skill-up notifications are not duplicated.

## Known Issues and TODO List:

- [ ] Some individual profession recipes may have `SkillupSkillLineID = 0` in DB2 data. These cannot award skill through `UpdateCraftSkill()` and are separate data issues from the profession skill-line handling addressed here.
- [ ] Other professions using parent and expansion-specific skill lines may have similar inconsistencies and should continue to be tested individually.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->

## How to Test BFA-HavenCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub.

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.