### PR TITLE
SQL: Clean up Trainer Gossip for BFA

### DIFF
--- a/sql/updates/world/2026_08_24_00_world_class_trainer_gossip_cleanup.sql
+++ b/sql/updates/world/2026_08_24_00_world_class_trainer_gossip_cleanup.sql
@@ -1,0 +1,18 @@
+DELETE gmo
+FROM `gossip_menu_option` gmo
+WHERE gmo.`MenuId` <> 0
+AND EXISTS
+(
+    SELECT 1
+    FROM `creature_template` ct
+    WHERE ct.`gossip_menu_id` = gmo.`MenuId`
+      AND ct.`trainer_class` BETWEEN 1 AND 11
+      AND ct.`subname` NOT LIKE '%Portal Trainer%'
+)
+AND
+(
+       gmo.`OptionType` IN (5, 16, 18, 20)
+    OR gmo.`OptionText` LIKE '%Dual Talent Specialization%'
+    OR gmo.`OptionText` LIKE '%unlearn my talents%'
+    OR gmo.`OptionText` LIKE '%reset my Class Specialization%'
+);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->

This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [X] Database (SAI, creatures, etc).

This PR fixes obsolete class trainer gossip options that are still present in the BFA world database.

Normal class abilities are no longer learned through traditional class trainers in Battle for Azeroth. However, many class trainer NPCs still retained older expansion gossip options such as:

- Class training.
- Talent unlearning.
- Dual Talent Specialization.
- Class Specialization reset options.

Because there is no corresponding BFA class trainer data behind these obsolete options, selecting them either does nothing or produces incomplete/broken trainer interactions.

The issue was confirmed across multiple classes, factions, and cities and was found to be a global database problem rather than an issue with individual NPCs.

The fix removes only obsolete class trainer gossip actions from class trainer menus while preserving unrelated NPC-specific gossip options.

The cleanup targets class trainers identified through `creature_template.trainer_class` values 1 through 11 and excludes Mage Portal Trainers.

The following obsolete interactions are removed:

- `OptionType = 5` class training options.
- `OptionType = 16` legacy talent reset options.
- `OptionType = 18` Dual Talent Specialization options.
- `OptionType = 20` Class Specialization reset options.
- Remaining legacy options containing:
  - `Dual Talent Specialization`
  - `unlearn my talents`
  - `reset my Class Specialization`

`MenuId = 0` is explicitly excluded because it is the shared generic gossip menu and contains options used by many unrelated NPC types.

Mage Portal Trainers are also explicitly excluded because portal/teleport training remains a legitimate trainer function.

Existing unrelated gossip options remain untouched, including quest dialogue, vendor interactions, NPC-specific dialogue, and Rogue trainer options such as `<Take the letter>`.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->

- Closes #41

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

The changes have been validated through:
- [X] Live research (checked expected Battle for Azeroth class trainer behavior).
- [ ] Sniffs (remember to share them with the open source community!)
- [X] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

The issue was reproduced and investigated using multiple class trainers across both factions.

Initial testing included:

### Mage

- Human Mage:
  - Sparkbright - Entry 85307
- Undead Mage:
  - Anastasia Hartwell - Entry 4568

Observed behavior:

- One trainer displayed only a generic greeting.
- Another trainer provided no functional response when the class training option was selected.

### Warrior

- Orc:
  - Blademaster Ronakada - Entry 46667
  - Grezz Ragefist - Entry 3353
- Human:
  - Ilsa Corbin - Entry 5480
  - Wu Shen - Entry 5479

### Priest

- Troll:
  - Tyelis - Entry 45337
- Gnome:
  - High Priest Rohan - Entry 11406
  - Braenna Flintcrag - Entry 5142

### Rogue

- Goblin:
  - Gest - Entry 3327
  - Ormok - Entry 3328
- Worgen:
  - Osborne the Night Man - Entry 918

Database investigation confirmed that the problem was not isolated to these NPCs.

A global audit identified hundreds of historical class trainer NPCs using `creature_template.trainer_class`, covering:

- Warrior
- Paladin
- Hunter
- Rogue
- Priest
- Death Knight
- Shaman
- Mage
- Warlock
- Monk
- Druid

These NPCs retained pre-BFA class trainer gossip options despite having no valid modern `creature_trainer` mapping for normal class training.

The modern trainer tables were also audited:

- `trainer`
- `trainer_spell`
- `creature_trainer`
- `trainer_locale`
- `gossip_menu_option`

The class trainer mappings were confirmed to be absent globally rather than missing from only a few individual NPCs.

The legacy `npc_trainer` table was also investigated.

