### PR TITLE
DB: Fix floating Peacebloom and Strigid Screecher

### DIFF
--- a/sql/updates/world/2026_08_16_00_strigid_screecher_and_floating_peacebloom_fix.sql
+++ b/sql/updates/world/2026_08_16_00_strigid_screecher_and_floating_peacebloom_fix.sql
@@ -1,0 +1,10 @@
+-- Strigid Screecher (ID 1996) - Set unit_flags to IMMUNE_TO_NPC
+UPDATE `creature_template`
+SET `unit_flags` = 512
+WHERE `entry` = 1996;
+
+
+-- Peacebloom (ID 1618) - was floating.
+UPDATE `gameobject`
+SET `position_z` = 1322.1
+WHERE `guid` = 14979 AND `id` = 1618


### PR DESCRIPTION
Addresses 2 issues at the same time.
1) Issue #301
2) Issue #299

- Strigid Screecher (1996) - Was an enemy when it should be neutral
- Peacebloom (1618/14979) - Was floating; now fixed.

