### PR TITLE
DB: Slain Outrunner + Impaled Blackrock Orc Fix

### DIFF
--- a/sql/updates/world/2026_08_18_00_fix_implaed_blackrock_orc_and_slain_outrunner.sql
+++ b/sql/updates/world/2026_08_18_00_fix_implaed_blackrock_orc_and_slain_outrunner.sql
@@ -1,0 +1,14 @@
+-- Slain Outrunner (17849) - Fixes the issue where she would show as alive while she should be dead.
+UPDATE `creature_template` 
+SET `unit_flags3` = 8192 
+WHERE (`entry` = 17849);
+
+
+-- Impaled Blackrock Ork (ID 43150) - Fixes a few issues.
+-- 1) Would be hostile towards player(s)
+-- 2) Feign death flag removed.
+-- 3) Showen as alive, when it should show as dead.
+-- 4) Shows correct animation, not death animation.
+UPDATE `creature_template` 
+SET `unit_flags` = 768, `unit_flags2` = 2048, `unit_flags3` = 8192, `dynamicflags` = 0 
+WHERE (`entry` = 43150);


### PR DESCRIPTION
Issues fixed with this PR
- #153
- #219

- Slain Outrunner (17849) now shows as dead.
- Impaled Blackrock Ork (ID 43150) - Fixes a few issues.
- 1) Would be hostile towards player(s)
- 2) Feign death flag removed.
- 3) Shown as alive when it should be shown as dead.
- 4) Shows the correct animation, not the death animation.