### PR TITLE
SQL: Fix all City Guards giving directions

### DIFF
--- a/sql/updates/world/2026_08_24_00_world_guard_navigation_gossip.sql
+++ b/sql/updates/world/2026_08_24_00_world_guard_navigation_gossip.sql
@@ -1,0 +1,331 @@
+-- BFA guard navigation gossip repair
+-- Corrects mismatched/missing BroadcastText references and removes obsolete guard directions.
+
+UPDATE `gossip_menu_option`
+SET `OptionBroadcastTextId` = CASE
+    WHEN `MenuId` = 421 AND `OptionIndex` = 1 THEN 44649
+    WHEN `MenuId` = 421 AND `OptionIndex` = 8 THEN 44664
+    WHEN `MenuId` = 421 AND `OptionIndex` = 14 THEN 44663
+    WHEN `MenuId` = 435 AND `OptionIndex` = 0 THEN 67342
+    WHEN `MenuId` = 435 AND `OptionIndex` = 2 THEN 56155
+    WHEN `MenuId` = 435 AND `OptionIndex` = 3 THEN 53080
+    WHEN `MenuId` = 435 AND `OptionIndex` = 12 THEN 32180
+    WHEN `MenuId` = 435 AND `OptionIndex` = 16 THEN 44612
+    WHEN `MenuId` = 721 AND `OptionIndex` = 0 THEN 5316
+    WHEN `MenuId` = 721 AND `OptionIndex` = 1 THEN 3426
+    WHEN `MenuId` = 721 AND `OptionIndex` = 3 THEN 2870
+    WHEN `MenuId` = 721 AND `OptionIndex` = 4 THEN 5513
+    WHEN `MenuId` = 721 AND `OptionIndex` = 5 THEN 4895
+    WHEN `MenuId` = 721 AND `OptionIndex` = 6 THEN 2869
+    WHEN `MenuId` = 721 AND `OptionIndex` = 7 THEN 8508
+    WHEN `MenuId` = 721 AND `OptionIndex` = 8 THEN 3427
+    WHEN `MenuId` = 721 AND `OptionIndex` = 9 THEN 5518
+    WHEN `MenuId` = 751 AND `OptionIndex` = 0 THEN 2952
+    WHEN `MenuId` = 751 AND `OptionIndex` = 1 THEN 44649
+    WHEN `MenuId` = 751 AND `OptionIndex` = 2 THEN 2942
+    WHEN `MenuId` = 751 AND `OptionIndex` = 3 THEN 2945
+    WHEN `MenuId` = 751 AND `OptionIndex` = 4 THEN 3006
+    WHEN `MenuId` = 751 AND `OptionIndex` = 5 THEN 2943
+    WHEN `MenuId` = 751 AND `OptionIndex` = 7 THEN 3005
+    WHEN `MenuId` = 751 AND `OptionIndex` = 8 THEN 2950
+    WHEN `MenuId` = 751 AND `OptionIndex` = 9 THEN 31542
+    WHEN `MenuId` = 751 AND `OptionIndex` = 10 THEN 15267
+    WHEN `MenuId` = 751 AND `OptionIndex` = 11 THEN 2947
+    WHEN `MenuId` = 751 AND `OptionIndex` = 12 THEN 2944
+    WHEN `MenuId` = 751 AND `OptionIndex` = 13 THEN 2948
+    WHEN `MenuId` = 751 AND `OptionIndex` = 14 THEN 2951
+    WHEN `MenuId` = 1942 AND `OptionIndex` = 0 THEN 2952
+    WHEN `MenuId` = 1942 AND `OptionIndex` = 1 THEN 44649
+    WHEN `MenuId` = 1942 AND `OptionIndex` = 2 THEN 2942
+    WHEN `MenuId` = 1942 AND `OptionIndex` = 3 THEN 2945
+    WHEN `MenuId` = 1942 AND `OptionIndex` = 4 THEN 3006
+    WHEN `MenuId` = 1942 AND `OptionIndex` = 5 THEN 2943
+    WHEN `MenuId` = 1942 AND `OptionIndex` = 7 THEN 3005
+    WHEN `MenuId` = 1942 AND `OptionIndex` = 8 THEN 44664
+    WHEN `MenuId` = 1942 AND `OptionIndex` = 9 THEN 2950
+    WHEN `MenuId` = 1942 AND `OptionIndex` = 10 THEN 31542
+    WHEN `MenuId` = 1942 AND `OptionIndex` = 11 THEN 15267
+    WHEN `MenuId` = 1942 AND `OptionIndex` = 12 THEN 2947
+    WHEN `MenuId` = 1942 AND `OptionIndex` = 13 THEN 2944
+    WHEN `MenuId` = 1942 AND `OptionIndex` = 14 THEN 44663
+    WHEN `MenuId` = 1942 AND `OptionIndex` = 15 THEN 2948
+    WHEN `MenuId` = 1942 AND `OptionIndex` = 16 THEN 2951
+    WHEN `MenuId` = 1951 AND `OptionIndex` = 0 THEN 67342
+    WHEN `MenuId` = 1951 AND `OptionIndex` = 2 THEN 56155
+    WHEN `MenuId` = 1951 AND `OptionIndex` = 3 THEN 53080
+    WHEN `MenuId` = 1951 AND `OptionIndex` = 4 THEN 5316
+    WHEN `MenuId` = 1951 AND `OptionIndex` = 5 THEN 3426
+    WHEN `MenuId` = 1951 AND `OptionIndex` = 6 THEN 31340
+    WHEN `MenuId` = 1951 AND `OptionIndex` = 7 THEN 15232
+    WHEN `MenuId` = 1951 AND `OptionIndex` = 9 THEN 2863
+    WHEN `MenuId` = 1951 AND `OptionIndex` = 10 THEN 2870
+    WHEN `MenuId` = 1951 AND `OptionIndex` = 11 THEN 5513
+    WHEN `MenuId` = 1951 AND `OptionIndex` = 12 THEN 9749
+    WHEN `MenuId` = 1951 AND `OptionIndex` = 13 THEN 5914
+    WHEN `MenuId` = 1951 AND `OptionIndex` = 14 THEN 2869
+    WHEN `MenuId` = 1951 AND `OptionIndex` = 15 THEN 8508
+    WHEN `MenuId` = 1951 AND `OptionIndex` = 16 THEN 5518
+    WHEN `MenuId` = 2121 AND `OptionIndex` = 0 THEN 5316
+    WHEN `MenuId` = 2121 AND `OptionIndex` = 1 THEN 5078
+    WHEN `MenuId` = 2121 AND `OptionIndex` = 2 THEN 5914
+    WHEN `MenuId` = 2121 AND `OptionIndex` = 3 THEN 5081
+    WHEN `MenuId` = 2121 AND `OptionIndex` = 4 THEN 2870
+    WHEN `MenuId` = 2121 AND `OptionIndex` = 5 THEN 4893
+    WHEN `MenuId` = 2121 AND `OptionIndex` = 6 THEN 4895
+    WHEN `MenuId` = 2121 AND `OptionIndex` = 7 THEN 8508
+    WHEN `MenuId` = 2121 AND `OptionIndex` = 8 THEN 10359
+    WHEN `MenuId` = 2121 AND `OptionIndex` = 9 THEN 31340
+    WHEN `MenuId` = 2121 AND `OptionIndex` = 11 THEN 2869
+    WHEN `MenuId` = 2168 AND `OptionIndex` = 0 THEN 2952
+    WHEN `MenuId` = 2168 AND `OptionIndex` = 1 THEN 44649
+    WHEN `MenuId` = 2168 AND `OptionIndex` = 2 THEN 2942
+    WHEN `MenuId` = 2168 AND `OptionIndex` = 3 THEN 2945
+    WHEN `MenuId` = 2168 AND `OptionIndex` = 4 THEN 3006
+    WHEN `MenuId` = 2168 AND `OptionIndex` = 5 THEN 2943
+    WHEN `MenuId` = 2168 AND `OptionIndex` = 7 THEN 3005
+    WHEN `MenuId` = 2168 AND `OptionIndex` = 8 THEN 2950
+    WHEN `MenuId` = 2168 AND `OptionIndex` = 9 THEN 31542
+    WHEN `MenuId` = 2168 AND `OptionIndex` = 10 THEN 15267
+    WHEN `MenuId` = 2168 AND `OptionIndex` = 11 THEN 2947
+    WHEN `MenuId` = 2168 AND `OptionIndex` = 12 THEN 2944
+    WHEN `MenuId` = 2168 AND `OptionIndex` = 13 THEN 2948
+    WHEN `MenuId` = 2168 AND `OptionIndex` = 14 THEN 2951
+    WHEN `MenuId` = 2351 AND `OptionIndex` = 1 THEN 44649
+    WHEN `MenuId` = 2351 AND `OptionIndex` = 2 THEN 2942
+    WHEN `MenuId` = 2351 AND `OptionIndex` = 3 THEN 2945
+    WHEN `MenuId` = 2351 AND `OptionIndex` = 4 THEN 3006
+    WHEN `MenuId` = 2351 AND `OptionIndex` = 5 THEN 2943
+    WHEN `MenuId` = 2351 AND `OptionIndex` = 7 THEN 3005
+    WHEN `MenuId` = 2351 AND `OptionIndex` = 8 THEN 2950
+    WHEN `MenuId` = 2351 AND `OptionIndex` = 9 THEN 31542
+    WHEN `MenuId` = 2351 AND `OptionIndex` = 10 THEN 15267
+    WHEN `MenuId` = 2351 AND `OptionIndex` = 11 THEN 2947
+    WHEN `MenuId` = 2351 AND `OptionIndex` = 12 THEN 2944
+    WHEN `MenuId` = 2351 AND `OptionIndex` = 13 THEN 2948
+    WHEN `MenuId` = 2351 AND `OptionIndex` = 14 THEN 2951
+    WHEN `MenuId` = 2352 AND `OptionIndex` = 0 THEN 5316
+    WHEN `MenuId` = 2352 AND `OptionIndex` = 1 THEN 4888
+    WHEN `MenuId` = 2352 AND `OptionIndex` = 2 THEN 5330
+    WHEN `MenuId` = 2352 AND `OptionIndex` = 4 THEN 4893
+    WHEN `MenuId` = 2352 AND `OptionIndex` = 5 THEN 4895
+    WHEN `MenuId` = 2352 AND `OptionIndex` = 6 THEN 8508
+    WHEN `MenuId` = 2352 AND `OptionIndex` = 7 THEN 7241
+    WHEN `MenuId` = 2352 AND `OptionIndex` = 8 THEN 10359
+    WHEN `MenuId` = 2352 AND `OptionIndex` = 10 THEN 2869
+    WHEN `MenuId` = 2352 AND `OptionIndex` = 11 THEN 32998
+    WHEN `MenuId` = 2849 AND `OptionIndex` = 1 THEN 4888
+    WHEN `MenuId` = 2849 AND `OptionIndex` = 2 THEN 31340
+    WHEN `MenuId` = 2849 AND `OptionIndex` = 3 THEN 6790
+    WHEN `MenuId` = 2849 AND `OptionIndex` = 6 THEN 4893
+    WHEN `MenuId` = 2849 AND `OptionIndex` = 7 THEN 33141
+    WHEN `MenuId` = 2849 AND `OptionIndex` = 9 THEN 8515
+    WHEN `MenuId` = 2849 AND `OptionIndex` = 13 THEN 6723
+    WHEN `MenuId` = 3580 AND `OptionIndex` = 7 THEN 5330
+    WHEN `MenuId` = 7667 AND `OptionIndex` = 2 THEN 2942
+    WHEN `MenuId` = 7667 AND `OptionIndex` = 3 THEN 2945
+    WHEN `MenuId` = 7667 AND `OptionIndex` = 4 THEN 3006
+    WHEN `MenuId` = 7667 AND `OptionIndex` = 5 THEN 2943
+    WHEN `MenuId` = 7667 AND `OptionIndex` = 7 THEN 3005
+    WHEN `MenuId` = 7667 AND `OptionIndex` = 8 THEN 2950
+    WHEN `MenuId` = 7667 AND `OptionIndex` = 9 THEN 31542
+    WHEN `MenuId` = 7667 AND `OptionIndex` = 10 THEN 15267
+    WHEN `MenuId` = 7667 AND `OptionIndex` = 11 THEN 2947
+    WHEN `MenuId` = 7667 AND `OptionIndex` = 12 THEN 2944
+    WHEN `MenuId` = 7667 AND `OptionIndex` = 13 THEN 2948
+    WHEN `MenuId` = 7777 AND `OptionIndex` = 0 THEN 5316
+    WHEN `MenuId` = 7777 AND `OptionIndex` = 1 THEN 3426
+    WHEN `MenuId` = 7777 AND `OptionIndex` = 2 THEN 5330
+    WHEN `MenuId` = 7777 AND `OptionIndex` = 3 THEN 2870
+    WHEN `MenuId` = 7777 AND `OptionIndex` = 4 THEN 5513
+    WHEN `MenuId` = 7777 AND `OptionIndex` = 5 THEN 4895
+    WHEN `MenuId` = 7777 AND `OptionIndex` = 6 THEN 8508
+    WHEN `MenuId` = 7777 AND `OptionIndex` = 7 THEN 15230
+    WHEN `MenuId` = 7777 AND `OptionIndex` = 8 THEN 15232
+    WHEN `MenuId` = 7777 AND `OptionIndex` = 9 THEN 2869
+    WHEN `MenuId` = 7788 AND `OptionIndex` = 0 THEN 2952
+    WHEN `MenuId` = 7788 AND `OptionIndex` = 1 THEN 44649
+    WHEN `MenuId` = 7788 AND `OptionIndex` = 2 THEN 2942
+    WHEN `MenuId` = 7788 AND `OptionIndex` = 3 THEN 3006
+    WHEN `MenuId` = 7788 AND `OptionIndex` = 4 THEN 2943
+    WHEN `MenuId` = 7788 AND `OptionIndex` = 6 THEN 3005
+    WHEN `MenuId` = 7788 AND `OptionIndex` = 7 THEN 2950
+    WHEN `MenuId` = 7788 AND `OptionIndex` = 8 THEN 31542
+    WHEN `MenuId` = 7788 AND `OptionIndex` = 9 THEN 15267
+    WHEN `MenuId` = 7788 AND `OptionIndex` = 10 THEN 2947
+    WHEN `MenuId` = 7788 AND `OptionIndex` = 11 THEN 2944
+    WHEN `MenuId` = 7788 AND `OptionIndex` = 12 THEN 2948
+    WHEN `MenuId` = 7788 AND `OptionIndex` = 13 THEN 2951
+    WHEN `MenuId` = 7788 AND `OptionIndex` = 14 THEN 2945
+    WHEN `MenuId` = 8357 AND `OptionIndex` = 8 THEN 2869
+    WHEN `MenuId` = 9727 AND `OptionIndex` = 0 THEN 28607
+    WHEN `MenuId` = 9727 AND `OptionIndex` = 1 THEN 28608
+    WHEN `MenuId` = 10043 AND `OptionIndex` = 5 THEN 2863
+    WHEN `MenuId` = 10043 AND `OptionIndex` = 6 THEN 2870
+    WHEN `MenuId` = 10043 AND `OptionIndex` = 7 THEN 5513
+    WHEN `MenuId` = 10043 AND `OptionIndex` = 9 THEN 4895
+    WHEN `MenuId` = 10043 AND `OptionIndex` = 11 THEN 8508
+    WHEN `MenuId` = 10043 AND `OptionIndex` = 13 THEN 32216
+    WHEN `MenuId` = 10082 AND `OptionIndex` = 0 THEN 2868
+    WHEN `MenuId` = 10082 AND `OptionIndex` = 5 THEN 2869
+    WHEN `MenuId` = 10173 AND `OptionIndex` = 4 THEN 32712
+    WHEN `MenuId` = 10767 AND `OptionIndex` = 1 THEN 44649
+    WHEN `MenuId` = 10767 AND `OptionIndex` = 2 THEN 2942
+    WHEN `MenuId` = 10767 AND `OptionIndex` = 3 THEN 2945
+    WHEN `MenuId` = 10767 AND `OptionIndex` = 4 THEN 3006
+    WHEN `MenuId` = 10767 AND `OptionIndex` = 5 THEN 2943
+    WHEN `MenuId` = 10767 AND `OptionIndex` = 7 THEN 3005
+    WHEN `MenuId` = 10767 AND `OptionIndex` = 8 THEN 2950
+    WHEN `MenuId` = 10767 AND `OptionIndex` = 9 THEN 31542
+    WHEN `MenuId` = 10767 AND `OptionIndex` = 10 THEN 15267
+    WHEN `MenuId` = 10767 AND `OptionIndex` = 11 THEN 2947
+    WHEN `MenuId` = 10767 AND `OptionIndex` = 12 THEN 2944
+    WHEN `MenuId` = 10767 AND `OptionIndex` = 13 THEN 2948
+    WHEN `MenuId` = 10767 AND `OptionIndex` = 14 THEN 2951
+    WHEN `MenuId` = 11839 AND `OptionIndex` = 0 THEN 6370
+    WHEN `MenuId` = 11839 AND `OptionIndex` = 1 THEN 44592
+    WHEN `MenuId` = 11841 AND `OptionIndex` = 0 THEN 44596
+    WHEN `MenuId` = 11841 AND `OptionIndex` = 1 THEN 44597
+    WHEN `MenuId` = 11843 AND `OptionIndex` = 0 THEN 44603
+    WHEN `MenuId` = 11843 AND `OptionIndex` = 1 THEN 44604
+    WHEN `MenuId` = 11845 AND `OptionIndex` = 0 THEN 44652
+    WHEN `MenuId` = 11845 AND `OptionIndex` = 2 THEN 44635
+    WHEN `MenuId` = 11845 AND `OptionIndex` = 3 THEN 44639
+    WHEN `MenuId` = 11845 AND `OptionIndex` = 4 THEN 29416
+    WHEN `MenuId` = 11845 AND `OptionIndex` = 5 THEN 44637
+    WHEN `MenuId` = 11846 AND `OptionIndex` = 0 THEN 44610
+    WHEN `MenuId` = 11846 AND `OptionIndex` = 1 THEN 44609
+    WHEN `MenuId` = 11848 AND `OptionIndex` = 0 THEN 5316
+    WHEN `MenuId` = 11848 AND `OptionIndex` = 1 THEN 44659
+    WHEN `MenuId` = 11848 AND `OptionIndex` = 2 THEN 44654
+    WHEN `MenuId` = 11848 AND `OptionIndex` = 3 THEN 44656
+    WHEN `MenuId` = 11848 AND `OptionIndex` = 4 THEN 44657
+    WHEN `MenuId` = 11848 AND `OptionIndex` = 5 THEN 2869
+    WHEN `MenuId` = 11969 AND `OptionIndex` = 0 THEN 5316
+    WHEN `MenuId` = 11969 AND `OptionIndex` = 1 THEN 3426
+    WHEN `MenuId` = 11969 AND `OptionIndex` = 3 THEN 5513
+    WHEN `MenuId` = 11969 AND `OptionIndex` = 4 THEN 4895
+    WHEN `MenuId` = 11969 AND `OptionIndex` = 5 THEN 2869
+    WHEN `MenuId` = 11969 AND `OptionIndex` = 6 THEN 8508
+    WHEN `MenuId` = 11969 AND `OptionIndex` = 7 THEN 44612
+    WHEN `MenuId` = 11977 AND `OptionIndex` = 0 THEN 2945
+    WHEN `MenuId` = 11977 AND `OptionIndex` = 1 THEN 2950
+    WHEN `MenuId` = 11977 AND `OptionIndex` = 2 THEN 31542
+    WHEN `MenuId` = 11977 AND `OptionIndex` = 3 THEN 3005
+    WHEN `MenuId` = 11978 AND `OptionIndex` = 0 THEN 32712
+    WHEN `MenuId` = 11978 AND `OptionIndex` = 1 THEN 45446
+    WHEN `MenuId` = 11978 AND `OptionIndex` = 2 THEN 45447
+    WHEN `MenuId` = 11978 AND `OptionIndex` = 3 THEN 32719
+    WHEN `MenuId` = 12243 AND `OptionIndex` = 1 THEN 129109
+    WHEN `MenuId` = 12245 AND `OptionIndex` = 1 THEN 129152
+    WHEN `MenuId` = 12245 AND `OptionIndex` = 2 THEN 129175
+    WHEN `MenuId` = 12245 AND `OptionIndex` = 3 THEN 129176
+    WHEN `MenuId` = 12245 AND `OptionIndex` = 5 THEN 129111
+    WHEN `MenuId` = 12245 AND `OptionIndex` = 7 THEN 129108
+    WHEN `MenuId` = 12245 AND `OptionIndex` = 8 THEN 129157
+    WHEN `MenuId` = 12637 AND `OptionIndex` = 0 THEN 50627
+    WHEN `MenuId` = 12637 AND `OptionIndex` = 1 THEN 50628
+    WHEN `MenuId` = 12638 AND `OptionIndex` = 0 THEN 50627
+    WHEN `MenuId` = 12638 AND `OptionIndex` = 1 THEN 50628
+    WHEN `MenuId` = 12639 AND `OptionIndex` = 0 THEN 50627
+    WHEN `MenuId` = 12639 AND `OptionIndex` = 1 THEN 50628
+    WHEN `MenuId` = 12865 AND `OptionIndex` = 0 THEN 2952
+    WHEN `MenuId` = 12865 AND `OptionIndex` = 2 THEN 2942
+    WHEN `MenuId` = 12865 AND `OptionIndex` = 3 THEN 2945
+    WHEN `MenuId` = 12865 AND `OptionIndex` = 4 THEN 3006
+    WHEN `MenuId` = 12865 AND `OptionIndex` = 5 THEN 2943
+    WHEN `MenuId` = 12865 AND `OptionIndex` = 7 THEN 3005
+    WHEN `MenuId` = 12865 AND `OptionIndex` = 8 THEN 2950
+    WHEN `MenuId` = 12865 AND `OptionIndex` = 9 THEN 31542
+    WHEN `MenuId` = 12865 AND `OptionIndex` = 10 THEN 15267
+    WHEN `MenuId` = 12865 AND `OptionIndex` = 11 THEN 2947
+    WHEN `MenuId` = 12865 AND `OptionIndex` = 12 THEN 2944
+    WHEN `MenuId` = 12865 AND `OptionIndex` = 14 THEN 2948
+    WHEN `MenuId` = 12865 AND `OptionIndex` = 15 THEN 2951
+    ELSE `OptionBroadcastTextId`
+END
+WHERE `MenuId` IN (421, 435, 721, 751, 1942, 1951, 2121, 2168, 2351, 2352, 2849, 3580, 7667, 7777, 7788, 8357, 9727, 10043, 10082, 10173, 10767, 11839, 11841, 11843, 11845, 11846, 11848, 11969, 11977, 11978, 12243, 12245, 12637, 12638, 12639, 12865);
+
+UPDATE `gossip_menu_option` SET `OptionText` = 'Weapon Master', `OptionBroadcastTextId` = 15230 WHERE `MenuId` = 7777 AND `OptionIndex` = 7;
+UPDATE `gossip_menu_option` SET `OptionText` = 'Battlemasters', `OptionBroadcastTextId` = 15232 WHERE `MenuId` = 7777 AND `OptionIndex` = 8;
+UPDATE `gossip_menu_option` SET `OptionText` = 'Profession Trainer', `OptionBroadcastTextId` = 2869 WHERE `MenuId` = 7777 AND `OptionIndex` = 9;
+UPDATE `gossip_menu_option_action` AS `dst` JOIN `gossip_menu_option_action` AS `src` ON `src`.`MenuId` = 7777 AND `src`.`OptionIndex` = 10 SET `dst`.`ActionMenuId` = `src`.`ActionMenuId`, `dst`.`ActionPoiId` = `src`.`ActionPoiId` WHERE `dst`.`MenuId` = 7777 AND `dst`.`OptionIndex` = 9;
+DELETE FROM `gossip_menu_option_action` WHERE `MenuId` = 7777 AND `OptionIndex` = 10;
+DELETE FROM `gossip_menu_option` WHERE `MenuId` = 7777 AND `OptionIndex` = 10;
+
+DELETE FROM `gossip_menu_option_action` WHERE `MenuId` = 721 AND `OptionIndex` IN (10, 11, 12);
+DELETE FROM `gossip_menu_option` WHERE `MenuId` = 721 AND `OptionIndex` IN (10, 11, 12);
+
+DELETE FROM `gossip_menu_option_action`
+WHERE (`MenuId`, `OptionIndex`) IN (
+    (435, 7),
+    (721, 2),
+    (1951, 8),
+    (2121, 10),
+    (2352, 9),
+    (2849, 12),
+    (3285, 4),
+    (3331, 4),
+    (3356, 4),
+    (3533, 5),
+    (3580, 5),
+    (7633, 3),
+    (8185, 4),
+    (8357, 7),
+    (8851, 2),
+    (11969, 2),
+    (421, 6),
+    (751, 6),
+    (1942, 6),
+    (2168, 6),
+    (2351, 6),
+    (3355, 5),
+    (7667, 6),
+    (8424, 4),
+    (10767, 6),
+    (12865, 6),
+    (14769, 6),
+    (17349, 6),
+    (7788, 5)
+);
+
+DELETE FROM `gossip_menu_option`
+WHERE (`MenuId`, `OptionIndex`) IN (
+    (435, 7),
+    (721, 2),
+    (1951, 8),
+    (2121, 10),
+    (2352, 9),
+    (2849, 12),
+    (3285, 4),
+    (3331, 4),
+    (3356, 4),
+    (3533, 5),
+    (3580, 5),
+    (7633, 3),
+    (8185, 4),
+    (8357, 7),
+    (8851, 2),
+    (11969, 2),
+    (421, 6),
+    (751, 6),
+    (1942, 6),
+    (2168, 6),
+    (2351, 6),
+    (3355, 5),
+    (7667, 6),
+    (8424, 4),
+    (10767, 6),
+    (12865, 6),
+    (14769, 6),
+    (17349, 6),
+    (7788, 5)
+);
+
+-- Verification: rows returned here still have mismatched BroadcastText on patched navigation menus.
+-- SELECT g.MenuId, g.OptionIndex, g.OptionText, g.OptionBroadcastTextId, b.Text
+-- FROM gossip_menu_option g
+-- LEFT JOIN bfa_hotfixes.broadcast_text b ON b.ID = g.OptionBroadcastTextId AND b.VerifiedBuild = 35662
+-- WHERE g.MenuId IN (421, 435, 721, 751, 1942, 1951, 2121, 2168, 2351, 2352, 2849, 3580, 7667, 7777, 7788, 8357, 9727, 10043, 10082, 10173, 10767, 11839, 11841, 11843, 11845, 11846, 11848, 11969, 11977, 11978, 12243, 12245, 12637, 12638, 12639, 12865)
+--   AND g.OptionBroadcastTextId <> 0
+--   AND LOWER(TRIM(g.OptionText)) <> LOWER(TRIM(b.Text))
+-- ORDER BY g.MenuId, g.OptionIndex;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->

