### PR TITLE
DB: Fixes 3 critters

### DIFF
--- a/sql/updates/world/2026_08_16_01_critter_fixes.sql
+++ b/sql/updates/world/2026_08_16_01_critter_fixes.sql
@@ -1,0 +1,14 @@
+-- Elfin Rabbit (ID 49728)
+UPDATE `creature_template_scaling`
+SET `LevelScalingMax` = 1, `LevelScalingMin` = 1
+WHERE `entry` = 49728;
+
+-- Red-Tailed Chipmunk (ID 49778)
+UPDATE `creature_template_scaling`
+SET `LevelScalingMax` = 1, `LevelScalingMin` = 1
+WHERE `entry` = 49778;
+
+-- Spider (ID 14881) - Unit_Flags corrected (Was 33024 (Only_Swim, IMMUNE_TO_PC)), Family corrected (was NONE, set to Spider (3))
+UPDATE `creature_template`
+SET `unit_flags` = 512, `family` = 3
+WHERE `entry` = 14881;


### PR DESCRIPTION
NOTE: Pathing isn't fixed here, but level scaling and being able to kill the spider critter have been fixed. Issue about these: #294

<img width="321" height="125" alt="Chipmunk" src="https://github.com/user-attachments/assets/3adf4544-6afc-4fbd-972e-071a5a8ce872" />
<img width="303" height="122" alt="Rabbit" src="https://github.com/user-attachments/assets/d4e07cff-253a-49c8-a32b-756ef68187e7" />
<img width="325" height="131" alt="Spider" src="https://github.com/user-attachments/assets/965be562-e487-44ec-9042-38cac37c7802" />

- Spider (ID 14881)
- Red-Tailed Chipmunk (ID 49778)
- Elfin Rabbit (ID 49728)