### PR TITLE
CPP: Fix Various Chest and Crates not producing Loot

### DIFF
--- a/src/server/game/Loot/LootMgr.cpp
+++ b/src/server/game/Loot/LootMgr.cpp
@@ -90,7 +90,7 @@ class LootTemplate::LootGroup                               // A set of loot def
         bool HasQuestDrop() const;                          // True if group includes at least 1 quest drop entry
         bool HasQuestDropForPlayer(Player const* player) const;
                                                             // The same for active quests of the player
-        void Process(Loot& loot, uint16 lootMode) const;    // Rolls an item from the group (if any) and adds the item to the loot
+        void Process(Loot& loot, uint16 lootMode, Player const* player, bool specOnly) const;    // Rolls an item from the group (if any) and adds the item to the loot
         float RawTotalChance() const;                       // Overall chance for the group (without equal chanced items)
         float TotalChance() const;                          // Overall chance for the group
 
@@ -464,10 +464,10 @@ void LootTemplate::LootGroup::CopyConditions(ConditionContainer /*conditions*/)
 }
 
 // Rolls an item from the group (if any takes its chance) and adds the item to the loot
-void LootTemplate::LootGroup::Process(Loot& loot, uint16 lootMode) const
+void LootTemplate::LootGroup::Process(Loot& loot, uint16 lootMode, Player const* player, bool specOnly) const
 {
     if (LootStoreItem const* item = Roll(loot, lootMode))
-        loot.AddItem(*item);
+        loot.AddItem(*item, player, specOnly);
 }
 
 // Overall chance for the group without equal chanced items
@@ -594,7 +594,7 @@ void LootTemplate::Process(Loot& loot, bool rate, uint16 lootMode, uint8 groupId
         if (!Groups[groupId - 1])
             return;
 
-        Groups[groupId - 1]->Process(loot, lootMode);
+        Groups[groupId - 1]->Process(loot, lootMode, player, specOnly);
         return;
     }
 
@@ -625,7 +625,7 @@ void LootTemplate::Process(Loot& loot, bool rate, uint16 lootMode, uint8 groupId
     // Now processing groups
     for (LootGroups::const_iterator i = Groups.begin(); i != Groups.end(); ++i)
         if (LootGroup* group = *i)
-            group->Process(loot, lootMode);
+            group->Process(loot, lootMode, player, specOnly);
 }
 
 // True if template includes at least 1 quest drop entry


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

This PR fixes a core loot-generation issue affecting grouped loot entries.

During investigation of issue #91, gameobject loot templates were confirmed to load correctly and grouped loot rolls were confirmed to select valid items. However, the selected grouped items were not reaching the player's loot container.

The root cause was in `LootTemplate::LootGroup::Process()`. Grouped loot called `Loot::AddItem()` without passing the player context. `Loot::AddItem()` requires a valid player and returns without adding the item when no player is supplied.

Non-grouped loot was already passing the player and `specOnly` context correctly, which explains why some standalone loot rolls could still appear while grouped loot remained missing.

The fix updates grouped loot processing to preserve the same player context already available in `LootTemplate::Process()`:

- `LootGroup::Process()` now accepts `Player const* player` and `bool specOnly`.
- Grouped loot passes those values to `Loot::AddItem()`.
- Both direct group processing and normal group iteration now forward the player/spec context.

No loot chances, loot tables, group definitions, database rows, or loot-selection algorithms are changed.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #91 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The issue was isolated through in-game testing and runtime tracing of the existing BFA-HavenCore loot path.

Testing confirmed that:

- Gameobjects resolved the correct `LootId`.
- `Loot::FillLoot()` successfully found and processed the expected loot template.
- `LootTemplate::Process()` correctly reached all configured loot groups.
- `LootGroup::Roll()` successfully selected valid grouped items.
- Selected grouped items reached `Loot::AddItem()` with a null player pointer and were therefore discarded.
- After forwarding the player/spec context through `LootGroup::Process()`, the same grouped items were added correctly and appeared in-game.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Confirmed working after the fix:

- Battered/Tattered chest-style gameobjects using grouped loot.
- Food crate gameobjects using grouped loot.
- Equal-chance grouped loot entries with `Chance = 0`.
- Existing non-grouped loot remained functional.

Before the fix, grouped items were successfully rolled by the server but silently discarded before being added to the player's loot. After the fix, the same grouped items are visible and lootable.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Build the server with this PR and start `worldserver`.
2. Log in with a normal player character.
3. Locate and open a world chest that uses grouped entries in `gameobject_loot_template`, such as Battered/Tattered chest variants.
4. Confirm that grouped loot such as food, trade goods, or equipment now appears instead of only independent non-grouped rolls.
5. Open a food crate or another gameobject whose loot template relies on grouped entries and confirm its grouped loot is present.
6. Repeat several times to confirm equal-chance groups continue to select and add items normally.
7. Test at least one gameobject using only/non-grouped loot and confirm there is no regression.
8. Where possible, also test other loot systems that use `LootTemplate` groups to ensure the player context propagation does not introduce regressions.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Additional regression testing across other grouped loot sources is recommended because this is a generic core loot path.
- [ ] No known remaining issue specific to #91 after the fix.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test BFA-HavenCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub.

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