_One important distinction for the PR: this fixes all of the city/guard navigation defects identified by this audit. It deliberately does not attempt to fix the other unrelated entries among the 459 global gossip mismatches, because those include ordinary quest text, punctuation differences, translations, and unrelated NPC interactions. That separation is what keeps this PR focused and safe._

This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [X] Database (SAI, creatures, etc).

This PR fixes incorrect, missing, duplicated, and obsolete city guard navigation gossip data.

The issue was originally identified while testing Ironforge guards, where the visible gossip options did not correspond to the actions that were executed.

Examples included:

- Selecting `Weapons Trainer` sent the player to the Battlemaster.
- Selecting `Battlemaster` sent the player to the Barber.
- `Profession Trainer` displayed as `Class Trainer`.
- Obsolete `Class Trainer` options remained available.
- Obsolete `First Aid` directions remained in profession trainer menus.

Further testing showed similar issues in other cities.

Thunder Bluff contained incorrectly displayed navigation options and duplicate Zeppelin entries.

Exodar displayed a shifted group of options:

- `Battlemaster` displayed as `Weapon Master`.
- `Class Trainer` displayed as `Battlemaster`.
- `Profession Trainer` displayed as `Class Trainer`.
- `Reforging` displayed as `Profession Trainer`.

An audit was performed across the active city guard navigation menus and their submenus.

