### PR TITLE
docs: add issue forms for player bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-quest.yml
+++ b/.github/ISSUE_TEMPLATE/01-quest.yml
@@ -1,0 +1,104 @@
+name: "🗺️ Quest problem"
+description: "A quest you can't pick up, can't finish, or that behaves wrongly"
+title: "[Quest] "
+labels: ["Quest", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        You do not need to know anything about code or GitHub to fill this in.
+
+        Answer what you can and leave the rest blank. A half-filled report is far more useful than no report.
+        A developer will read this and work out the technical side.
+
+  - type: input
+    id: quest-name
+    attributes:
+      label: What is the quest called?
+      description: "Copy the name exactly as it appears in your quest log."
+      placeholder: "Webwood Corruption"
+    validations:
+      required: true
+
+  - type: input
+    id: quest-id
+    attributes:
+      label: Quest ID or Wowhead link
+      description: "If you don't know it, leave this blank — the name above is enough. If you use Wowhead, just paste the address bar."
+      placeholder: "28726  —  or  https://www.wowhead.com/quest=28726"
+
+  - type: dropdown
+    id: what-part
+    attributes:
+      label: Which part of the quest goes wrong?
+      description: "Pick the closest one. If nothing fits, choose Something else and explain below."
+      options:
+        - "I can't pick the quest up"
+        - "The quest doesn't show on my map or minimap"
+        - "The objective never completes, even though I did it"
+        - "The objective completed on its own, without me doing it"
+        - "The objective text is wrong or confusing"
+        - "I can't hand the quest in"
+        - "An NPC that should appear never does"
+        - "An NPC that should follow me doesn't"
+        - "Something in the quest can't be clicked or used"
+        - "Something else"
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: "Describe it the way you'd tell a friend. No special format needed."
+      placeholder: |
+        I picked up the quest from Tarindrella and she was supposed to follow me,
+        but she just stood there. I killed the spiders anyway and the counter
+        never went up.
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-should-happen
+    attributes:
+      label: What should have happened instead?
+      description: "This is the most useful thing you can tell us. Even 'she should have followed me' is enough."
+      placeholder: "Tarindrella should have joined me as a follower when I accepted the quest."
+    validations:
+      required: true
+
+  - type: input
+    id: where
+    attributes:
+      label: Where were you?
+      description: "The zone name is plenty. Coordinates are a bonus if your addon shows them."
+      placeholder: "Teldrassil, near Starbreeze Village"
+
+  - type: input
+    id: character
+    attributes:
+      label: Your character
+      description: "Level, faction, race and class. This helps us reproduce it on a matching character."
+      placeholder: "Level 8 Alliance Night Elf Druid"
+
+  - type: textarea
+    id: proof
+    attributes:
+      label: Screenshots or video
+      description: |
+        Drag an image straight into this box and it will upload by itself. You can also paste a video link.
+        A screenshot of the quest log or the broken NPC is often all we need.
+
+  - type: input
+    id: source
+    attributes:
+      label: How do you know it should work differently?
+      description: "Optional. A Wowhead page, a YouTube video, or just 'I remember it from retail'."
+      placeholder: "https://www.youtube.com/watch?v=..."
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        Please don't add a priority label. A maintainer sorts that during triage, so you never have to
+        guess how serious your report is. Everything gets read.

--- a/.github/ISSUE_TEMPLATE/02-npc.yml
+++ b/.github/ISSUE_TEMPLATE/02-npc.yml
@@ -1,0 +1,101 @@
+name: "👤 NPC or creature problem"
+description: "A monster, guard, vendor or friendly NPC behaving wrongly"
+title: "[NPC] "
+labels: ["Creatures", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        You do not need to know anything about code or GitHub to fill this in.
+
+        Answer what you can and leave the rest blank. A half-filled report is far more useful than no report.
+
+  - type: input
+    id: npc-name
+    attributes:
+      label: What is the NPC called?
+      description: "Copy the name exactly as it appears over their head."
+      placeholder: "Webwood Lurker"
+    validations:
+      required: true
+
+  - type: input
+    id: npc-id
+    attributes:
+      label: NPC ID or Wowhead link
+      description: "If you don't know it, leave this blank. If you use Wowhead, just paste the address bar."
+      placeholder: "1998  —  or  https://www.wowhead.com/npc=1998"
+
+  - type: dropdown
+    id: what-part
+    attributes:
+      label: What is wrong with them?
+      description: "Pick the closest one. If nothing fits, choose Something else and explain below."
+      options:
+        - "They aren't there at all"
+        - "There are two of them when there should be one"
+        - "They stand still when they should walk around"
+        - "They walk somewhere they shouldn't, like up a cliff"
+        - "They attack me when they shouldn't"
+        - "They don't attack when they should"
+        - "They're supposed to be dead or lying down, but they're alive and active"
+        - "They keep casting spells while running away"
+        - "Wrong level, health or damage"
+        - "I can't click on them or talk to them"
+        - "They look wrong, or are floating or sunk into the ground"
+        - "Something else"
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: "Describe it the way you'd tell a friend. No special format needed."
+      placeholder: |
+        I killed Ressan the Needler and his name stayed red and hostile
+        even after he was dead on the ground.
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-should-happen
+    attributes:
+      label: What should have happened instead?
+      placeholder: "His name should go grey once he's dead, like every other mob."
+    validations:
+      required: true
+
+  - type: input
+    id: where
+    attributes:
+      label: Where were you?
+      description: "The zone name is plenty. Coordinates are a bonus if your addon shows them."
+      placeholder: "Tirisfal Glades, near Brill"
+
+  - type: input
+    id: character
+    attributes:
+      label: Your character
+      placeholder: "Level 11 Horde Undead Rogue"
+
+  - type: textarea
+    id: proof
+    attributes:
+      label: Screenshots or video
+      description: |
+        Drag an image straight into this box and it will upload by itself. You can also paste a video link.
+        A screenshot showing the NPC and their nameplate is ideal.
+
+  - type: input
+    id: source
+    attributes:
+      label: How do you know it should work differently?
+      description: "Optional. A Wowhead page, a YouTube video, or just 'I remember it from retail'."
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        Please don't add a priority label. A maintainer sorts that during triage, so you never have to
+        guess how serious your report is. Everything gets read.

--- a/.github/ISSUE_TEMPLATE/03-item.yml
+++ b/.github/ISSUE_TEMPLATE/03-item.yml
@@ -1,0 +1,97 @@
+name: "🎒 Item or loot problem"
+description: "Wrong stats on an item, something that won't drop, or an empty chest"
+title: "[Item] "
+labels: ["Loot", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        You do not need to know anything about code or GitHub to fill this in.
+
+        Answer what you can and leave the rest blank. A half-filled report is far more useful than no report.
+
+  - type: input
+    id: item-name
+    attributes:
+      label: What is the item called?
+      description: "Copy the name exactly as it appears in your bags."
+      placeholder: "Black Leather Vest"
+    validations:
+      required: true
+
+  - type: input
+    id: item-id
+    attributes:
+      label: Item ID or Wowhead link
+      description: "If you don't know it, leave this blank. If you use Wowhead, just paste the address bar."
+      placeholder: "23375  —  or  https://www.wowhead.com/item=23375"
+
+  - type: dropdown
+    id: what-part
+    attributes:
+      label: What is wrong with it?
+      options:
+        - "The stats are wrong"
+        - "It never drops, even after many kills"
+        - "The chest, crate or container it comes from is empty"
+        - "It drops from the wrong creature"
+        - "The item level or quality is wrong"
+        - "I can't equip it, but I should be able to"
+        - "It's the wrong reward for the quest"
+        - "The name, icon or tooltip is wrong"
+        - "Something else"
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: "Describe it the way you'd tell a friend. No special format needed."
+      placeholder: |
+        I've opened about fifteen Battered Chests around Westfall and every
+        single one of them was completely empty.
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-should-happen
+    attributes:
+      label: What should it be instead?
+      description: "For wrong stats, the easiest thing is a Wowhead link plus a screenshot of what you see in game."
+      placeholder: "It should have +4 Agility and +3 Stamina. In game it shows +1 Strength."
+    validations:
+      required: true
+
+  - type: input
+    id: where
+    attributes:
+      label: Where did you get it, or where were you?
+      placeholder: "Westfall, quest reward from Furlbrow's Deed"
+
+  - type: input
+    id: character
+    attributes:
+      label: Your character
+      placeholder: "Level 14 Alliance Human Rogue"
+
+  - type: textarea
+    id: proof
+    attributes:
+      label: Screenshots or video
+      description: |
+        Drag an image straight into this box and it will upload by itself.
+        For wrong stats, a screenshot of the item tooltip in game is the most useful thing you can attach.
+
+  - type: input
+    id: source
+    attributes:
+      label: How do you know it should work differently?
+      description: "Optional. A Wowhead page is ideal for items."
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        Please don't add a priority label. A maintainer sorts that during triage, so you never have to
+        guess how serious your report is. Everything gets read.

--- a/.github/ISSUE_TEMPLATE/04-spell.yml
+++ b/.github/ISSUE_TEMPLATE/04-spell.yml
@@ -1,0 +1,101 @@
+name: "✨ Spell, talent or class ability problem"
+description: "An ability that deals the wrong damage, has the wrong cooldown, or that you shouldn't have yet"
+title: "[Class] "
+labels: ["Class", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        You do not need to know anything about code or GitHub to fill this in.
+
+        Answer what you can and leave the rest blank. A half-filled report is far more useful than no report.
+
+  - type: input
+    id: spell-name
+    attributes:
+      label: What is the ability called?
+      placeholder: "Moonfire"
+    validations:
+      required: true
+
+  - type: input
+    id: spell-id
+    attributes:
+      label: Spell ID or Wowhead link
+      description: "If you don't know it, leave this blank. If you use Wowhead, just paste the address bar."
+      placeholder: "8921  —  or  https://www.wowhead.com/spell=8921"
+
+  - type: input
+    id: class-spec
+    attributes:
+      label: Your class and specialisation
+      description: "If you're below level 10 and haven't picked a spec yet, just say so."
+      placeholder: "Druid, no spec yet (level 3)"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: what-part
+    attributes:
+      label: What is wrong with it?
+      options:
+        - "It deals no damage or healing at all"
+        - "The damage or healing is too high or too low"
+        - "The cooldown is wrong, or there's no cooldown at all"
+        - "I have this ability but I'm too low level for it"
+        - "I should have this ability by now, but I don't"
+        - "I can't learn it from the trainer"
+        - "It doesn't do what the tooltip says"
+        - "The buff or debuff doesn't apply, or falls off early"
+        - "The resource cost is wrong"
+        - "Something else"
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: "Describe it the way you'd tell a friend. If you can, say what numbers you saw."
+      placeholder: |
+        Moonfire is supposed to tick every 2 seconds. On the same target,
+        sometimes it ticks normally and sometimes it deals nothing at all
+        for the whole duration.
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-should-happen
+    attributes:
+      label: What should have happened instead?
+      placeholder: "It should tick for arcane damage every 2 seconds, every time."
+    validations:
+      required: true
+
+  - type: input
+    id: character
+    attributes:
+      label: Your character level and race
+      description: "Race matters for racial abilities."
+      placeholder: "Level 3 Night Elf"
+
+  - type: textarea
+    id: proof
+    attributes:
+      label: Screenshots or video
+      description: |
+        Drag an image straight into this box and it will upload by itself.
+        A screenshot of your combat log or the ability tooltip is very useful here.
+
+  - type: input
+    id: source
+    attributes:
+      label: How do you know it should work differently?
+      description: "Optional. A Wowhead page, a YouTube video, or just 'I remember it from retail'."
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        Please don't add a priority label. A maintainer sorts that during triage, so you never have to
+        guess how serious your report is. Everything gets read.

--- a/.github/ISSUE_TEMPLATE/05-profession.yml
+++ b/.github/ISSUE_TEMPLATE/05-profession.yml
@@ -1,0 +1,100 @@
+name: "🔨 Profession problem"
+description: "A profession you can't train, a skill that won't go up, or a missing recipe"
+title: "[Profession] "
+labels: ["Proffesion", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        You do not need to know anything about code or GitHub to fill this in.
+
+        Answer what you can and leave the rest blank. A half-filled report is far more useful than no report.
+
+  - type: dropdown
+    id: profession
+    attributes:
+      label: Which profession?
+      options:
+        - Alchemy
+        - Blacksmithing
+        - Enchanting
+        - Engineering
+        - Inscription
+        - Jewelcrafting
+        - Leatherworking
+        - Tailoring
+        - Herbalism
+        - Mining
+        - Skinning
+        - Archaeology
+        - Cooking
+        - Fishing
+        - First Aid
+    validations:
+      required: true
+
+  - type: dropdown
+    id: what-part
+    attributes:
+      label: What is wrong?
+      options:
+        - "I can't learn the profession at all"
+        - "The trainer won't talk to me, or clicking does nothing"
+        - "The trainer only offers it to some classes or races"
+        - "My skill level is wrong, or it was set to the wrong number"
+        - "My skill won't go up any further"
+        - "A recipe I should have is missing"
+        - "Gathering gives nothing, or gives the wrong thing"
+        - "I can gather while mounted, and I don't think I should"
+        - "Something else"
+    validations:
+      required: true
+
+  - type: input
+    id: trainer
+    attributes:
+      label: Which trainer, and where?
+      description: "If a trainer is involved, their name and zone. Leave blank if not."
+      placeholder: "Karolek in Orgrimmar"
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: "Describe it the way you'd tell a friend. No special format needed."
+      placeholder: |
+        I learned Fishing and it immediately gave me 60 out of 60 skill.
+        The trainer then said I don't have enough skill to learn the next rank,
+        so I'm stuck and can't raise it any further.
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-should-happen
+    attributes:
+      label: What should have happened instead?
+      placeholder: "Learning Fishing should start me at 1 skill and let me raise it by fishing."
+    validations:
+      required: true
+
+  - type: input
+    id: character
+    attributes:
+      label: Your character
+      description: "Level, faction, race and class. Class and race matter a lot for trainer problems."
+      placeholder: "Level 10 Horde Orc Shaman"
+
+  - type: textarea
+    id: proof
+    attributes:
+      label: Screenshots or video
+      description: |
+        Drag an image straight into this box and it will upload by itself.
+        A screenshot of the trainer window or your profession panel is ideal.
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        Please don't add a priority label. A maintainer sorts that during triage, so you never have to
+        guess how serious your report is. Everything gets read.

--- a/.github/ISSUE_TEMPLATE/06-dungeon.yml
+++ b/.github/ISSUE_TEMPLATE/06-dungeon.yml
@@ -1,0 +1,101 @@
+name: "🏰 Dungeon or raid problem"
+description: "A boss that doesn't work, a fight you can't finish, or wrong loot from a dungeon"
+title: "[Dungeon] "
+labels: ["Instance", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        You do not need to know anything about code or GitHub to fill this in.
+
+        Answer what you can and leave the rest blank. A half-filled report is far more useful than no report.
+
+  - type: input
+    id: dungeon
+    attributes:
+      label: Which dungeon or raid?
+      placeholder: "The Deadmines"
+    validations:
+      required: true
+
+  - type: input
+    id: boss
+    attributes:
+      label: Which boss or which part?
+      description: "Leave blank if it's not tied to one boss."
+      placeholder: "Admiral Ripsnarl"
+
+  - type: dropdown
+    id: difficulty
+    attributes:
+      label: Which difficulty?
+      options:
+        - Normal
+        - Heroic
+        - "Not sure"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: what-part
+    attributes:
+      label: What is wrong?
+      options:
+        - "The fight can't be finished, we're stuck"
+        - "The boss doesn't spawn, or doesn't come back after a wipe"
+        - "The boss doesn't use their abilities properly"
+        - "An invisible or wrong creature is attacking us"
+        - "The loot is wrong for this difficulty"
+        - "A door, chest or object won't work"
+        - "Trash mobs behave wrongly"
+        - "I can't enter the dungeon"
+        - "Something else"
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: "Describe it the way you'd tell a friend. No special format needed."
+      placeholder: |
+        We pulled Admiral Ripsnarl, he vanished into the fog phase and never
+        came back. Something called "General Purpose Bunny" was hitting us
+        the whole time. We had to reset the instance.
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-should-happen
+    attributes:
+      label: What should have happened instead?
+      placeholder: "Ripsnarl should reappear after the fog phase so we can keep fighting him."
+    validations:
+      required: true
+
+  - type: input
+    id: group
+    attributes:
+      label: How many were in your group, and what levels?
+      placeholder: "5 players, levels 16 to 19"
+
+  - type: textarea
+    id: proof
+    attributes:
+      label: Screenshots or video
+      description: |
+        Drag an image straight into this box and it will upload by itself. You can also paste a video link.
+        Video is especially helpful for boss fights.
+
+  - type: input
+    id: source
+    attributes:
+      label: How do you know it should work differently?
+      description: "Optional. A Wowhead page, a YouTube video of the fight, or just 'I remember it from retail'."
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        Please don't add a priority label. A maintainer sorts that during triage, so you never have to
+        guess how serious your report is. Everything gets read.

--- a/.github/ISSUE_TEMPLATE/07-object.yml
+++ b/.github/ISSUE_TEMPLATE/07-object.yml
@@ -1,0 +1,93 @@
+name: "📦 Object or vehicle problem"
+description: "A chest, door, ladder, cannon or vehicle that won't work when you click it"
+title: "[Object] "
+labels: ["Object", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This one is for things in the world you click on rather than talk to — chests, crates, doors,
+        levers, ladders, cannons, mine carts, and anything you're supposed to ride or control.
+
+        You do not need to know anything about code or GitHub to fill this in.
+
+  - type: input
+    id: object-name
+    attributes:
+      label: What is it called?
+      description: "The name that appears when you hover your mouse over it."
+      placeholder: "Rope Ladder"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: what-part
+    attributes:
+      label: What is wrong with it?
+      options:
+        - "Clicking it does nothing at all"
+        - "I can't click it, the cursor never changes"
+        - "It's a chest or container and it's empty"
+        - "I get in the vehicle but the controls don't work"
+        - "I get a pet instead of getting in the vehicle"
+        - "It moves me somewhere instead of doing what it should"
+        - "It's floating, sunk into the ground, or in the wrong place"
+        - "It's already used or already open when it shouldn't be"
+        - "I can use it over and over when I should only get one use"
+        - "Something else"
+    validations:
+      required: true
+
+  - type: input
+    id: quest
+    attributes:
+      label: Is this part of a quest?
+      description: "If yes, the quest name. This tells us whether the quest is blocked."
+      placeholder: "Precious Cargo"
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: "Describe it the way you'd tell a friend. No special format needed."
+      placeholder: |
+        The rope ladders on the side of the ship show the gear cursor when I
+        get close, so I know I'm near enough, but right clicking them does
+        absolutely nothing. I can't get up the ship at all.
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-should-happen
+    attributes:
+      label: What should have happened instead?
+      placeholder: "Clicking the ladder should climb me up onto the ship deck."
+    validations:
+      required: true
+
+  - type: input
+    id: where
+    attributes:
+      label: Where is it?
+      description: "The zone name is plenty. Coordinates are a bonus if your addon shows them."
+      placeholder: "The Lost Isles, at the beached ship"
+
+  - type: input
+    id: character
+    attributes:
+      label: Your character
+      placeholder: "Level 6 Horde Goblin Warrior"
+
+  - type: textarea
+    id: proof
+    attributes:
+      label: Screenshots or video
+      description: |
+        Drag an image straight into this box and it will upload by itself. You can also paste a video link.
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        Please don't add a priority label. A maintainer sorts that during triage, so you never have to
+        guess how serious your report is. Everything gets read.

--- a/.github/ISSUE_TEMPLATE/08-something-else.yml
+++ b/.github/ISSUE_TEMPLATE/08-something-else.yml
@@ -1,0 +1,60 @@
+name: "❓ Something else"
+description: "Anything that doesn't fit the other categories — including visual glitches, the shop, or the game client"
+title: ""
+labels: ["needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this one if none of the other templates fit, or if you're not sure which one to pick.
+        Picking the "wrong" template is not a problem — a maintainer will sort it out.
+
+        You do not need to know anything about code or GitHub to fill this in.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: "Describe it the way you'd tell a friend. No special format needed."
+      placeholder: |
+        There's a whirlwind visual effect that keeps drifting across Eversong Woods.
+        Nothing is casting it and it doesn't seem to belong to anything.
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-should-happen
+    attributes:
+      label: What should have happened instead?
+      description: "If you're not sure, just say what looked wrong about it."
+      placeholder: "There shouldn't be a whirlwind there at all."
+    validations:
+      required: true
+
+  - type: input
+    id: where
+    attributes:
+      label: Where were you?
+      description: "Leave blank if it isn't tied to a place."
+      placeholder: "Eversong Woods"
+
+  - type: input
+    id: character
+    attributes:
+      label: Your character
+      description: "Level, faction, race and class, if it's relevant."
+      placeholder: "Level 12 Horde Blood Elf Mage"
+
+  - type: textarea
+    id: proof
+    attributes:
+      label: Screenshots or video
+      description: |
+        Drag an image straight into this box and it will upload by itself. You can also paste a video link.
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        Please don't add a priority label. A maintainer sorts that during triage, so you never have to
+        guess how serious your report is. Everything gets read.

--- a/.github/ISSUE_TEMPLATE/09-server.yml
+++ b/.github/ISSUE_TEMPLATE/09-server.yml
@@ -1,0 +1,71 @@
+name: "⚙️ Server, build or crash"
+description: "For contributors: build failures, crashes, performance problems, or core code issues"
+title: "[Core] "
+labels: ["CPP", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This one is aimed at people building or running the core themselves. If you're a player who hit
+        something odd in game, one of the other templates will fit better — but don't worry about
+        picking wrong, a maintainer will re-file it.
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: What kind of problem is it?
+      options:
+        - "worldserver or bnetserver crashes"
+        - "Build failure"
+        - "Performance: lag, low update diff, or high CPU"
+        - "Database or SQL update problem"
+        - "Something is wrong in the core code"
+        - "Something else technical"
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: "Include the exact error text if there is one."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How do we reproduce it?
+      description: "The steps you took, in order."
+      placeholder: |
+        1. Configure with -DTOOLS=0
+        2. Build the worldserver target
+        3. Build fails in ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs, crash dump or build output
+      description: "Paste the relevant part. Long output is fine — GitHub will fold it automatically."
+      render: text
+
+  - type: input
+    id: commit
+    attributes:
+      label: Which commit are you on?
+      description: "Run `git rev-parse --short HEAD` if you're not sure."
+      placeholder: "adbeaf1"
+
+  - type: input
+    id: environment
+    attributes:
+      label: Your build environment
+      placeholder: "Windows 11, Visual Studio 2022, RelWithDebInfo, MySQL 8.0, OpenSSL 3.x"
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        Please don't add a priority label. A maintainer sorts that during triage.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
Adds nine GitHub issue forms under `.github/ISSUE_TEMPLATE/`, plus a `config.yml` that turns off the blank issue box.

## Why

Most people filing here are players, not contributors. They land on an empty text box and are asked, implicitly, to already know how a good bug report is structured — which quest ID matters, whether "it doesn't work" means the NPC is missing or the credit doesn't fire, what a maintainer needs in order to reproduce it. Reports come in thin, a maintainer asks three follow-up questions, and half the time the reporter is gone by then.

These forms ask those questions up front, in plain language, before the report is submitted.

## What's in it

| File | Form | Auto-label |
| --- | --- | --- |
| `01-quest.yml` | 🗺️ Quest problem | `Quest` |
| `02-npc.yml` | 👤 NPC or creature problem | `Creatures` |
| `03-item.yml` | 🎒 Item or loot problem | `Loot` |
| `04-spell.yml` | ✨ Spell, talent or class ability problem | `Class` |
| `05-profession.yml` | 🔨 Profession problem | `Proffesion` |
| `06-dungeon.yml` | 🏰 Dungeon or raid problem | `Instance` |
| `07-object.yml` | 📦 Object or vehicle problem | `Object` |
| `08-something-else.yml` | ❓ Something else | — |
| `09-server.yml` | ⚙️ Server, build or crash | `CPP` |

Every form also applies `needs-triage`.

Design decisions worth flagging, since they are deliberate rather than accidental:

- **Written for someone who has never used GitHub.** Each player-facing form opens with "You do not need to know anything about code or GitHub to fill this in. Answer what you can and leave the rest blank."
- **IDs are optional everywhere**, with an inline "if you don't know it, leave this blank". Requiring a quest ID from a player is how you lose the report.
- **Every form asks both "what happened" and "what should have happened instead."** The second half is the one that is almost always missing and almost always the useful one — it tells a maintainer what correct looks like.
- **Each form ends by asking reporters *not* to set a priority label**, because a maintainer sorts that during triage. This is the counterpart to the label cleanup on the tracker: priority was being self-assigned by reporters, which meant it sorted nothing.
- **Screenshot fields explain drag-and-drop upload**, because that is not obvious if you have not done it before.
- **`blank_issues_enabled: false`** so nobody lands back on the empty box by accident. `08-something-else.yml` is the escape hatch, and it says outright that picking the "wrong" template is not a problem.
- **`09-server.yml` is the only contributor-facing form** — build failures, crashes, performance — and it says so in its first paragraph so players self-select away from it.

## Changes Proposed:

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

None of the above — this is repository tooling only. No C++, no SQL, no script or DB2 changes. Nothing in this PR is reachable from a running worldserver.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request.

Claude Opus 5, via Claude Code. The form copy and structure were drafted with it after a manual pass over the open tracker to work out which categories the real reports actually fall into and what information they were consistently missing.

## Issues Addressed:

None directly. This is preventative — it is aimed at the quality of issues that have not been filed yet.

## SOURCE:

- [ ] Live research
- [ ] Sniffs
- [ ] Video evidence, knowledge databases or other public sources
- [ ] Cherry-pick

Not applicable. This PR changes no game behaviour, so there is nothing to validate against retail or a sniff. The category split and the field list were derived from the currently open issues on this tracker.

## Tests Performed:

- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members.
- [x] This pull request requires further testing and may have edge cases to be tested.

What was actually verified: all ten YAML files parse, and each was checked against GitHub's issue-form schema — every field has a valid `type`, every non-`markdown` field has a `label`, every `dropdown` has a non-empty `options` list, and `validations` is a sibling of `attributes` rather than nested inside it. One nesting error in `09-server.yml` was caught this way and fixed before commit.

What was **not** verified, and cannot be from a branch: GitHub only serves issue templates from the default branch, so the template chooser and the rendered forms cannot be seen until this is merged. The labels each form applies must also already exist on the repo or GitHub silently drops them — they all exist today, including `Proffesion` with its current spelling, which the forms match deliberately rather than correcting.

## How to Test the Changes:

- [x] This pull request requires further testing.

1. Merge to the default branch.
2. Open **Issues → New issue**. The chooser should list all nine forms and offer no blank-issue option.
3. Open one player-facing form (🗺️ Quest problem is the busiest category) and submit a throwaway report. Confirm the title prefix `[Quest]` and the labels `Quest` + `needs-triage` are applied, and that leaving every optional field blank still submits.
4. Open ⚙️ Server, build or crash and confirm the `render: text` box on the log field produces an unformatted code block.

## Known Issues and TODO List:

- [ ] The `Proffesion` label is misspelled on the repo. The forms match the existing spelling on purpose so labelling does not silently break. Renaming the label is a separate change, and would need these forms updated in the same commit.
- [ ] Category boundaries will need adjusting once real traffic arrives — expect "Object or vehicle" and "Quest" to overlap, since a stuck vehicle is usually also a blocked quest.
