### PR TITLE
Fix quest 26273 Tiki Target behavior

### DIFF
--- a/sql/updates/world/2026_08_21_03_world_quest_26273_tiki_target.sql
+++ b/sql/updates/world/2026_08_21_03_world_quest_26273_tiki_target.sql
@@ -1,0 +1,29 @@
+-- Tiki Targets must retain incoming damage until normal death instead of
+-- entering evade when they cannot select an attacker as their victim.
+UPDATE `creature_template`
+SET `npcflag` = 0,
+    `AIName` = 'NullCreatureAI'
+WHERE `entry` = 38038;
+
+DELETE FROM `creature_queststarter`
+WHERE `id` = 38038;
+
+-- Quest 26273 already credits normal kills of creature 38038.
+DELETE FROM `smart_scripts`
+WHERE `entryorguid` = 38038
+  AND `source_type` = 0;
+
+-- Arcane Missiles Trainer is obsolete in BFA; retain the Tiki visual aura.
+UPDATE `creature_template_addon`
+SET `auras` = '71064'
+WHERE `entry` = 38038;
+
+UPDATE `creature_addon` AS `ca`
+INNER JOIN `creature` AS `c`
+    ON `c`.`guid` = `ca`.`guid`
+SET `ca`.`auras` = CASE `ca`.`auras`
+    WHEN '71064 83470' THEN '71064'
+    WHEN '71066 83470' THEN '71066'
+END
+WHERE `c`.`id` = 38038
+  AND `ca`.`auras` IN ('71064 83470', '71066 83470');


### PR DESCRIPTION
Description

Fixes incorrect behavior for Tiki Target (NPC 38038) used by quest 26273 - The Basics: Hitting Things.

Problem

Tiki Target was incorrectly configured as a quest giver and had several outdated SmartAI spell-hit scripts.

The previous setup caused multiple issues:

NPC 38038 had npcflag = 2, making it behave as an interactable quest giver.
The creature had eight incorrect creature_queststarter relations, while those quests are actually started by the corresponding class trainers.
The existing SmartAI only reacted to a limited set of old class spells.
SmartAI manually granted credit for creature 44175, while quest 26273 uses a normal kill objective for creature 38038.
Because the target was pacified and running SmartAI, incoming damage could place it into combat without a valid victim.
This could trigger evade behavior and restore the target to full health.
Aura 83470 was still applied even though it is an obsolete Arcane Missiles training aura.
Fix

This change:

Removes npcflag = 2 from Tiki Target.
Removes all incorrect quest-starter relations for NPC 38038.
Removes the obsolete class-specific SmartAI credit scripts.
Changes the AI to NullCreatureAI.
Keeps the NPC stationary and passive while still allowing normal incoming damage.
Removes obsolete aura 83470.
Preserves the Tiki visual auras 71064 and 71066.
Uses the normal core kill and quest-credit system instead of scripted credit workarounds.
Result

Tiki Target now behaves as a normal stationary training target:

Can be attacked normally.
Does not evade and reset its health.
Does not move or fight back.
Takes normal damage.
Uses normal death handling.
Grants quest credit through the standard kill objective.
Uses normal corpse and respawn behavior.
Database verification

All eight creature_queststarter rows for NPC 38038 were confirmed to be incorrect Tiki Target relations. The quests themselves remain correctly assigned to their respective class trainers.

The Tiki Target spawn addons were also verified:

71064 83470: 43 spawns
71066 83470: 33 spawns
No other aura combinations were present.
Remaining spawns inherit the template addon.
Testing

Verified in-game after applying the migration.

Tiki Target now remains stationary, takes damage correctly, dies normally, grants the expected quest credit, and respawns normally.