The underlying issue was found to be incorrect or missing `OptionBroadcastTextId` values in `gossip_menu_option`.

The plain `OptionText` and, in many cases, the associated `gossip_menu_option_action` were correct. However, the client uses the referenced BroadcastText when one is present.

As a result, an option could contain:

`OptionText = Battlemaster`

while its `OptionBroadcastTextId` resolved to:

`Weapons Trainer`

The player therefore saw `Weapons Trainer`, but selecting it executed the Battlemaster action associated with the actual gossip row.

This made correctly routed guard options appear to send the player to the wrong destination.

The problem was systemic rather than isolated to one city.

A global comparison between `bfa_world.gossip_menu_option` and the BFA `broadcast_text` data found:

- 6,480 gossip options using BroadcastText.
- 6,021 whose stored text matched the referenced BroadcastText.
- 459 mismatches globally.

The global mismatch list was not used directly because it also contains legitimate wording differences, punctuation changes, quest gossip, and unrelated NPC interactions.

A second audit was therefore restricted to guard-related navigation trees.

That audit identified:

- 102 menus in the broad guard-tree scan.
- 542 gossip options.
- 212 potential BroadcastText inconsistencies.

The guard-tree scan was then manually filtered to distinguish actual city/service navigation menus from unrelated NPCs whose names happened to contain terms such as Guard, Guardian, Grunt, Sentinel, or Vindicator.

