### PR TITLE
CPP/SQL: Fix Spell Click Vehicles / Fix All World Mining Nodes Icon

### DIFF
--- a/sql/updates/world/2026_08_25_00_world_mining_node_icon_cleanup.sql
+++ b/sql/updates/world/2026_08_25_00_world_mining_node_icon_cleanup.sql
@@ -1,0 +1,37 @@
+-- BFA-HavenCore mining node icon metadata cleanup
+-- Follow-up to PR #180 (General Mining / Gathering Repair)
+--
+-- Affected mining gathering nodes use IconName = 'Mining', which causes
+-- the BFA client to display a black-box cursor/icon when hovering the node.
+--
+-- Clearing IconName restores the correct mining cursor.
+-- No loot, lock, skill-up, respawn, or core behavior is changed.
+--
+-- IMPORTANT:
+-- After applying this update, restart the worldserver and clear the client
+-- Cache directory before testing, as GameObject query data may be cached.
+
+UPDATE `gameobject_template`
+SET `IconName` = ''
+WHERE `entry` IN (
+    181555, -- Fel Iron Deposit
+    181556, -- Adamantite Deposit
+    181557, -- Khorium Vein
+    181569, -- Rich Adamantite Deposit
+    181570, -- Rich Adamantite Deposit
+    185877, -- Nethercite Deposit
+    202738, -- Elementium Vein
+    202741, -- Rich Elementium Vein
+    228563, -- Blackrock Deposit
+    241726, -- Leystone Deposit
+    241743, -- Felslate Deposit
+    245325, -- Rich Felslate Deposit
+    272768, -- Empereits Reserves
+    272778, -- Rich Empyrium Deposit
+    276616, -- Monelite Deposit
+    276617, -- Storm Silver Deposit
+    276618, -- Platinum Deposit
+    276621, -- Rich Monelite Deposit
+    276622, -- Rich Storm Silver Deposit
+    325875  -- Osmenite Deposit
+);

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -13624,7 +13624,10 @@ bool Unit::HandleSpellClick(Unit* clicker, int8 seatId)
             }
 
             if (!valid)
