### PR TITLE
Fix Felstalker right-click attack behavior

### DIFF
--- a/sql/updates/world/2026_08_18_00_world_npc_3102_felstalker.sql
+++ b/sql/updates/world/2026_08_18_00_world_npc_3102_felstalker.sql
@@ -1,0 +1,3 @@
+UPDATE `creature_template`
+SET `npcflag` = 0
+WHERE `entry` = 3102;


### PR DESCRIPTION
Summary
-------
Felstalker (NPC 3102) in the Valley of Trials cannot be attacked normally by right-clicking.

Right-clicking the creature displays:

    You need to be closer to interact with that target.

Using an attack ability or the auto-attack action button still works.

Observed Data
-------------
Entry: 3102
Name: Felstalker
NPC Flags: 2
AIName: SmartAI

The creature is a hostile kill target for the Burning Blade Medallion quest, but npcflag = 2 causes it to behave like an interactable / quest-giver NPC when right-clicked.

This appears to be the same issue previously confirmed on Vile Familiar (NPC 3101), where setting npcflag from 2 to 0 restored normal right-click attack behavior.

Testing Status
--------------
Bug reproduced in-game on HavenCore.
