### PR TITLE
Fix obsolete quest 26951 relations

### DIFF
--- a/sql/updates/world/2026_08_21_04_world_quest_26951_cleanup.sql
+++ b/sql/updates/world/2026_08_21_04_world_quest_26951_cleanup.sql
@@ -1,0 +1,8 @@
+-- Cleanup on Isle E. was removed before Cataclysm and is not part of BFA progression.
+DELETE FROM `creature_queststarter`
+WHERE `id` = 3188
+  AND `quest` = 26951;
+
+DELETE FROM `creature_questender`
+WHERE `id` = 3188
+  AND `quest` = 26951;


### PR DESCRIPTION
Fixes obsolete quest relations for quest 26951 "Cleanup on Isle E".

The quest was still linked to NPC 3188 as starter/ender data even though it is not part of the BFA progression.

This change removes the obsolete starter and ender relations only.

No other quests, NPCs, or tables are modified.