The final update is restricted to confirmed navigation menus.

### BroadcastText Corrections

The update repairs incorrect and missing `OptionBroadcastTextId` values on confirmed guard navigation menus and their service submenus.

This includes navigation categories such as:

- Auction House
- Bank
- Barber
- Battlemaster
- Flight Master
- Gryphon/Hippogryph/Wind Rider Master
- Guild Master & Vendor
- Inn
- Mailbox
- Profession Trainer
- Stable Master
- Zeppelin Master
- Vendors
- Points of Interest
- Other Continents

Profession trainer submenus were also audited.

Several contained shifted BroadcastText references where the displayed profession did not match the actual menu option.

Examples included:

- Archaeology displaying as Blacksmithing or Cooking.
- Blacksmithing displaying as Cooking or Enchanting.
- Cooking displaying as Enchanting or First Aid.
- Engineering displaying as First Aid or Fishing.
- Fishing displaying as Herbalism.
- Herbalism displaying as Inscription.
- Inscription displaying as Leatherworking or Jewelcrafting.
- Jewelcrafting displaying as Mining or Leatherworking.
- Leatherworking displaying as Skinning or Mining.
- Mining displaying as Tailoring or Skinning.

These references are corrected to BroadcastText records matching the intended profession.

Missing BroadcastText references are also populated where an exact BFA BroadcastText record exists.

