### PR TITLE
core/crypto: unbreak world login on OpenSSL 3.x

### DIFF
--- a/src/common/Cryptography/HMAC.h
+++ b/src/common/Cryptography/HMAC.h
@@ -135,7 +135,7 @@ namespace Trinity::Impl
 
             void Finalize()
             {
-                size_t length = 0;
+                size_t length = DIGEST_LENGTH;
                 int result = EVP_DigestSignFinal(_ctx, _digest.data(), &length);
                 ASSERT(result == 1);
                 ASSERT(length == DIGEST_LENGTH);

--- a/src/common/Cryptography/RSA.cpp
+++ b/src/common/Cryptography/RSA.cpp
@@ -17,8 +17,10 @@
 
 #include "RSA.h"
 #include "HMAC.h"
-#include <openssl/objects.h>
+#include <openssl/core_names.h>
+#include <openssl/params.h>
 #include <openssl/pem.h>
+#include <openssl/provider.h>
 #include <openssl/sha.h>
 #include <algorithm>
 #include <cstring>
@@ -36,8 +38,20 @@ struct BIODeleter
     }
 };
 
+struct EVP_PKEY_CTXDeleter
+{
+    void operator()(EVP_PKEY_CTX* ctx)
+    {
+        EVP_PKEY_CTX_free(ctx);
+    }
+};
+
+extern OSSL_DISPATCH const HMAC_SHA256_funcs[];
+extern OSSL_ALGORITHM const HMAC_SHA256_algs[];
+extern OSSL_DISPATCH const HMAC_SHA256_method[];
+
 // The client expects the EnterEncryptedMode signature to be a PKCS1 signature carrying the sha256 algorithm id,
-// but computed over an HMAC-SHA256 of the message - wrap our HMAC in a custom EVP_MD to feed it to EVP_DigestSign
+// but computed over an HMAC-SHA256 of the message - expose the HMAC to EVP_DigestSign as a provider supplied digest
 struct HMAC_SHA256_MD
 {
     struct CTX_DATA
@@ -45,27 +59,12 @@ struct HMAC_SHA256_MD
         Trinity::Crypto::HMAC_SHA256* hmac;
     };
 
-// EVP_MD_meth_* is deprecated in OpenSSL 3.0 with no replacement able to wrap an arbitrary digest implementation
-#if TRINITY_COMPILER == TRINITY_COMPILER_GNU
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#else
-#pragma warning(push)
-#pragma warning(disable: 4996)
-#endif
-
     HMAC_SHA256_MD()
     {
-        _md = EVP_MD_meth_new(NID_sha256, NID_sha256WithRSAEncryption);
-        EVP_MD_meth_set_result_size(_md, Trinity::Crypto::Constants::SHA256_DIGEST_LENGTH_BYTES);
-        EVP_MD_meth_set_flags(_md, EVP_MD_FLAG_DIGALGID_ABSENT);
-        EVP_MD_meth_set_init(_md, &Init);
-        EVP_MD_meth_set_update(_md, &UpdateData);
-        EVP_MD_meth_set_final(_md, &Finalize);
-        EVP_MD_meth_set_copy(_md, &Copy);
-        EVP_MD_meth_set_cleanup(_md, &Cleanup);
-        EVP_MD_meth_set_input_blocksize(_md, SHA256_CBLOCK);
-        EVP_MD_meth_set_app_datasize(_md, sizeof(EVP_MD*) + sizeof(CTX_DATA*));
+        _lib = OSSL_LIB_CTX_new();
+        OSSL_PROVIDER_add_builtin(_lib, "havencore-rsa-hmac-sha256", &InitProvider);
+        // retain fallbacks so RSA itself still resolves from the default provider inside this library context
+        _handle = OSSL_PROVIDER_try_load(_lib, "havencore-rsa-hmac-sha256", 1);
     }
 
     HMAC_SHA256_MD(HMAC_SHA256_MD const&) = delete;