-                continue;
+                    {
+        TC_LOG_ERROR("sql.sql", "Spell %u specified in npc_spellclick_spells is not a valid vehicle enter aura!", itr->second.spellId);
+        continue;
+    }
 
             int32 bp0 = seatId + 1;
             if (IsInMap(caster))

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -13573,6 +13573,7 @@ void Unit::JumpTo(WorldObject* obj, float speedZ, bool withOrientation)
 bool Unit::HandleSpellClick(Unit* clicker, int8 seatId)
 {
     bool result = false;
+    bool acceptedSpellHasVehicleControlAura = false;
     uint32 spellClickEntry = GetVehicleKit() ? GetVehicleKit()->GetCreatureEntry() : GetEntry();
     SpellClickInfoMapBounds clickPair = sObjectMgr->GetSpellClickInfoMapBounds(spellClickEntry);
     for (SpellClickInfoContainer::const_iterator itr = clickPair.first; itr != clickPair.second; ++itr)
@@ -13592,31 +13593,42 @@ bool Unit::HandleSpellClick(Unit* clicker, int8 seatId)
         SpellInfo const* spellEntry = sSpellMgr->GetSpellInfo(itr->second.spellId);
         // if (!spellEntry) should be checked at npc_spellclick load
 
+        if (spellEntry)
+        {
+            for (SpellEffectInfo const* effect : spellEntry->GetEffectsForDifficulty(GetMap()->GetDifficultyID()))
+            {
+                if (effect && effect->ApplyAuraName == SPELL_AURA_CONTROL_VEHICLE)
+                {
+                    acceptedSpellHasVehicleControlAura = true;
+                    break;
+                }
+            }
+        }
+
         if (seatId > -1)
         {
             uint8 i = 0;
             bool valid = false;
             for (SpellEffectInfo const* effect : spellEntry->GetEffectsForDifficulty(GetMap()->GetDifficultyID()))
             {
-                if (!effect)
-                    continue;
-
-                if (effect->ApplyAuraName == SPELL_AURA_CONTROL_VEHICLE)
+                if (effect && effect->ApplyAuraName == SPELL_AURA_CONTROL_VEHICLE)
                 {
-                    valid = true;
-                    break;
+                    if (effect->CalcValue() - 1 == seatId)
+                    {
+                        valid = true;
+                        break;
+                    }
+
+                    ++i;
                 }
-                ++i;
             }
 
             if (!valid)
-            {
-                TC_LOG_ERROR("sql.sql", "Spell %u specified in npc_spellclick_spells is not a valid vehicle enter aura!", itr->second.spellId);
                 continue;
-            }
 
+            int32 bp0 = seatId + 1;
             if (IsInMap(caster))
-                caster->CastCustomSpell(itr->second.spellId, SpellValueMod(SPELLVALUE_BASE_POINT0+i), seatId + 1, target, GetVehicleKit() ? TRIGGERED_IGNORE_CASTER_MOUNTED_OR_ON_VEHICLE : TRIGGERED_NONE, nullptr, nullptr, origCasterGUID);
+                caster->CastCustomSpell(target, spellEntry->Id, &bp0, nullptr, nullptr, true, nullptr, nullptr, origCasterGUID);
             else    // This can happen during Player::_LoadAuras
             {
                 int32 bp0[MAX_SPELL_EFFECTS];
@@ -13638,6 +13650,14 @@ bool Unit::HandleSpellClick(Unit* clicker, int8 seatId)
 
         result = true;
     }
+
+    // Some spell-click vehicle definitions can reference spells that no longer
+    // contain SPELL_AURA_CONTROL_VEHICLE in the loaded client data. Preserve
+    // normal spell-click behavior first, then fall back to the core vehicle
+    // entry path for a player clicking a real vehicle.
+    if (result && clicker && clicker->GetTypeId() == TYPEID_PLAYER && GetVehicleKit() &&
+        !clicker->GetVehicle() && !acceptedSpellHasVehicleControlAura)
+        clicker->EnterVehicle(this, seatId);
 
     Creature* creature = ToCreature();
     if (creature && creature->IsAIEnabled)


### PR DESCRIPTION
# Vehicle Spell-Click and Mining Node Icon Fixes

<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->

This PR fixes player interaction with spell-click vehicles whose configured click spell no longer contains a `SPELL_AURA_CONTROL_VEHICLE` effect in the loaded BFA client data.

The normal spell-click path remains unchanged. After an accepted spell-click has been processed, the core now falls back to `Unit::EnterVehicle()` only when all of the following are true:

- The clicker is a player.
- The clicked unit has a valid `VehicleKit`.
- The spell-click definition was accepted and processed.
- The player did not already enter a vehicle.
- None of the accepted spell-click spells contains `SPELL_AURA_CONTROL_VEHICLE`.

Creature/accessory spell-clicks are not affected by the fallback, and vehicles whose spell-click spell already supplies the normal vehicle-control aura continue to use the existing path.

This PR proposes changes to:
-  [X] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #89
- _May close other related issues_

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

The issue was reproduced with Reprogrammed Shredder (creature 35129, vehicle 460) from **The Captain's Logs**.

The spell-click packet reached `Unit::HandleSpellClick()` and the configured spell-click row was accepted. Spell 66775 was cast successfully, but its loaded effect data did not contain `SPELL_AURA_CONTROL_VEHICLE`, so the player never became a passenger even though the creature had a valid `VehicleKit`.

After the fallback was added, the player successfully entered Reprogrammed Shredder and received the vehicle action bar.

Additional spell-click vehicles were tested to check for regressions, including:

- Emerald Drake (27692) - entered successfully.
- Salvaged Siege Engine (33060) - entered successfully.
- Arachnopod Destroyer (34183) - entered successfully.
- Skyshredder Turret (49135) - entered successfully.
- Toy Cart (52359) - existing spell-click behavior continued to work.

Vehicles gated by database conditions/quests continued to respect those conditions. For example, Xink's Shredder (27061) and Alliance Steam Tank (27587) do not expose a usable spell-click interaction unless their existing quest conditions are satisfied.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [X] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Start or obtain the Reprogrammed Shredder used by **The Captain's Logs** (creature entry 35129 / vehicle 460).
2. Right-click the Reprogrammed Shredder.
3. Verify the player enters the shredder and receives the vehicle action bar.
4. Exit the vehicle and verify normal player control is restored.
5. Test a vehicle whose spell-click spell already contains `SPELL_AURA_CONTROL_VEHICLE` and verify it still enters through the existing path.
6. Test a spell-click vehicle with quest/condition restrictions and verify the fallback does not bypass those restrictions.
7. Test creature/accessory spell-click behavior and verify non-player spell-clicks are unchanged.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Other vehicle/transport/use-object reports grouped under meta issue #285 may have separate causes and should be tested/fixed independently.
- [ ] Rope ladder issue #74 is not part of this PR.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test BFA-HavenCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub.

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.


---

# Mining Node Hover Icon Cleanup

## Changes Proposed

This PR fixes additional mining nodes that display a black-box cursor/icon when hovered in the BFA client.

This is a database-only follow-up to PR #180, where the same issue was previously identified and corrected for Copper Vein and Tin Vein.

- [ ] Core (units, players, creatures, game systems)
- [ ] Scripts (bosses, spell scripts, creature scripts)
- [x] Database (GameObject template metadata)

## Summary

PR #180 established that affected mining gathering nodes can render with a black-box hover icon when their `gameobject_template.IconName` field is populated with:

```text
Mining
```

Clearing `IconName` corrected the issue for the previously tested Copper and Tin nodes.

Additional mining nodes from later expansions were found to contain the same incorrect metadata pattern. This PR clears `IconName` on those remaining confirmed mining-node templates.

No changes are made to:

- Mining skill progression
- Lock handling
- Loot tables
- Personal loot behavior
- Node depletion/despawn
- GameObject interaction logic
- Core code

## Database Fix

The affected GameObject templates now use:

```sql
IconName = ''
```

instead of:

```sql
IconName = 'Mining'
```

Affected nodes include mining deposits and veins from Outland through Battle for Azeroth, including Fel Iron, Adamantite, Khorium, Elementium, Blackrock, Leystone, Felslate, Empyrium, Monelite, Storm Silver, Platinum, and Osmenite nodes.

## Testing

Testing was performed on:

- Monelite Deposit (`276616`)
- Storm Silver Deposit (`276617`)

Before the database correction, both displayed the black-box hover icon.

After clearing `IconName`, restarting the worldserver, and clearing the BFA client cache, both nodes displayed the correct mining cursor/icon.

## Important Testing Note

GameObject query data is cached by the client.

After applying the SQL update:

1. Stop the client.
2. Restart the worldserver.
3. Clear the client's `Cache` directory.
4. Restart the client.
5. Spawn and test the affected mining nodes.

Without clearing the client cache, the old black-box icon may continue to appear even after the database value has been corrected.

## Scope

This PR intentionally contains only the remaining mining-node `IconName` cleanup.

The broader mining fixes for profession skill resolution, gathering skill detection, loot completion, node depletion, and related Copper/Tin/Silver issues were already addressed in PR #180.

