### PR TITLE
Fix quest 25165 venom credit behavior

### DIFF
--- a/sql/updates/world/2026_08_23_00_world_quest_25165_poison_extraction.sql
+++ b/sql/updates/world/2026_08_23_00_world_quest_25165_poison_extraction.sql
@@ -1,0 +1,29 @@
+-- Quest 25165 grants venom credit only when Envenom hits a player using
+-- the Poison Extraction Totem.
+
+UPDATE `creature_template`
+SET `KillCredit2` = 0
+WHERE `entry` = 3125
+  AND `KillCredit2` = 39236;
+
+DELETE FROM `smart_scripts`
+WHERE `entryorguid` = 3125
+  AND `source_type` = 0
+  AND `id` = 3
+  AND `link` = 0;
+
+DELETE FROM `smart_scripts`
+WHERE `entryorguid` = 3125
+  AND `source_type` = 0
+  AND `id` = 1
+  AND `link` = 2;
+
+UPDATE `smart_scripts`
+SET `event_flags` = 1
+WHERE `entryorguid` = 3125
+  AND `source_type` = 0
+  AND `id` = 1
+  AND `link` = 0
+  AND `event_type` = 0
+  AND `action_type` = 11
+  AND `action_param1` = 73672;


### PR DESCRIPTION
Description

Fixes incorrect quest credit behavior for 25165 - Never Trust a Big Barb and a Smile.

Problems

The quest could grant credit incorrectly in several cases:

Killing a Clattering Scorpid without using the Poison Extraction Totem could still grant quest progress.
Using the totem could cause multiple credits from a single scorpid.
Multiple credit paths were overlapping instead of relying on the intended venom extraction mechanic.
Fix

This change restores the intended quest behavior:

Normal Clattering Scorpid kills no longer grant quest credit by themselves.
Quest progress is granted only through the intended Poison Extraction Totem / Envenom interaction.
A valid venom extraction grants exactly one quest credit.
Duplicate credit paths were removed so one scorpid interaction cannot grant multiple samples.
No unrelated quest or combat behavior is modified.
Result

The quest now behaves as intended:

Engage Clattering Scorpid
→ use Poison Extraction Totem
→ valid Envenom interaction occurs
→ exactly +1 venom sample credit

Killing a scorpid without using the totem gives no credit.

Testing

Verified in-game.

Confirmed:

No credit from normal kills without the totem.
Valid totem interaction grants credit.
No duplicate 2–3 credit increments.
Quest can be completed normally.