### PR TITLE
DB: Gameobject and Critter fixes.

### DIFF
--- a/sql/updates/world/2026_08_21_00_gameobject_spawns_and_critter_fixes.sql
+++ b/sql/updates/world/2026_08_21_00_gameobject_spawns_and_critter_fixes.sql
@@ -1,0 +1,137 @@
+-- Skunk (ID 17467)
+UPDATE `creature_template_scaling`
+SET `LevelScalingMin` = 1, `LevelScalingMax` = 1
+WHERE `entry` = 17467;
+
+-- Food Crate (ID 3662 - GUID 13271) 
+UPDATE `gameobject` 
+SET `position_z` = 30.6
+WHERE `id` = 3662 AND `guid` = 13271;
+
+
+-- Barrel of Milk (ID 3705 - GUID 4931) 
+UPDATE `gameobject` 
+SET `position_z` = 30.5
+WHERE `id` = 3705 AND `guid` = 4931;
+
+
+-- Battered Chest (ID 106319 - GUID 11225) 
+UPDATE `gameobject` 
+SET `position_z` = 27.4
+WHERE `id` = 106319 AND `guid` = 11225;
+
+
+-- Silver Leaf (ID 1617 - GUID 1194) 
+UPDATE `gameobject` 
+SET `position_z` = 19.1
+WHERE `id` = 1617 AND `guid` = 1194;
+
+
+-- Silver Leaf (ID 1617 - GUID 89315) 
+UPDATE `gameobject` 
+SET `position_z` = 17
+WHERE `id` = 1617 AND `guid` = 89315;
+
+
+-- Silver Leaf (ID 1617 - GUID 91611) 
+UPDATE `gameobject` 
+SET `position_z` = 24.6
+WHERE `id` = 1617 AND `guid` = 91611;
+
+
+-- Silver Leaf (ID 1617 - GUID 3739) 
+UPDATE `gameobject` 
+SET `position_z` = 24.8
+WHERE `id` = 1617 AND `guid` = 3739;
+
+
+-- Silver Leaf (ID 1617 - GUID 91584) 
+UPDATE `gameobject` 
+SET `position_z` = 5.1, `position_x` = 6473.9, `position_y` = -113.3
+WHERE `id` = 1617 AND `guid` = 91584;
+
+
+-- Earthroot (ID 1619 - GUID 15765)
+UPDATE `gameobject`
+SET `position_z` = 3.6, `position_x` = 5416.5, `position_y` = 135.5
+WHERE `id` = 1619 AND `guid` = 15765;
+
+-- Earthroot (ID 1619 - GUID 89314)
+UPDATE `gameobject`
+SET `position_z` = 12.32, `position_x` = 5416.5, `position_y` = 135.5
+WHERE `id` = 1619 AND `guid` = 89314;
+
+-- Earthroot (ID 1619 - GUID 8610)
+UPDATE `gameobject`
+SET `position_z` = 3.6, `position_x` = 5416.5, `position_y` = 135.5
+WHERE `id` = 1619 AND `guid` = 8610;
+
+-- Mageroyal (ID 1620 - GUID 6668)
+UPDATE `gameobject`
+SET `position_z` = 10.1, `position_x` = 5166.5, `position_y` = 211.1
+WHERE `id` = 1620 AND `guid` = 6668;
+
+-- Mageroyal (ID 1620 - GUID 6662)
+UPDATE `gameobject`
+SET `position_z` = 4.9, `position_x` = 5166.5, `position_y` = 211.1
+WHERE `id` = 1620 AND `guid` = 6662;
+
+-- Mageroyal (ID 1620 - GUID 6887)
+UPDATE `gameobject`
+SET `position_z` = 33.1, `position_x` = 5166.5, `position_y` = 211.1
+WHERE `id` = 1620 AND `guid` = 6887;
+
+-- Mageroyal (ID 1620 - GUID 6362)
+UPDATE `gameobject`
+SET `position_z` = 681.9
+WHERE `id` = 1620 AND `guid` = 6362;
+
+-- Briarthorn (ID 1621 - GUID 91554)
+UPDATE `gameobject`
+SET `position_z` = 46.2
+WHERE `id` = 1621 AND `guid` = 91554;
+
+-- Briarthorn (ID 1621 - GUID 94010)
+UPDATE `gameobject`
+SET `position_z` = 329.7, `position_x` = -5389.1, `position_y` = 3844.8
+WHERE `id` = 1621 AND `guid` = 94010;
+
+-- Peacebloom (ID 1618 - GUID 31393)
+UPDATE `gameobject`
+SET `position_z` = 4.8
+WHERE `id` = 1618 AND `guid` = 31393;
+
+-- Peacebloom (ID 1618 - GUID 15738)
+UPDATE `gameobject`
+SET `position_z` = 7.31
+WHERE `id` = 1618 AND `guid` = 15738;
+
+-- Peacebloom (ID 1618 - GUID 14485)
+UPDATE `gameobject`
+SET `position_z` = 11.4
+WHERE `id` = 1618 AND `guid` = 14485;
+
+-- Peacebloom (ID 1618 - GUID 94256)
+UPDATE `gameobject`
+SET `position_z` = 402.6
+WHERE `id` = 1618 AND `guid` = 94256;
+
+-- Peacebloom (ID 1618 - GUID 94255)
+UPDATE `gameobject`
+SET `position_z` = 399.8
+WHERE `id` = 1618 AND `guid` = 94255;
+
+-- Peacebloom (ID 1618 - GUID 31737)
+UPDATE `gameobject`
+SET `position_z` = 26
+WHERE `id` = 1618 AND `guid` = 31737;
+
+-- Peacebloom (ID 1618 - GUID 94232)
+UPDATE `gameobject`
+SET `position_z` = 386.7
+WHERE `id` = 1618 AND `guid` = 94232;
+
+-- Peacebloom (ID 1618 - GUID 94230)
+UPDATE `gameobject`
+SET `position_z` = 388.5
+WHERE `id` = 1618 AND `guid` = 94230;


### PR DESCRIPTION
- Floating Peacebloom(s), Mageroyal(s), and Briarthorn(s), Earthroot(s), Silver Leaf(s) fixed
- Skunk (17467) - Level scaling fixed.