### Ironforge

Ironforge guard menu `2121` was confirmed to contain mismatched BroadcastText references.

Examples included:

- `Battlemaster` referencing BroadcastText for `Weapons Trainer`.
- `Barber` referencing BroadcastText for `Battlemaster`.
- `Profession Trainer` referencing BroadcastText for `Class Trainer`.

These references are corrected.

The obsolete `Class Trainer` guard direction is removed.

The profession submenu is corrected so each profession displays the proper label.

The obsolete `First Aid` guard direction is removed.

### Thunder Bluff

Thunder Bluff menu `721` contained several incorrect BroadcastText mappings.

Examples included:

- `Auction House` displaying as `The Bank`.
- `Bank` displaying as `The wind rider master`.
- `Guild Master & Vendor` displaying as `The Inn`.
- `Inn` displaying as `Mailbox`.
- `Mailbox` displaying as `Auction House`.
- `Profession Trainer` displaying as `Weapon Master`.
- `Wind Rider Master` displaying as `Battlemaster`.
- `Zeppelin Master` displaying as `A class trainer`.

These references are corrected.

The obsolete `Class Trainer` entry is removed.

Duplicate legacy options are also removed:

- Duplicate profession trainer entry.
- Duplicate/unlinked Zeppelin entry.
- Duplicate Zeppelin Master entry.

