### PR TITLE
Fix quest 37446 Lazy Peons

### DIFF
--- a/sql/updates/world/2026_08_17_00_world_quest_37446_lazy_peons.sql
+++ b/sql/updates/world/2026_08_17_00_world_quest_37446_lazy_peons.sql
@@ -1,0 +1,7 @@
+-- Fix quest 37446 "Lazy Peons"
+-- Let SmartAI control the sleep/wake state for Lazy Peon (10556).
+
+UPDATE `creature_template_addon`
+SET `bytes1` = 0,
+    `auras` = ''
+WHERE `entry` = 10556;


### PR DESCRIPTION
Quest 37446 - Lazy Peons

Problem:
Using Foreman's Blackjack on sleeping Lazy Peons (NPC 10556) returned "Invalid target".
After waking, peons could also continue working while still in the sleeping state.

Cause:
creature_template_addon forced bytes1 = 3 and aura 78677, while SmartAI already controls the Lazy Peon's sleep/wake state dynamically.

Fix:
Set bytes1 to 0 and remove aura 78677 from creature_template_addon for NPC 10556.

Tested:
- Peons spawn sleeping
- Foreman's Blackjack works correctly
- Quest credit is granted
- Peons wake and work standing
- Peons eventually return to sleep