### PR TITLE
Fix Vile Familiar right-click attack

### DIFF
--- a/sql/updates/world/2026_08_17_01_world_npc_3101_vile_familiar.sql
+++ b/sql/updates/world/2026_08_17_01_world_npc_3101_vile_familiar.sql
@@ -1,0 +1,6 @@
+-- Fix Vile Familiar (3101) right-click attack behavior.
+-- npcflag 2 causes hostile creatures to be treated as interactable NPCs.
+
+UPDATE `creature_template`
+SET `npcflag` = 0
+WHERE `entry` = 3101;


### PR DESCRIPTION
Fixes incorrect interaction behavior for Vile Familiar (NPC 3101) in the Valley of Trials.

Problem

Right-clicking a Vile Familiar did not start auto attack and instead displayed:

You need to be closer to interact with that target.

Attacking through an ability or the auto-attack action button worked correctly.

Cause

Vile Familiar had:

npcflag = 2

in creature_template.

This caused the creature to be treated as an interactable NPC when right-clicked instead of behaving as a normal hostile creature.

Fix

Changed npcflag from 2 to 0 for creature entry 3101.

Testing

Tested in-game after applying the database change:

Right-clicking Vile Familiar now starts combat normally.
The incorrect interaction-distance message no longer appears.
Spell attacks continue to work normally.
Other combat behavior remains unchanged.