One valid Zeppelin Master option remains.

The profession submenu is also repaired and the obsolete First Aid entry is removed.

### Exodar

Exodar required both BroadcastText correction and menu cleanup.

The original menu contained shifted service entries where the visible labels did not correspond to their actions.

The corrected menu provides:

- Weapon Master
- Battlemasters
- Profession Trainer

with each option routed to its correct destination/submenu.

The obsolete Class Trainer entry is removed from the effective navigation flow.

The obsolete Reforging entry is removed.

The working Profession Trainer action is retained and attached to the correct visible Profession Trainer option.

The Exodar profession submenu is also corrected and First Aid is removed.

### Other Guard Navigation Trees

The same BroadcastText audit and repair is applied to other confirmed guard/service-navigation menus, including navigation used by:

- Stormwind guards
- Orgrimmar guards
- Darnassus guards
- Undercity guards
- Silvermoon guards
- Ironforge guards and mountaineers
- Thunder Bluff guards
- Exodar guards
- Darkspear navigation NPCs
- Shattrath guard navigation
- Theramore guard navigation
- Stormshield/Warspear profession navigation
- Other guard-linked service submenus identified during the audit

The update intentionally does not modify unrelated quest dialogue or NPC gossip that happened to be returned by the broad guard-name audit.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->