It contains 27,192 rows, but the negative-reference/template system primarily contains profession trainer data such as:

- Blacksmithing
- Tailoring
- Cooking
- Leatherworking
- Engineering
- Herbalism
- Skinning
- Bandage/First Aid
- Archaeology

The legacy table does not contain a complete class trainer spell system that could be migrated into the modern trainer tables.

The small number of class-associated legacy trainer rows were confirmed to be specialized cases, such as:

- Mage Portal Trainers.
- Warrior-Matic NX-01.
- Limited/specialized Druid training.

They are not complete class spell trainer datasets.

### Gossip Audit

Class trainer gossip menus were audited globally.

The database contained large numbers of obsolete options including:

- `I require warrior training.`
- `I am interested in mage training.`
- `I seek more training in the priestly ways.`
- `Can you train me how to use rogue skills?`
- `Teach me the ways of the spirits.`
- `I would like to train further in the ways of the Light.`
- `I wish to unlearn my talents.`
- `I wish to know about Dual Talent Specialization.`
- `How do I reset my Class Specialization?`

These were confirmed to be legacy options from older class trainer mechanics.

Some of the same menus also contained legitimate unrelated options, such as:

- `<Take the letter>`
- Quest dialogue
- Vendor interactions
- NPC-specific conversation choices
- Special scenario/quest interactions

For this reason, entire gossip menus were not removed.

Only the obsolete trainer/talent/spec-related options are deleted.

### Test Cleanup

The proposed cleanup was first tested against the previously identified Mage, Warrior, Priest, and Rogue trainers.

After applying the cleanup:

- Obsolete class training options were removed.
- Dead trainer interactions no longer appeared.
- Talent unlearning options were removed.
- Dual Talent Specialization options were removed.
- Class Specialization reset options were removed.
- Existing unrelated gossip options remained available.
- Rogue-specific `<Take the letter>` options remained intact.
- Portal trainer functionality was not affected.
- Shared `MenuId = 0` was not modified.

The test was successful in-game.

This PR has been:

- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [X] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [X] This pull request can be tested by following the reproduction steps provided in the linked issue
- [X] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Apply the SQL update to the world database.

2. Restart the worldserver.

3. Log into a Mage character.

4. Visit a normal Mage Trainer such as Anastasia Hartwell.

5. Open the NPC gossip window.

Expected:

- The obsolete `I am interested in mage training` option should no longer be present.
- Obsolete talent reset and Dual Talent Specialization options should not be present.
- Any unrelated valid gossip options should remain.

6. Repeat the test with a Warrior trainer.

Recommended examples:

- Grezz Ragefist
- Ilsa Corbin
- Wu Shen
- Blademaster Ronakada

Expected:

- `I require warrior training` should no longer appear.
- Legacy talent/spec options should no longer appear.
- Other valid NPC gossip should remain.

7. Repeat the test with a Priest trainer.

Recommended examples:

- High Priest Rohan
- Braenna Flintcrag

Expected:

- Traditional Priest training options should no longer appear.
- Obsolete talent/spec options should no longer appear.

8. Repeat the test with a Rogue trainer.

Recommended examples:

- Osborne the Night Man
- Gest
- Ormok

Expected:

- Traditional Rogue training options should no longer appear.
- Obsolete talent/spec options should no longer appear.
- Legitimate options such as `<Take the letter>` must remain.

9. Test a Hunter trainer with additional non-training dialogue, such as Acteon.

Expected:

- The obsolete Hunter training option should be removed.
- NPC-specific quest/dialogue options should remain.

10. Test a Mage Portal Trainer.

Expected:

- Portal/teleport training functionality must remain unchanged.
- Portal Trainers should not be affected by the cleanup.

11. Test NPCs using `gossip_menu_id = 0`.

Expected:

- Shared generic MenuId 0 should remain unchanged.
- Unrelated generic NPC services must continue functioning normally.

12. Test representatives from the remaining classes:

- Paladin
- Hunter
- Death Knight
- Shaman
- Warlock
- Monk
- Druid

Expected:

- Legacy class training/talent/spec options should no longer appear.
- Any unrelated legitimate gossip options should remain functional.

13. Verify normal profession trainers still function.

Recommended:

- Mining
- Herbalism
- Blacksmithing
- Tailoring
- Engineering
- Fishing
- Cooking

Expected:

- Profession trainer functionality should remain unchanged.

14. Verify Mage Portal Trainers still teach their appropriate teleport/portal spells.

15. Verify quest/vendor/dialogue interactions sharing historical class trainer menus still function correctly.

Additional community testing is recommended across older capital cities and expansion zones to identify any unusual class trainer menus that contain special quest or scripted interactions.