### PR TITLE
DB: Removes leftover gameobjects

### DIFF
--- a/sql/updates/world/2026_08_20_00_removes_floating_debris_and_lesser_oily_blackmouth_school.sql
+++ b/sql/updates/world/2026_08_20_00_removes_floating_debris_and_lesser_oily_blackmouth_school.sql
@@ -1,0 +1,364 @@
+-- Deletes a lot of Floating Debries and (DEPRECATED) Lesser Oily Blackmouth Schoo leftover from after Cataclysim changed the zones.
+
+
+-- Floating Debris (Entry 180655 - GUID 4589) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180655) AND (`guid` = 4589);
+
+-- Floating Debris (GUID 4589) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4589));
+-- -------------------------------
+
+
+-- Floating Debris (Entry 180655 - GUID 4618) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180655) AND (`guid` = 4618);
+
+-- Floating Debris (GUID 4618) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4618));
+-- -------------------------------
+
+
+-- Floating Debris (Entry 180655 - GUID 4621) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180655) AND (`guid` = 4621);
+
+-- Floating Debris (GUID 4621) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4621));
+-- -------------------------------
+
+
+-- Floating Debris (Entry 180655 - GUID 4584) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180655) AND (`guid` = 4584);
+
+-- Floating Debris (GUID 4584) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4584));
+-- -------------------------------
+
+
+-- Floating Debris (Entry 180655 - GUID 4636) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180655) AND (`guid` = 4636);
+
+-- Floating Debris (GUID 4636) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4636));
+-- -------------------------------
+
+
+-- Floating Debris (Entry 180655 - GUID 4637) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180655) AND (`guid` = 4637);
+
+-- Floating Debris (GUID 4637) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4637));
+-- -------------------------------
+
+
+-- Floating Debris (Entry 180655 - GUID 4619) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180655) AND (`guid` = 4619);
+
+-- Floating Debris (GUID 4619) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4619));
+-- -------------------------------
+
+
+-- Floating Debris (Entry 180655 - GUID 4588) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180655) AND (`guid` = 4588);
+
+-- Floating Debris (GUID 4588) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4588));
+-- -------------------------------
+
+
+-- Floating Debris (Entry 180655 - GUID 4579) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180655) AND (`guid` = 4579);
+
+-- Floating Debris (GUID 4579) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4579));
+-- -------------------------------
+
+
+-- Floating Debris (Entry 180655 - GUID 4587) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180655) AND (`guid` = 4587);
+
+-- Floating Debris (GUID 4587) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4587));
+-- -------------------------------
+
+
+-- Floating Debris (Entry 180655 - GUID 4638) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180655) AND (`guid` = 4638);
+
+-- Floating Debris (GUID 4638) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4638));
+-- -------------------------------
+
+
+-- Floating Debris (Entry 180655 - GUID 4631) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180655) AND (`guid` = 4631);
+
+-- Floating Debris (GUID 4631) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4631));
+-- -------------------------------
+
+
+-- Floating Debris (Entry 180655 - GUID 4620) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180655) AND (`guid` = 4620);
+
+-- Floating Debris (GUID 4620) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4620));
+-- -------------------------------
+
+
+-- Floating Debris (Entry 180655 - GUID 4713) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180655) AND (`guid` = 4713);
+
+-- Floating Debris (GUID 4713) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4713));
+-- -------------------------------
+
+
+-- Floating Debris (Entry 180655 - GUID 4582) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180655) AND (`guid` = 4582);
+
+-- Floating Debris (GUID 4582) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4582));
+-- -------------------------------
+
+
+-- Floating Debris (Entry 180655 - GUID 4634) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180655) AND (`guid` = 4634);
+
+-- Floating Debris (GUID 4634) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4634));
+-- -------------------------------
+
+
+-- Floating Debris (Entry 180655 - GUID 26576) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180655) AND (`guid` = 26576);
+
+-- Floating Debris (GUID 26576) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (26576));
+-- -------------------------------
+
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (Entry 180582 - GUID 4737) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180582) AND (`guid` = 4737);
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (GUID 4737) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4737));
+-- -------------------------------
+
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (Entry 180582 - GUID 4752) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180582) AND (`guid` = 4752);
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (GUID 4752) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4752));
+-- -------------------------------
+
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (Entry 180582 - GUID 4757) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180582) AND (`guid` = 4757);
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (GUID 4757) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4757));
+-- -------------------------------
+
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (Entry 180582 - GUID 4727) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180582) AND (`guid` = 4727);
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (GUID 4727) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4727));
+-- -------------------------------
+
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (Entry 180582 - GUID 4778) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180582) AND (`guid` = 4778);
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (GUID 4778) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4778));
+-- -------------------------------
+
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (Entry 180582 - GUID 4754) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180582) AND (`guid` = 4754);
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (GUID 4754) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4754));
+-- -------------------------------
+
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (Entry 180582 - GUID 4733) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180582) AND (`guid` = 4733);
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (GUID 4733) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4733));
+-- -------------------------------
+
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (Entry 180582 - GUID 4723) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180582) AND (`guid` = 4723);
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (GUID 4723) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4723));
+-- -------------------------------
+
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (Entry 180582 - GUID 4730) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180582) AND (`guid` = 4730);
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (GUID 4730) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4730));
+-- -------------------------------
+
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (Entry 180582 - GUID 4780) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180582) AND (`guid` = 4780);
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (GUID 4780) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4780));
+-- -------------------------------
+
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (Entry 180582 - GUID 4764) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180582) AND (`guid` = 4764);
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (GUID 4764) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4764));
+-- -------------------------------
+
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (Entry 180582 - GUID 4755) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180582) AND (`guid` = 4755);
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (GUID 4755) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4755));
+-- -------------------------------
+
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (Entry 180582 - GUID 4787) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180582) AND (`guid` = 4787);
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (GUID 4787) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4787));
+-- -------------------------------
+
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (Entry 180582 - GUID 4725) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180582) AND (`guid` = 4725);
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (GUID 4725) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4725));
+-- -------------------------------
+
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (Entry 180582 - GUID 4765) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180582) AND (`guid` = 4765);
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (GUID 4765) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4765));
+-- -------------------------------
+
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (Entry 180582 - GUID 4751) - from gameobject table
+-- -------------------------------
+DELETE FROM `gameobject`
+WHERE (`id` = 180582) AND (`guid` = 4751);
+
+-- (DEPRECATED) Lesser Oily Blackmouth School (GUID 4751) - from gameobject_addon table
+DELETE FROM `gameobject_addon`
+WHERE (`guid` IN (4751));
+-- -------------------------------


### PR DESCRIPTION
Removes a lot of Floating Debris and Lesser Oily Blackmouth School.
All these objects were found while fixing the 1 - 19 bracket(s).
More fixes for objects in the air to come.