Fixes incorrect city guard directions and menu labels caused by mismatched BFA BroadcastText references.

This also completes cleanup discovered while testing class trainer behavior by removing obsolete Class Trainer directions from guard menus.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

The fix was developed from:

- Existing BFA world database gossip data.
- BFA Hotfix `broadcast_text` records.
- Existing `gossip_menu_option_action` routing data.
- Existing Points of Interest data.
- In-game testing of the affected guard menus.

The database audit compared:

`bfa_world.gossip_menu_option.OptionText`

against:

`bfa_hotfixes.broadcast_text.Text`

for the corresponding `OptionBroadcastTextId`.

This identified cases where the intended gossip text and the BroadcastText displayed by the client represented entirely different services.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

The issue was reproduced and tested in-game across multiple capital cities.

### Ironforge

Test NPC:

- Ironforge Guard - Entry 5595

Before the fix:

- Weapons Trainer displayed but selecting it routed to the Battlemaster.
- Battlemaster routed to the Barber.
- Profession Trainer displayed as Class Trainer.
- Obsolete Class Trainer direction remained available.

After the fix:

- Battlemaster displays correctly and routes correctly.
- Barber displays correctly and routes correctly.
- Profession Trainer displays correctly.
- Profession submenu displays correctly.
- Class Trainer is no longer shown.
- Remaining service directions function correctly.

