### PR TITLE
build(docker): unbreak the Docker build and container start

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .git
+build/
 docker/build*.log
 sql/base/*.sql
 sql/base/*.rar

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/dep/boost/CMakeLists.txt
+++ b/dep/boost/CMakeLists.txt
@@ -30,7 +30,9 @@ include (CheckCXXSourceCompiles)
 
 set(BOOST_REQUIRED_VERSION 1.74)
 
-cmake_policy(SET CMP0167 OLD)
+if(POLICY CMP0167)
+  cmake_policy(SET CMP0167 OLD)
+endif()
 
 find_package(Boost ${BOOST_REQUIRED_VERSION} REQUIRED system filesystem thread program_options iostreams regex)
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -34,16 +34,14 @@ services:
       context: .
       dockerfile: docker/Dockerfile.runtime
     entrypoint: ["/entrypoint.sh", "bnetserver"]
-    volumes:
+    volumes: !override
       - dev_install:/opt/bfacore
-      - bnetserver_etc:/opt/bfacore/etc
 
   worldserver:
     build:
       context: .
       dockerfile: docker/Dockerfile.runtime
     entrypoint: ["/entrypoint.sh", "worldserver"]
-    volumes:
+    volumes: !override
       - dev_install:/opt/bfacore
-      - worldserver_etc:/opt/bfacore/etc
       - ./client-data:/opt/bfacore/bin/ClientData:ro


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).
-  [x] **Build system / Docker** (none of the above categories apply — no gameplay behaviour changes).

The documented Docker path in `docker/README.md` does not work today. `docker compose build` fails at configure, and even with that fixed the containers exit immediately for anyone who cloned on Windows. Three separate defects, each reproduced before it was fixed, plus one hygiene change. **4 files, +7 / −5.**

### 1. `dep/boost/CMakeLists.txt` — guard `CMP0167` (the build failure)

`cmake_policy(SET CMP0167 OLD)` is called unconditionally. That policy was introduced in **CMake 3.30**, and setting an unknown policy is a hard error on anything older:

```
CMake Error at dep/boost/CMakeLists.txt:33 (cmake_policy):
  Policy "CMP0167" is not known to this version of CMake.
-- Configuring incomplete, errors occurred!
```

`docker/Dockerfile` builds on `ubuntu:24.04` and installs apt's `cmake`, which is **3.28.3**. So every `docker compose build` on a clean checkout dies here.

Wrapping it in `if(POLICY CMP0167)` keeps the exact previous behaviour on CMake 3.30+, where the policy exists and `OLD` is what selects the legacy `FindBoost` module. Below 3.30 it becomes a no-op and Boost resolves through `BoostConfig.cmake` instead — all six components are found by config mode, and the build completes.

### 2. `.gitattributes` — force LF on shell scripts (the container start failure)

Once the build succeeds, both containers still exit immediately:

```
exec /opt/bfacore/entrypoint.sh: no such file or directory
```

The file is plainly there. `docker/Dockerfile` does `COPY docker/entrypoint.sh`, so whatever line endings the checkout has get baked into the image. Cloning on Windows with the default `core.autocrlf=true` gives CRLF, the shebang line becomes `#!/bin/bash\r`, and the kernel goes looking for an interpreter literally named `/bin/bash\r`. Invoked explicitly as `bash entrypoint.sh` it fails differently but just as fatally:

```
/entrypoint.sh: line 3: set: pipefail: invalid option name
```

`*.sh text eol=lf` pins the two scripts that get baked into images (`docker/entrypoint.sh`, `docker/db-import.sh`) to LF in the working tree regardless of platform. Scoped to `*.sh` deliberately rather than `* text=auto`: the index currently holds 5 CRLF blobs, all under `sql/updates/world/`, and a repo-wide renormalisation would rewrite them as a side effect of a Docker fix. This touches nothing already committed — `git ls-files --eol` reports both scripts as `i/lf` before and after.

### 3. `docker-compose.dev.yml` — stop the dev override shadowing the installed `etc/`

The dev-loop override inherits `bnetserver_etc:/opt/bfacore/etc` and `worldserver_etc:/opt/bfacore/etc` from `docker-compose.yml` (Compose merges volume lists by target path) and adds `dev_install:/opt/bfacore` on top. Docker sorts nested mounts by path depth, so the `*_etc` volumes mount *inside* `dev_install` and hide the `etc/` that `cmake --install` just wrote there. A named volume only ever populates from the **image**, never from another volume, and `docker/Dockerfile.runtime` deliberately bakes nothing under `/opt/bfacore` — so `etc/` comes up empty. `docker/entrypoint.sh` then does `cp "$DIST" "$CONF"` on a `.conf.dist` that is not there and dies under `set -e`.

`volumes: !override` (Compose 2.24+) replaces the inherited list instead of merging into it, dropping the two `*_etc` mounts on the dev path only. Plain `docker compose up` is untouched and keeps its `*_etc` volumes, which is correct there — the image *does* ship `etc/` in that path.

### 4. `.dockerignore` — add `build/`

Hygiene. A local Windows `build/` tree is not part of the Linux image context and has no business being sent to the daemon. **This is not a fix and not a measured speed-up** — I checked, and BuildKit transfers the context lazily, so excluding it changed nothing measurable (0.71s vs 0.69s, `transferring context: 3.00kB`). Included because it is obviously correct, not because it fixes a reported symptom.

### Overlap with #113

Change 1 is byte-for-byte the same `CMP0167` guard as in my open PR #113. That PR is about the Linux CI workflow and says explicitly that it did **not** run `docker compose build`, so the Docker claim there was inference from the CMake version. This PR is the observation that confirms it. I have kept the guard here so this PR stands alone and can be tested on its own — the other three changes are unreachable without it. The hunks are identical, so whichever merges first, the other rebases without conflict. Happy to strip it from either PR if maintainers prefer.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request.

**Claude Code, model Claude Opus 5.** Used for diagnosis, the fixes, and running the verification below. Every defect above was reproduced first and the fix confirmed against the reproduction; nothing here is inferred. Four one-line-ish changes, all of which I can justify.

## Issues Addressed:

- Closes

No open issue. #85 (`fix(docker): build process`, closed unmerged) is the same report — @dr1s hit defect 1 there in August. That PR worked around it by installing a newer CMake from the Kitware apt repo; this fixes the cause instead, so the image keeps using distro packages.

For the record, the other two changes in #85 do not appear to be needed and are not included here:

- `-DCMAKE_CXX_FLAGS="-D__cdecl="` — `WheatyExceptionReport.h` is `TRINITY_PLATFORM_WINDOWS`-gated and only added to the sources under `elseif(WIN32)` in `src/common/CMakeLists.txt`, and `dep/g3dlite/include/G3D/platform.h` already defines `__cdecl` away for non-MSVC.
- gcc → clang — the build completes on the image's stock GCC 13.

The segfault @dr1s reported did not reproduce here at `-j32` on 30 GB, so it looks like an OOM-driven environment issue rather than a compiler bug. I have deliberately shipped no mitigation for it, since I could not reproduce it and would only be guessing.

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

**None of these apply.** There is no gameplay behaviour here, so there is nothing to source against retail. The authority is the reproductions and command output below, plus the CMake policy documentation for `CMP0167` (introduced in 3.30) and the Compose spec for `!override` (2.24+).

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

**What I actually ran**, on a clean checkout of `main` with only these four changes applied:

**Build** — full `docker compose build`, no cache:

```
1811 objects, 8m15s, zero errors
GCC 13 / Ubuntu 24.04 / CMake 3.28.3
worldserver + bnetserver images, 3.35 GB each
build context 73.63 MB
```

**Start** — `docker compose up`:

- MySQL healthy, the four databases auto-created by `docker/mysql-init`
- entrypoint executed on **both** servers (this is what fails without change 2)
- `worldserver.conf` and `bnetserver.conf` generated from `.dist` and correct: `DataDir = "./ClientData"`, `LogsDir` rewritten to forward slashes, all four `*DatabaseInfo` pointed at the `mysql` service, `Updates.EnableDatabases = 0`
- `Connected to MySQL database at mysql` on both servers
- run then stops at `Table 'bfa_auth.account' doesn't exist` → `Could not prepare statements of the Login database`

That last line is the expected outcome without the base dumps and is exactly what `docker/README.md` §2/§10 describe — not a defect. The dumps are not in the repo, so a full login path could not be exercised.

**Dev path** — `docker compose -f docker-compose.yml -f docker-compose.dev.yml up`:

- `dev_install` populated from the built image
- `docker inspect` confirms the mounts are now only `dev_install → /opt/bfacore` plus the client-data bind
- entrypoint generated both `.conf` files, which it cannot do on `main`

**What I did not run, stated plainly:**

- **No in-game testing.** No base SQL dumps and no extracted client data here, so nothing past database-statement preparation was exercised. The servers start, configure themselves and reach MySQL; whether a client can log in and enter the world is untested by me.
- **No Windows/MSVC rebuild.** On CMake 3.30+ the guarded path is byte-for-byte the previous behaviour, so change 1 should be a no-op there, but I have not reconfirmed it. Worth a maintainer with a VS2022 tree doing a configure pass.
- **No Linux-host clone tested.** Change 2 fixes a Windows-checkout symptom; on Linux `core.autocrlf` is off and the scripts were already LF, which is why this was never visible to the author of the Docker setup.
- **`docker compose run --rm db-import` not run** — no dumps to import.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes.

Each defect reproduces independently on `main`:

1. **Build.** `docker compose build worldserver` on `main` → `Policy "CMP0167" is not known to this version of CMake`. On this branch it compiles to completion.
2. **Start (Windows clone only).** With `core.autocrlf=true`, `docker compose up worldserver` on `main` → container exits 255 with `exec /opt/bfacore/entrypoint.sh: no such file or directory`. Check with `git ls-files --eol docker/entrypoint.sh`: `w/crlf` on `main`, `w/lf` here. A fresh clone of this branch picks the attribute up on its own; on an existing clone with no uncommitted work, `git rm --cached -r . && git reset --hard` refreshes the working tree.
3. **Dev path.** `docker compose build dev-builder && docker compose run --rm dev-builder`, then `docker compose -f docker-compose.yml -f docker-compose.dev.yml up worldserver`. On `main` the entrypoint dies because `/opt/bfacore/etc/worldserver.conf.dist` is missing; here both configs are generated. `docker inspect bfacore-worldserver --format '{{json .Mounts}}'` shows the `worldserver_etc` mount present on `main` and gone here.
4. Expect the run to end at `Table 'bfa_auth.account' doesn't exist` unless you have imported the base dumps first — that is the documented state.

## Known Issues and TODO List:

- [ ] `docker/README.md` is unchanged. It documents a working setup, and after this PR it is accurate again, so I would rather not mix prose into a fix. A troubleshooting entry for the OOM-looking gcc failure @dr1s hit would be worth adding once someone can reproduce it.
- [ ] `docker/Dockerfile` takes `ARG BUILD_JOBS=0` (meaning `nproc`) but `docker-compose.yml` never passes it, so there is no way to cap parallelism from Compose without editing the Dockerfile. Deliberately left out of this PR to keep it to reproduced defects only; worth a follow-up if the OOM reports continue.
- [ ] The `CMP0167` guard is a compatibility shim, not the destination. The real fix is moving `dep/boost/CMakeLists.txt` to Boost's config mode so the policy stops mattering — a larger change that deserves its own PR and a Windows test pass.