@@ -76,102 +75,202 @@ struct HMAC_SHA256_MD
 
     ~HMAC_SHA256_MD()
     {
-        EVP_MD_meth_free(_md);
-        _md = nullptr;
+        if (_handle)
+            OSSL_PROVIDER_unload(_handle);
+        if (_lib)
+            OSSL_LIB_CTX_free(_lib);
     }
 
-#if TRINITY_COMPILER == TRINITY_COMPILER_GNU
-#pragma GCC diagnostic pop
-#else
-#pragma warning(pop)
-#endif
-
-    operator EVP_MD const* () const
+    OSSL_LIB_CTX* GetLib() const
     {
-        return _md;
+        return _lib;
     }
 
-    static int Init(EVP_MD_CTX* ctx)
+    static int InitProvider(OSSL_CORE_HANDLE const* /*handle*/, OSSL_DISPATCH const* /*in*/, OSSL_DISPATCH const** out, void** /*provctx*/)
     {
-        Cleanup(ctx);
+        *out = HMAC_SHA256_method;
         return 1;
     }
 
-    static int UpdateData(EVP_MD_CTX* ctx, const void* data, size_t count)
+    static OSSL_ALGORITHM const* QueryProvider(void* /*provctx*/, int operation_id, int* no_cache)
     {
-        CTX_DATA* ctxData = reinterpret_cast<CTX_DATA*>(EVP_MD_CTX_md_data(ctx));
-        if (!ctxData->hmac)
-            return 0;
+        *no_cache = 0;
+        if (operation_id == OSSL_OP_DIGEST)
+            return HMAC_SHA256_algs;
 
-        ctxData->hmac->UpdateData(reinterpret_cast<uint8 const*>(data), count);
+        return nullptr;
+    }
+
+    static CTX_DATA* DigestNew()
+    {
+        CTX_DATA* data = new CTX_DATA();
+        data->hmac = nullptr;
+        return data;
+    }
+
+    static int DigestInit(void* dctx, OSSL_PARAM const* params)
+    {
+        CTX_DATA* ctxData = reinterpret_cast<CTX_DATA*>(dctx);
+
+        delete ctxData->hmac;
+        ctxData->hmac = nullptr;
+        if (OSSL_PARAM const* keyParam = OSSL_PARAM_locate_const(params, "hmac-key"))
+        {
+            uint8 const* key = nullptr;
+            size_t keyLength = 0;
+            if (OSSL_PARAM_get_octet_ptr(keyParam, reinterpret_cast<void const**>(&key), &keyLength))
+            {
+                ctxData->hmac = new Trinity::Crypto::HMAC_SHA256(key, keyLength);
+                return 1;
+            }
+        }
+
+        return 0;
+    }
+
+    static int DigestUpdate(void* dctx, unsigned char const* in, size_t inl)
+    {
+        reinterpret_cast<CTX_DATA*>(dctx)->hmac->UpdateData(in, inl);
         return 1;
     }
 
-    static int Finalize(EVP_MD_CTX* ctx, unsigned char* md)
+    static int DigestFinal(void* dctx, unsigned char* out, size_t* outl, size_t outsz)
     {
-        CTX_DATA* ctxData = reinterpret_cast<CTX_DATA*>(EVP_MD_CTX_md_data(ctx));
-        if (!ctxData->hmac)
-            return 0;
-
+        CTX_DATA* ctxData = reinterpret_cast<CTX_DATA*>(dctx);
         ctxData->hmac->Finalize();
-        memcpy(md, ctxData->hmac->GetDigest().data(), ctxData->hmac->GetDigest().size());
+        *outl = std::min(ctxData->hmac->GetDigest().size(), outsz);
+        memcpy(out, ctxData->hmac->GetDigest().data(), *outl);
         return 1;
     }
 
