### PR TITLE
CPP: Fix for Profession Engineering

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -5648,6 +5648,8 @@ bool Player::UpdateCraftSkill(uint32 spellid)
             // Inscription on the parent skill line.
             if (skillId == SKILL_INSCRIPTION_2)
                 skillId = SKILL_INSCRIPTION;
+            else if (skillId == SKILL_ENGINEERING_2)
+                skillId = SKILL_ENGINEERING;
 
             uint32 SkillValue = GetPureSkillValue(skillId);
 
@@ -5807,7 +5809,7 @@ bool Player::UpdateSkillPro(uint16 skillId, int32 chance, uint32 step)
     // recipe skill line to the parent skill, so explicitly send the skill-up
     // chat notification for that parent skill. Other professions already
     // receive their native client notification and must not be duplicated.
-    if (skillId == SKILL_INSCRIPTION)
+    if (skillId == SKILL_INSCRIPTION || skillId == SKILL_ENGINEERING)
     {
         if (SkillLineEntry const* skillLine = sSkillLineStore.LookupEntry(skillId))
         {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:

This PR fixes Classic Engineering skill progression when crafting recipes whose DB2 data references the expansion-specific Engineering skill line.

Engineering uses:

```text
SKILL_ENGINEERING   = 202
SKILL_ENGINEERING_2 = 2506
```

When Engineering is learned normally from the profession trainer, the character stores the usable profession skill as:

```text
SKILL_ENGINEERING = 202
```

However, Classic Engineering recipes can reference:

```text
SKILL_ENGINEERING_2 = 2506
```

in their `SkillupSkillLineID`.

During testing, **Rough Blasting Powder** spell `3918` reported:

```text
abilitySkillLine   = 202
skillupSkillLineID = 2506
low                = 20
high               = 40
numSkillUps        = 1
```

Before the fix, the character had:

```text
202 = 1/75
```

with no skill `2506`.

The crafting skill update therefore attempted to progress the nonexistent child skill:

```text
rawSkill=2506
resolvedSkill=2506
current=0
max=0
chance=1000
gained=0
newValue=0
```

The fix resolves:

```text
SKILL_ENGINEERING_2
```

to:

```text
SKILL_ENGINEERING
```

before checking and applying crafting skill progression.

After this change, Classic Engineering recipes correctly increase the player's actual stored Engineering skill.

Engineering progression through the resolved parent skill also did not produce the normal client skill-up notification.

The existing supplemental `CHAT_MSG_SKILL` handling is therefore extended to Engineering so successful Classic Engineering skill increases display the normal blue skill-up message.

Example:

```text
Your skill in Engineering has increased to 4.
```

This PR proposes changes to:

- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

## Issues Addressed:

- Classic Engineering recipes referencing `SKILL_ENGINEERING_2` fail to increase Engineering.
- The player's normally trained Engineering skill exists as `SKILL_ENGINEERING`, while Classic recipe DB2 data can target `SKILL_ENGINEERING_2`.
- `UpdateCraftSkill()` attempts to increase a skill the character does not possess.
- Engineering skill gains through the resolved parent skill do not display the normal client skill-up notification.

## SOURCE:

The changes have been validated through:

- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The issue was validated directly against the current BFA-HavenCore skill and DB2 data through in-game testing.

Observed recipe data for Rough Blasting Powder:

```text
spell=3918
abilitySkillLine=202
skillupSkillLineID=2506
low=20
high=40
numSkillUps=1
```

Before resolving the skill line:

```text
rawSkill=2506
resolvedSkill=2506
current=0
max=0
chance=1000
gained=0
newValue=0
```

The character's stored Engineering skill was:

```text
202 = 1/75
```

and no `2506` skill entry existed.

After resolving the recipe skill line to `SKILL_ENGINEERING`, crafting successfully increased the profession.

Two Rough Blasting Powder crafts produced:

```text
202 = 3/75
```

with no `2506` skill entry required.

## Tests Performed:

This PR has been:

- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Testing was performed on Windows using a locally compiled RelWithDebInfo build.

The following scenarios were tested:

- Learned Engineering normally from a profession trainer.
- Confirmed Engineering appears correctly in the Professions window.
- Confirmed the normally trained profession uses skill `202`.
- Crafted Rough Blasting Powder before the fix.
- Confirmed crafting produced the item but did not increase Engineering.
- Confirmed recipe DB2 data referenced `SkillupSkillLineID = 2506`.
- Confirmed skill `2506` did not exist on the character.
- Applied the Engineering skill-line resolution.
- Crafted Rough Blasting Powder multiple times.
- Confirmed Engineering skill `202` increased correctly.
- Confirmed no `2506` skill entry was required.
- Confirmed successful Engineering skill increases display one blue `CHAT_MSG_SKILL` notification.
- Confirmed no duplicate skill-up messages are displayed.
- Raised the character level and confirmed additional Engineering trainer recipes became available normally.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create or use a character without Engineering.

2. Learn Engineering normally from a profession trainer.

3. Open the Professions window and confirm Engineering appears normally.

4. Verify the stored profession skill if desired:

```sql
SELECT guid, skill, value, max
FROM character_skills
WHERE guid = <character_guid>
  AND skill IN (202, 2506);
```

The normally trained profession should contain:

```text
202 = 1/75
```

Skill `2506` does not need to exist.

5. Obtain Rough Stone.

6. Craft **Rough Blasting Powder**.

Recipe spell used during testing:

```text
3918
```

7. Confirm the Engineering profession increases from 1 to 2.

8. Craft another Rough Blasting Powder.

9. Confirm Engineering increases again.

10. Confirm a single blue skill-up notification appears in chat:

```text
Your skill in Engineering has increased to <new skill>.
```

11. Save and log out.

12. Verify the persisted skill:

```sql
SELECT guid, skill, value, max
FROM character_skills
WHERE guid = <character_guid>
  AND skill IN (202, 2506);
```

Expected behavior is progression on skill `202` without requiring skill `2506`.

13. Raise the character level as required and visit an Engineering trainer.

14. Confirm additional Engineering recipes become available normally.

15. Regression test Inscription crafting to confirm its existing parent-skill resolution and skill-up notification remain functional.

## Known Issues and TODO List:

- [ ] Other professions using parent and expansion-specific skill lines may have similar Classic recipe progression mismatches and should continue to be tested individually.
- [ ] Additional profession regression testing is recommended because `Player::UpdateCraftSkill()` is shared by multiple crafting professions.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->

## How to Test BFA-HavenCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub.

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.