### Thunder Bluff

Test NPC:

- Bluffwatcher - Entry 3084

Before the fix:

- Profession Trainer displayed as Weapon Master.
- Several primary navigation options displayed the wrong service.
- Duplicate Zeppelin options were displayed.
- Class Trainer remained available.

After the fix:

- Primary service labels display correctly.
- Profession Trainer opens the correct profession menu.
- Wind Rider Master displays and routes correctly.
- Zeppelin Master displays and routes correctly.
- Duplicate Zeppelin options are removed.
- Duplicate profession trainer entry is removed.
- Class Trainer is removed.
- Profession submenu labels display correctly.

### Exodar

Test NPC:

- Exodar Peacekeeper - Entry 16733

Before the fix:

- Battlemaster displayed as Weapon Master.
- Class Trainer displayed as Battlemaster.
- Profession Trainer displayed as Class Trainer.
- Reforging displayed as Profession Trainer.

After the fix:

- Weapon Master displays and routes correctly.
- Battlemasters displays and routes correctly.
- Profession Trainer displays and opens the correct profession submenu.
- Class Trainer is removed from the effective navigation menu.
- Reforging is removed.
- Profession submenu labels display correctly.

### Additional Cities

The following cities were also checked during investigation:

- Stormwind
- Darnassus
- Orgrimmar
- Undercity
- Silvermoon

Their active navigation structures were included in the audit to ensure the fix addresses the systemic problem instead of only patching the originally reported Ironforge NPC.

### Database Validation

The global gossip BroadcastText audit returned:

- 6,480 BroadcastText-backed gossip options.
- 6,021 matching their referenced BroadcastText.
- 459 mismatches.

A guard-navigation audit returned:

- 102 menus in the broad guard tree.
- 542 options.
- 212 potential inconsistencies.

The broad results were manually narrowed to confirmed navigation menus so unrelated NPC and quest gossip would not be modified.

The resulting SQL performs explicit BroadcastText corrections rather than a broad text-based global update.

The final migration contains explicit corrections for confirmed navigation rows and does not modify unrelated gossip content.

This PR has been:

- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [X] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Apply the supplied world database SQL update.

2. Restart the worldserver.

3. Test Ironforge Guard entry 5595.

Verify:

- Auction House.
- Bank.
- Other Continents.
- Gryphon Master.
- Guild Master & Vendor.
- Inn.
- Mailbox.
- Stable Master.
- Battlemaster.
- Barber.
- Profession Trainer.

Expected:

- Every visible option should correspond to the service it opens.
- Class Trainer should not be present.
- Profession Trainer should open the profession submenu.
- First Aid should not appear in the profession submenu.

4. Test Thunder Bluff Bluffwatcher entry 3084.

Expected:

- Auction House routes correctly.
- Bank routes correctly.
- Guild Master & Vendor routes correctly.
- Inn routes correctly.
- Mailbox routes correctly.
- Profession Trainer routes correctly.
- Stable Master routes correctly.
- Wind Rider Master routes correctly.
- Exactly one Zeppelin Master entry is present.
- Class Trainer is not present.
- No duplicate profession trainer or Zeppelin options are present.

5. Test Exodar Peacekeeper entry 16733.

Expected:

- Weapon Master routes correctly.
- Battlemasters routes correctly.
- Profession Trainer routes correctly.
- Class Trainer is not present.
- Reforging is not present.
- Profession submenu labels match the selected profession.

6. Test a Stormwind City Guard.

Expected:

- All service categories continue to route correctly.
- Profession navigation continues functioning.
- Obsolete Class Trainer and First Aid directions are absent.

7. Test an Orgrimmar Grunt.

Expected:

- Main service navigation remains functional.
- Profession trainer options display the proper profession names.
- Obsolete Class Trainer and First Aid directions are absent.

8. Test Darnassus, Undercity, and Silvermoon guard navigation.

Expected:

- Service labels correspond to their actions.
- Profession submenu labels correspond to their intended profession.
- No obsolete class trainer direction remains.

9. Test Shattrath guard navigation.

Expected:

- Existing city service navigation remains functional.
- Profession Trainer displays correctly.
- First Aid is not offered as a profession direction.

10. Test Theramore guard navigation.

Expected:

- Existing navigation remains functional.
- Profession options display correctly.
- Obsolete trainer directions are absent.

11. Test Stormshield/Warspear profession navigation.

Expected:

- Existing navigation continues to function.
- First Aid is no longer offered.

12. Verify unrelated quest NPCs and non-city guards remain unchanged.

This is important because the audit intentionally excludes unrelated gossip interactions even when the NPC name contains terms such as Guard, Guardian, Sentinel, Grunt, or Vindicator.

13. Verify the worldserver starts normally with no SQL loading errors related to:

- `gossip_menu_option`
- `gossip_menu_option_action`
- missing action menus
- invalid gossip option references

14. Perform additional testing of older city/navigation guards where available to confirm all displayed service names match the action performed.