-    // post-processing after openssl memcpys from source to dest (no need to cleanup dest)
-    static int Copy(EVP_MD_CTX* to, EVP_MD_CTX const* from)
+    static void DigestFree(void* dctx)
     {
-        CTX_DATA const* ctxDataFrom = reinterpret_cast<CTX_DATA const*>(EVP_MD_CTX_md_data(from));
-        CTX_DATA* ctxDataTo = reinterpret_cast<CTX_DATA*>(EVP_MD_CTX_md_data(to));
+        CTX_DATA* data = reinterpret_cast<CTX_DATA*>(dctx);
+        delete data->hmac;
+        data->hmac = nullptr;
+        delete data;
+    }
 
+    static void* DigestDup(void* dctx)
+    {
+        CTX_DATA const* ctxDataFrom = reinterpret_cast<CTX_DATA const*>(dctx);
+        CTX_DATA* ctxDataTo = DigestNew();
         if (ctxDataFrom->hmac)
             ctxDataTo->hmac = new Trinity::Crypto::HMAC_SHA256(*ctxDataFrom->hmac);
 
+        return ctxDataTo;
+    }
+
+    static int DigestGetParams(OSSL_PARAM params[])
+    {
+        OSSL_PARAM* p = nullptr;
+
+        p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_BLOCK_SIZE);
+        if (p != nullptr && !OSSL_PARAM_set_size_t(p, SHA256_CBLOCK))
+            return 0;
+
+        p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_SIZE);
+        if (p != nullptr && !OSSL_PARAM_set_size_t(p, Trinity::Crypto::Constants::SHA256_DIGEST_LENGTH_BYTES))
+            return 0;
+
+        p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_XOF);
+        if (p != nullptr && !OSSL_PARAM_set_int(p, 0))
+            return 0;
+
+        p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_ALGID_ABSENT);
+        if (p != nullptr && !OSSL_PARAM_set_int(p, 1))
+            return 0;
+
         return 1;
     }
 
-    static int Cleanup(EVP_MD_CTX* ctx)
+    static OSSL_PARAM const* DigestGettableParams()
     {
-        CTX_DATA* data = reinterpret_cast<CTX_DATA*>(EVP_MD_CTX_md_data(ctx));
-        if (data->hmac)
+        static constexpr OSSL_PARAM Params[] =
         {
-            delete data->hmac;
-            data->hmac = nullptr;
-        }
+            OSSL_PARAM_size_t(OSSL_DIGEST_PARAM_BLOCK_SIZE, nullptr),
+            OSSL_PARAM_size_t(OSSL_DIGEST_PARAM_SIZE, nullptr),
+            OSSL_PARAM_int(OSSL_DIGEST_PARAM_XOF, nullptr),
+            OSSL_PARAM_int(OSSL_DIGEST_PARAM_ALGID_ABSENT, nullptr),
+            OSSL_PARAM_END
+        };
 
-        return 1;
+        return Params;
     }
 
 private:
-    EVP_MD* _md;
-} HmacSha256Md;
+    OSSL_LIB_CTX* _lib;
+    OSSL_PROVIDER* _handle;
+} const HmacSha256Md;
+
+OSSL_DISPATCH const HMAC_SHA256_funcs[] =
+{
+    { OSSL_FUNC_DIGEST_NEWCTX, (void (*)())HMAC_SHA256_MD::DigestNew },
+    { OSSL_FUNC_DIGEST_INIT, (void (*)())HMAC_SHA256_MD::DigestInit },
+    { OSSL_FUNC_DIGEST_UPDATE, (void (*)())HMAC_SHA256_MD::DigestUpdate },
+    { OSSL_FUNC_DIGEST_FINAL, (void (*)())HMAC_SHA256_MD::DigestFinal },
+    { OSSL_FUNC_DIGEST_FREECTX, (void (*)())HMAC_SHA256_MD::DigestFree },
+    { OSSL_FUNC_DIGEST_DUPCTX, (void (*)())HMAC_SHA256_MD::DigestDup },
+    { OSSL_FUNC_DIGEST_GET_PARAMS, (void (*)())HMAC_SHA256_MD::DigestGetParams },
+    { OSSL_FUNC_DIGEST_GETTABLE_PARAMS, (void (*)())HMAC_SHA256_MD::DigestGettableParams },
+    { 0, nullptr }
+};
+
+OSSL_ALGORITHM const HMAC_SHA256_algs[] =
+{
+    // pretend this custom HMAC_SHA256 is a regular SHA256 - openssl has a whitelist of allowed digests for RSA and HMAC_SHA256 is not on it
+    { OSSL_DIGEST_NAME_SHA2_256, "provider=havencore-rsa-hmac-sha256", HMAC_SHA256_funcs, "HMAC SHA256 \"digest\" for RSA" },
+    { nullptr, nullptr, nullptr, nullptr }
+};
+
+OSSL_DISPATCH const HMAC_SHA256_method[] =
+{
+    { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)())HMAC_SHA256_MD::QueryProvider },
+    { 0, nullptr },
+};
 }
 
 namespace Trinity
 {
 namespace Crypto
 {
-EVP_MD const* RsaSignature::SHA256::GetGenerator() const
+void RsaSignature::DigestGenerator::EVP_MD_Deleter::operator()(EVP_MD* md) const
 {
-    return EVP_sha256();
+    EVP_MD_free(md);
 }
 
-void RsaSignature::SHA256::PostInitCustomizeContext(EVP_MD_CTX*)
+std::unique_ptr<EVP_MD, RsaSignature::DigestGenerator::EVP_MD_Deleter> RsaSignature::SHA256::GetGenerator() const
 {
+    return std::unique_ptr<EVP_MD, EVP_MD_Deleter>(EVP_MD_fetch(nullptr, OSSL_DIGEST_NAME_SHA2_256, "provider=default"));
 }
 
-EVP_MD const* RsaSignature::HMAC_SHA256::GetGenerator() const
+OSSL_LIB_CTX* RsaSignature::SHA256::GetLib() const
 {
-    return HmacSha256Md;
+    return nullptr;
 }
 
-void RsaSignature::HMAC_SHA256::PostInitCustomizeContext(EVP_MD_CTX* ctx)
+std::unique_ptr<OSSL_PARAM[]> RsaSignature::SHA256::GetParams() const
 {
-    HMAC_SHA256_MD::CTX_DATA* ctxData = reinterpret_cast<HMAC_SHA256_MD::CTX_DATA*>(EVP_MD_CTX_md_data(ctx));
-    if (ctxData->hmac)
-        delete ctxData->hmac;
+    return nullptr;
+}
 
-    ctxData->hmac = new Crypto::HMAC_SHA256(_key, _keyLength);
+std::unique_ptr<EVP_MD, RsaSignature::DigestGenerator::EVP_MD_Deleter> RsaSignature::HMAC_SHA256::GetGenerator() const
+{
+    return std::unique_ptr<EVP_MD, EVP_MD_Deleter>(EVP_MD_fetch(HmacSha256Md.GetLib(), OSSL_DIGEST_NAME_SHA2_256, "provider=havencore-rsa-hmac-sha256"));
+}
+
+OSSL_LIB_CTX* RsaSignature::HMAC_SHA256::GetLib() const
+{
+    return HmacSha256Md.GetLib();
+}
+
+std::unique_ptr<OSSL_PARAM[]> RsaSignature::HMAC_SHA256::GetParams() const
+{
+    return std::unique_ptr<OSSL_PARAM[]>(new OSSL_PARAM[2]
+    {
+        OSSL_PARAM_octet_ptr("hmac-key", const_cast<void**>(reinterpret_cast<void const* const*>(&_key)), _keyLength),
+        OSSL_PARAM_END
+    });
 }
 
 RsaSignature::RsaSignature()
@@ -221,11 +320,24 @@ bool RsaSignature::LoadKeyFromString(std::string const& keyPem)
 
 bool RsaSignature::Sign(uint8 const* message, std::size_t messageLength, DigestGenerator& generator, std::vector<uint8>& output)
 {
+    std::unique_ptr<EVP_MD, DigestGenerator::EVP_MD_Deleter> digestGenerator = generator.GetGenerator();
+    if (!digestGenerator)
+        return false;
+
+    std::unique_ptr<EVP_PKEY_CTX, EVP_PKEY_CTXDeleter> keyCtx(EVP_PKEY_CTX_new_from_pkey(generator.GetLib(), _key, nullptr));
+    EVP_MD_CTX_set_pkey_ctx(_ctx, keyCtx.get());
+
+    std::unique_ptr<OSSL_PARAM[]> params = generator.GetParams();
+    int result = EVP_DigestSignInit_ex(_ctx, nullptr, EVP_MD_get0_name(digestGenerator.get()), generator.GetLib(), nullptr, _key, params.get());
+    if (result == 0)
+        return false;
+
+    result = EVP_DigestSignUpdate(_ctx, message, messageLength);
+    if (result == 0)
+        return false;
+
     size_t signatureLength = 0;
-    EVP_DigestSignInit(_ctx, nullptr, generator.GetGenerator(), nullptr, _key);
-    generator.PostInitCustomizeContext(_ctx);
-    EVP_DigestSignUpdate(_ctx, message, messageLength);
-    int result = EVP_DigestSignFinal(_ctx, nullptr, &signatureLength);
+    result = EVP_DigestSignFinal(_ctx, nullptr, &signatureLength);
     if (result == 0)
         return false;
 

--- a/src/common/Cryptography/RSA.h
+++ b/src/common/Cryptography/RSA.h
@@ -21,6 +21,7 @@
 #include "Define.h"
 #include <openssl/evp.h>
 #include <array>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -34,16 +35,23 @@ public:
     class TC_COMMON_API DigestGenerator
     {
     public:
+        struct EVP_MD_Deleter
+        {
+            void operator()(EVP_MD* md) const;
+        };
+
         virtual ~DigestGenerator() = default;
-        virtual EVP_MD const* GetGenerator() const = 0;
-        virtual void PostInitCustomizeContext(EVP_MD_CTX* ctx) = 0;
+        virtual std::unique_ptr<EVP_MD, EVP_MD_Deleter> GetGenerator() const = 0;
+        virtual OSSL_LIB_CTX* GetLib() const = 0;
+        virtual std::unique_ptr<OSSL_PARAM[]> GetParams() const = 0;
     };
 
     class TC_COMMON_API SHA256 : public DigestGenerator
     {
     public:
-        EVP_MD const* GetGenerator() const override;
-        void PostInitCustomizeContext(EVP_MD_CTX* ctx) override;
+        std::unique_ptr<EVP_MD, EVP_MD_Deleter> GetGenerator() const override;
+        OSSL_LIB_CTX* GetLib() const override;
+        std::unique_ptr<OSSL_PARAM[]> GetParams() const override;
     };
 
     class TC_COMMON_API HMAC_SHA256 : public DigestGenerator
@@ -51,8 +59,9 @@ public:
     public:
         explicit HMAC_SHA256(uint8 const* key, size_t keyLength) : _key(key), _keyLength(keyLength) { }
 
-        EVP_MD const* GetGenerator() const override;
-        void PostInitCustomizeContext(EVP_MD_CTX* ctx) override;
+        std::unique_ptr<EVP_MD, EVP_MD_Deleter> GetGenerator() const override;
+        OSSL_LIB_CTX* GetLib() const override;
+        std::unique_ptr<OSSL_PARAM[]> GetParams() const override;
 
     private:
         uint8 const* _key;


### PR DESCRIPTION
## Changes Proposed:

**World login is completely broken on OpenSSL 3.x.** Every character login kills `worldserver` — first on an assert, then on an access violation. Both faults come from #268 (`6c26bd0`, *"Switch away from most deprecated openssl functions and removed upper version limit"*), and since `dep/openssl/CMakeLists.txt:14` is `find_package(OpenSSL 3 REQUIRED)`, every build is affected.

Two independent bugs, one per commit. Neither fix alone makes login work.

---

### 1. `HMAC.h` — zero buffer size passed to `EVP_DigestSignFinal`

```
D:\BFA-HavenCore\src\common\Cryptography\HMAC.h:140 in
Trinity::Impl::GenericHMAC<&EVP_sha256,32>::Finalize ASSERTION FAILED:
  result == 1
```

```cpp
size_t length = 0;                                            // in/out parameter, not out-only
int result = EVP_DigestSignFinal(_ctx, _digest.data(), &length);
ASSERT(result == 1);                                          // fires
```

Per the OpenSSL docs: *"If `sig` is not NULL then before the call the `siglen` parameter should contain the length of the `sig` buffer."* On 3.x an HMAC `EVP_PKEY` resolves to the provider MAC path, ending in `EVP_MAC_final()` — `crypto/evp/mac_lib.c`:

```c
if (outsize < macsize) {
    ERR_raise(ERR_LIB_EVP, EVP_R_BUFFER_TOO_SMALL);
    return 0;
}
```

`outsize` is the `0` we pass in, `macsize` is 32. It fails on every call with any key and any input.

`6c26bd0` swapped `HMAC_Final` for `EVP_DigestSignFinal` but kept the old initializer. `HMAC_Final`'s length was purely an **output**; `EVP_DigestSignFinal`'s is **in/out**. The same commit removed the OpenSSL upper version bound, which is why this surfaces now — 1.1.1's `hmac_signctx` writes `*siglen` before ever reading it, so `0` was harmless there.

Fix is the initializer, matching [upstream TrinityCore](https://github.com/TrinityCore/TrinityCore/blob/master/src/common/Cryptography/HMAC.h):

```diff
-                size_t length = 0;
+                size_t length = DIGEST_LENGTH;
```

This trips first in `WorldSocket::HandleAuthSession` (`WorldSocket.cpp:699`, the client digest check) — bnetserver's SRP6 handshake is plain SHA256 with no HMAC, so account login succeeds and the abort lands at realm entry.

### 2. `RSA.cpp` — legacy custom `EVP_MD` is never initialized on OpenSSL 3.x

With #1 fixed, login gets four frames further and dies here:

```
Exception code: C0000005 ACCESS_VIOLATION
RAX:0000000000000000

RsaSignature::HMAC_SHA256::PostInitCustomizeContext+23   RSA.cpp line 171
RsaSignature::Sign+5E                                    RSA.cpp line 227
WorldPackets::Auth::EnterEncryptedMode::Write+9D         AuthenticationPackets.cpp line 320
WorldSocket::LoadSessionPermissionsCallback+9D           WorldSocket.cpp line 866
```

`EVP_MD_CTX_md_data()` returns NULL (`RAX:0`). `md_data` is only allocated by OpenSSL's **legacy** digest init, but `EVP_DigestSignInit` with an RSA key takes the **provider** signature path on 3.x — so the custom `EVP_MD` built with `EVP_MD_meth_new` is never initialized that way and its `Init`/`UpdateData`/`Finalize` callbacks are dead code. The file's own comment already flagged the risk: *"EVP_MD_meth_* is deprecated in OpenSSL 3.0 with no replacement able to wrap an arbitrary digest implementation"*.

This is not patchable in place — there is no legacy hook left to hang the HMAC on, and OpenSSL separately whitelists digest names for RSA signing. TrinityCore hit the same wall and solved it in **[`758580c0760c`](https://github.com/TrinityCore/TrinityCore/commit/758580c0760c) — Shauren, 2022-06-17**, which this commit ports: register the HMAC as a **real OpenSSL 3 provider** in its own `OSSL_LIB_CTX`, advertise it under the name `SHA2-256` so it passes RSA's whitelist, and pass the key via `OSSL_PARAM` instead of poking at context internals.

Adjusted from the original in two ways:
- The OpenSSL 1.1 `#if` branches are dropped — OpenSSL 3 is already a hard requirement here.
- The provider is loaded with `OSSL_PROVIDER_try_load(_lib, ..., 1)` (retain fallbacks) rather than separately loading `default` into the libctx, which avoids an unmanaged provider handle. TrinityCore master has since moved to the same form.

`AuthenticationPackets.cpp` is the only consumer and needs no changes — it only touches the generator constructors and `Sign()`, whose signatures are unchanged.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code (Claude Opus 5) was used for the root-cause investigation, the port, and this description. Both changes were reviewed against the OpenSSL 3.0/3.5 documentation and sources and against upstream TrinityCore before submission.

## Issues Addressed:

- Closes <!-- no issue filed for this -->

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Commit 2 is committed with `--author "Shauren <shauren.trinity@gmail.com>"`, crediting the TrinityCore original. Commit 1 is a one-line initializer that restores what upstream TrinityCore already has; no commit was taken for it.

Sources:
- [`EVP_DigestSignInit(3)` — OpenSSL 3.0](https://docs.openssl.org/3.0/man3/EVP_DigestSignFinal/) for the `siglen` in/out contract.
- [`crypto/evp/mac_lib.c`](https://github.com/openssl/openssl/blob/openssl-3.0/crypto/evp/mac_lib.c) (`evp_mac_final`) for the `EVP_R_BUFFER_TOO_SMALL` check.
- [`crypto/hmac/hm_pmeth.c`](https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/crypto/hmac/hm_pmeth.c) (`hmac_signctx`) for why 1.1.1 builds never saw bug 1.
- [TrinityCore `758580c0760c`](https://github.com/TrinityCore/TrinityCore/commit/758580c0760c) — the provider implementation ported in commit 2.

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

- **Build:** `worldserver` builds clean on Windows / VS 2022, x64, RelWithDebInfo — zero errors, no new warnings.
- **Bug 1, runtime:** confirmed fixed against a live server. The `HMAC.h:140` assert is gone and login advances four stack frames further, into the crash described in part 2. That second crash log is the evidence.
- **Bug 2, runtime:** verified with a standalone harness compiled against the same OpenSSL the server links (**3.5.7**), reproducing the exact `Sign()` flow. It confirms the provider loads into the private libctx, `EVP_MD_fetch` resolves the custom `SHA2-256`, RSA resolves through the retained fallback, `EVP_DigestSignInit_ex` succeeds, the digest `init`/`update`/`final` callbacks are all invoked (the ones that were previously dead code), and a 256-byte signature is produced.
- **In-game:** a full character login has **not** been retested end to end yet. The harness proves the signature is produced; it does not prove the client accepts it. The signature construction itself (PKCS1, sha256 algid, reversed byte order) is untouched by this PR.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Build `worldserver` from `main` and start it against a working `auth`/`characters`/`world`/`hotfixes` set.
2. Log in with the 8.3.7 client and select the realm. `worldserver` aborts at `HMAC.h:140` with `ASSERTION FAILED: result == 1` before the character list is sent.
3. Apply commit 1 only, rebuild, repeat: the assert is gone and it now dies with `C0000005 ACCESS_VIOLATION` in `PostInitCustomizeContext` at `RSA.cpp:171`.
4. Apply commit 2, rebuild, repeat: character list loads and world entry completes.
5. Regression check — `HMAC.h` is shared by every HMAC consumer, so also confirm packet encryption holds after world entry and let Warden run a check cycle (`HMAC_SHA1`, `WardenWin.cpp:289`). `RsaSignature::SHA256` shares the reworked `Sign()` path even though only `HMAC_SHA256` was broken.

## Known Issues and TODO List:

- [ ] None.
