### PR TITLE
core/database: support MariaDB Connector/C and Dun Morogh fixes

### DIFF
--- a/sql/updates/world/2026_08_28_00_Bralla_Cloudwing.sql
+++ b/sql/updates/world/2026_08_28_00_Bralla_Cloudwing.sql
@@ -1,0 +1,11 @@
+/* Bralla Cloudwing - Flying Trainer */
+DELETE FROM `npc_trainer` WHERE `ID` = 43769;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`, `MoneyCost`, `ReqSkillLine`, `ReqSkillRank`, `ReqLevel`, `Index`) VALUES 
+(43769, 33389, 40000, 762, 0, 20, 0),
+(43769, 33392, 500000, 762, 75, 40, 1),
+(43769, 34092, 2500000, 762, 150, 60, 2),
+(43769, 34093, 50000000, 762, 225, 70, 3),
+(43769, 90266, 50000000, 762, 300, 80, 4),
+(43769, 90269, 2500000, 762, 225, 60, 5);
+
+UPDATE `creature_template` SET `trainer_type` = 2 WHERE `entry` = 43769;

--- a/sql/updates/world/2026_08_28_01_fix_vendor.sql
+++ b/sql/updates/world/2026_08_28_01_fix_vendor.sql
@@ -1,0 +1,23 @@
+DELETE FROM `game_event_npc_vendor` WHERE `eventEntry` = 10 AND `guid` = 10675053 AND `item` IN (69895, 69896);
+DELETE FROM `game_event_npc_vendor` WHERE `eventEntry` = 10 AND `guid` = 299101 AND `item` IN (69895, 69896);
+INSERT INTO `game_event_npc_vendor` (`eventEntry`, `guid`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `BonusListIDs`, `PlayerConditionID`, `IgnoreFiltering`) VALUES (10, 10675053, 0, 69895, 0, 0, 0, 1, NULL, 0, 0);
+INSERT INTO `game_event_npc_vendor` (`eventEntry`, `guid`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `BonusListIDs`, `PlayerConditionID`, `IgnoreFiltering`) VALUES (10, 10675053, 0, 69896, 0, 0, 0, 1, NULL, 0, 0);
+INSERT INTO `game_event_npc_vendor` (`eventEntry`, `guid`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `BonusListIDs`, `PlayerConditionID`, `IgnoreFiltering`) VALUES (10, 299101, 0, 69895, 0, 0, 0, 1, NULL, 0, 0);
+INSERT INTO `game_event_npc_vendor` (`eventEntry`, `guid`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `BonusListIDs`, `PlayerConditionID`, `IgnoreFiltering`) VALUES (10, 299101, 0, 69896, 0, 0, 0, 1, NULL, 0, 0);
+
+DELETE FROM `npc_vendor` WHERE `entry` = 52358 AND `item` IN (69895, 69896);
+DELETE FROM `npc_vendor` WHERE `entry` = 52809 AND `item` IN (69895, 69896);
+
+/* Alliance */
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 23 AND `SourceGroup` = 52358 AND `SourceEntry` = 69057;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`) VALUES (23, 52358, 69057, 47, 171, 42);
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 23 AND `SourceGroup` = 52358 AND `SourceEntry` = 68890;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`) VALUES (23, 52358, 68890, 47, 29117, 42);
+
+/* Horde */
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 23 AND `SourceGroup` = 52809 AND `SourceEntry` = 69057;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`) VALUES (23, 52809, 69057, 47, 5502, 42);
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 23 AND `SourceGroup` = 52809 AND `SourceEntry` = 69231;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`) VALUES (23, 52809, 69231, 47, 29190, 42);

--- a/sql/updates/world/2026_08_28_02_quest_24474.sql
+++ b/sql/updates/world/2026_08_28_02_quest_24474.sql
@@ -1,0 +1,23 @@
+/* Quest: First Things First: We're Gonna Need Some Beer (24474) */
+DELETE FROM `quest_poi_points` WHERE `QuestID` = 24474;   
+INSERT INTO `quest_poi_points` (`QuestID`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES 
+(24474, 3, 0, -6087, 378, 0),
+(24474, 2, 0, -6142, 322, 0),
+(24474, 0, 0, -6142, 432, 0),
+(24474, 1, 0, -6149, 596, 0);  
+
+DELETE FROM `quest_poi` WHERE `QuestID` = 24474;
+INSERT INTO `quest_poi` (`QuestID`, `BlobIndex`, `Idx1`, `ObjectiveIndex`, `QuestObjectiveID`, `QuestObjectID`, `MapID`, `UiMapID`, `Priority`, `Flags`, `WorldEffectID`, `PlayerConditionID`, `SpawnTrackingID`, `AlwaysAllowMergingBlobs`, `VerifiedBuild`) VALUES 
+(24474, 0, 3, -1, 0, 0, 0, 427, 0, 0, 0, 0, 0, 0, 0),
+(24474, 0, 0, 0, 255019, 49744, 0, 427, 0, 0, 0, 0, 0, 0, 0),
+(24474, 0, 1, 0, 255020, 49745, 0, 427, 0, 0, 0, 0, 0, 0, 0),
+(24474, 0, 2, 0, 255021, 49746, 0, 427, 0, 0, 0, 0, 0, 0, 0);
+
+/* Gameobject: Keg of Theramore Pale Ale (201609) needs quest 24474 */
+UPDATE `gameobject_template` SET `Data8` = 24474 WHERE `entry` = 201609;  
+
+/* Gameobject: Keg of Stormhammer Stout (201610) needs quest 24474 */
+UPDATE `gameobject_template` SET `Data8` = 24474 WHERE `entry` = 201610;
+
+/* Gameobject: Keg of Gnomenbrau (201611) needs quest 24474 */
+UPDATE `gameobject_template` SET `Data8` = 24474 WHERE `entry` = 201611;

--- a/sql/updates/world/2026_08_28_03_quest_24477.sql
+++ b/sql/updates/world/2026_08_28_03_quest_24477.sql
@@ -1,0 +1,2 @@
+/* Gameobject: Forgotten Dwarven Artifact (201608) needs quest 24477 */
+UPDATE `gameobject_template` SET `Data8` = 24477 WHERE `entry` = 201608;   

--- a/sql/updates/world/2026_08_28_04_quest_6391_6388_6392.sql
+++ b/sql/updates/world/2026_08_28_04_quest_6391_6388_6392.sql
@@ -1,0 +1,8 @@
+/* Quest: Ride to Ironforge (6391) */
+UPDATE `quest_poi` SET `QuestObjectiveID` = 256815, `QuestObjectID` = 16310 WHERE `QuestID` = 6391 AND `BlobIndex` = 0 AND `Idx1` = 0;
+
+/* Quest: Gryth Thurden (6388) */
+UPDATE `quest_poi` SET `QuestObjectiveID` = 259844, `QuestObjectID` = 16311 WHERE `QuestID` = 6388 AND `BlobIndex` = 0 AND `Idx1` = 0;
+
+/* Quest: Return to Gremlock (6392) */
+UPDATE `quest_poi` SET `QuestObjectiveID` = 257584, `QuestObjectID` = 16311 WHERE `QuestID` = 6392 AND `BlobIndex` = 0 AND `Idx1` = 0;

--- a/sql/updates/world/2026_08_28_05_quest_384.sql
+++ b/sql/updates/world/2026_08_28_05_quest_384.sql
@@ -1,0 +1,34 @@
+/* Quest: Beer Basted Boar Ribs (384) */
+DELETE FROM `quest_poi` WHERE `QuestID` = 384;
+INSERT INTO `quest_poi` (`QuestID`, `BlobIndex`, `Idx1`, `ObjectiveIndex`, `QuestObjectiveID`, `QuestObjectID`, `MapID`, `UiMapID`, `Priority`, `Flags`, `WorldEffectID`, `PlayerConditionID`, `SpawnTrackingID`, `AlwaysAllowMergingBlobs`, `VerifiedBuild`) VALUES 
+(384, 0, 0, -1, 0, 0, 0, 27, 0, 1, 0, 0, 0, 0, 0),
+(384, 0, 1, 0, 252712, 60496, 0, 27, 0, 7, 0, 0, 0, 0, 0),
+(384, 0, 2, 1, 252713, 2894, 0, 27, 0, 7, 0, 0, 0, 0, 0),
+(384, 1, 1, 0, 252712, 60496, 0, 27, 0, 7, 0, 0, 0, 0, 0),
+(384, 2, 2, 0, 252713, 2894, 0, 27, 0, 7, 0, 0, 0, 0, 0);
+
+DELETE FROM `quest_poi_points` WHERE `QuestID` = 384;
+INSERT INTO `quest_poi_points` (`QuestID`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES 
+(384, 0, 0, -5596, -504, 22908),
+(384, 1, 0, -5538, -838, 22908),
+(384, 1, 1, -5456, -744, 22908),
+(384, 1, 2, -5377, -584, 22908),
+(384, 1, 3, -5358, -486, 22908),
+(384, 1, 4, -5385, -337, 22908),
+(384, 1, 5, -5467, -203, 22908),
+(384, 1, 6, -5648, -102, 22908),
+(384, 1, 7, -5789, -86, 22908),
+(384, 1, 8, -5926, -200, 22908),
+(384, 1, 9, -5926, -329, 22908),
+(384, 1, 10, -5887, -548, 22908),
+(384, 1, 11, -5683, -752, 22908),
+(384, 2, 0, -5581, -482, 22908);
+
+
+DELETE FROM `creature_questitem` WHERE `CreatureEntry` IN (1682, 7744, 44006, 100012, 1247);
+INSERT INTO `creature_questitem` (`CreatureEntry`, `Idx`, `ItemId`, `VerifiedBuild`) VALUES 
+(1682, 0, 2894, 35662),
+(7744, 0, 2894, 35662),
+(44006, 0, 2894, 35662),
+(100012, 0, 2894, 35662),
+(1247, 0, 2894, 35662);

--- a/sql/updates/world/2026_08_28_06_quest_25668_315.sql
+++ b/sql/updates/world/2026_08_28_06_quest_25668_315.sql
@@ -1,0 +1,5 @@
+/* Quest: Pilfered Supplies (25668) requires quest 25668 */
+UPDATE `gameobject_template` SET `Data8` = 25668 WHERE `entry` IN (203129, 203130);
+
+/* Gameobject: Shimmerweed Basket (276) needs quest 315 */
+UPDATE `gameobject_template` SET `Data8` = 315 WHERE `entry` = 276;

--- a/sql/updates/world/2026_08_28_07_quest_25838_25882.sql
+++ b/sql/updates/world/2026_08_28_07_quest_25838_25882.sql
@@ -1,0 +1,13 @@
+/* Quest: Help from Steelgrill's Depot (25838) */
+DELETE FROM `quest_poi` WHERE `QuestID` = 25838;
+INSERT INTO `quest_poi` (`QuestID`, `BlobIndex`, `Idx1`, `ObjectiveIndex`, `QuestObjectiveID`, `QuestObjectID`, `MapID`, `UiMapID`, `Priority`, `Flags`, `WorldEffectID`, `PlayerConditionID`, `SpawnTrackingID`, `AlwaysAllowMergingBlobs`, `VerifiedBuild`) VALUES (25838, 0, 0, -1, 0, 0, 0, 27, 0, 1, 0, 0, 0, 0, 23877);
+
+DELETE FROM `quest_poi_points` WHERE `QuestID` = 25838;
+INSERT INTO `quest_poi_points` (`QuestID`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES (25838, 0, 0, -5479, -646, 22908);
+
+/* Quest: A Hand at the Ranch (25882) */
+DELETE FROM `quest_poi` WHERE `QuestID` = 25882;
+INSERT INTO `quest_poi` (`QuestID`, `BlobIndex`, `Idx1`, `ObjectiveIndex`, `QuestObjectiveID`, `QuestObjectID`, `MapID`, `UiMapID`, `Priority`, `Flags`, `WorldEffectID`, `PlayerConditionID`, `SpawnTrackingID`, `AlwaysAllowMergingBlobs`, `VerifiedBuild`) VALUES (25882, 0, 0, -1, 0, 0, 0, 27, 0, 1, 0, 0, 0, 0, 23877);
+
+DELETE FROM `quest_poi_points` WHERE `QuestID` = 25882;
+INSERT INTO `quest_poi_points` (`QuestID`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES (25882, 0, 0, -5539, -1311, 22908);

--- a/src/server/database/Database/DatabaseWorkerPool.cpp
+++ b/src/server/database/Database/DatabaseWorkerPool.cpp
@@ -60,10 +60,10 @@ DatabaseWorkerPool<T>::DatabaseWorkerPool()
 {
     WPFatal(mysql_thread_safe(), "Used MySQL library isn't thread-safe.");
 #ifdef MARIADB_VERSION_ID
-    WPFatal(mysql_get_client_version() >= MIN_MYSQL_CLIENT_VERSION, "BfaCore does not support MariaDB Connector/C versions below 3.2.3");
+    WPFatal(mysql_get_client_version() >= MIN_MYSQL_CLIENT_VERSION, "BFA-HavenCore does not support MariaDB Connector/C versions below 3.2.3");
 #else
-    WPFatal(mysql_get_client_version() >= MIN_MYSQL_CLIENT_VERSION, "BfaCore does not support MySQL versions below 5.1");
-    WPFatal(mysql_get_client_version() == MYSQL_VERSION_ID, "Used MySQL library version (%s) does not match the version used to compile BfaCore (%s). Search on forum for TCE00011.",
+    WPFatal(mysql_get_client_version() >= MIN_MYSQL_CLIENT_VERSION, "BFA-HavenCore does not support MySQL versions below 5.1");
+    WPFatal(mysql_get_client_version() == MYSQL_VERSION_ID, "Used MySQL library version (%s) does not match the version used to compile BFA-HavenCore (%s). Search on forum for TCE00011.",
         mysql_get_client_info(), MYSQL_SERVER_VERSION);
 #endif
 }

--- a/src/server/database/Database/DatabaseWorkerPool.cpp
+++ b/src/server/database/Database/DatabaseWorkerPool.cpp
@@ -36,7 +36,12 @@
 #include <mysqld_error.h>
 
 #define MIN_MYSQL_SERVER_VERSION 50100u
+#ifdef MARIADB_VERSION_ID
+// Connector/C reports 3.3.19 as 30319; MYSQL_VERSION_ID is the server id 101118.
+#define MIN_MYSQL_CLIENT_VERSION 30203u
+#else
 #define MIN_MYSQL_CLIENT_VERSION 50100u
+#endif
 
 class PingOperation : public SQLOperation
 {
@@ -54,9 +59,13 @@ DatabaseWorkerPool<T>::DatabaseWorkerPool()
       _async_threads(0), _synch_threads(0)
 {
     WPFatal(mysql_thread_safe(), "Used MySQL library isn't thread-safe.");
+#ifdef MARIADB_VERSION_ID
+    WPFatal(mysql_get_client_version() >= MIN_MYSQL_CLIENT_VERSION, "BfaCore does not support MariaDB Connector/C versions below 3.2.3");
+#else
     WPFatal(mysql_get_client_version() >= MIN_MYSQL_CLIENT_VERSION, "BfaCore does not support MySQL versions below 5.1");
     WPFatal(mysql_get_client_version() == MYSQL_VERSION_ID, "Used MySQL library version (%s) does not match the version used to compile BfaCore (%s). Search on forum for TCE00011.",
         mysql_get_client_info(), MYSQL_SERVER_VERSION);
+#endif
 }
 
 template <class T>


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Quest Fixes:
- Added map markers for:
	- A Hand at the Ranch [25882](https://www.wowhead.com/quest=25882)
	- Help from Steelgrill's Depot [25838](https://www.wowhead.com/quest=25838)
	- Beer Basted Boar Ribs [384](https://www.wowhead.com/quest=384)
	- We're Gonna Need Some Beer [24474](https://www.wowhead.com/quest=24474)
- Fixed map markers for:
	- Return to Gremlock [6392](https://www.wowhead.com/quest=6392)
	- Gryth Thurden [6388](https://www.wowhead.com/quest=6388)
	- Ride to Ironforge [6391](https://www.wowhead.com/quest=6391)
- Using quest objects when a quest is active:
	- Shimmerweed Basket [276](https://www.wowhead.com/object=276) requires quest 315
	- Pilfered Supplies [25668](https://www.wowhead.com/object=25668) requires quest 25668
	- Forgotten Dwarven Artifact [201608](https://www.wowhead.com/object=201608)
	- Keg of Theramore Pale Ale [201609](https://www.wowhead.com/object=201609) needs quest 24474
	- Keg of Stormhammer Stout [201610](https://www.wowhead.com/object=201610) needs quest 24474
	- Keg of Gnomenbrau [201611](https://www.wowhead.com/object=201611) needs quest 24474
- Tooltip display for vendors with quest items:
	- Beer Basted Boar Ribs [384](https://www.wowhead.com/quest=384)
Fixed the Craggle Wobbletop ([52358](https://www.wowhead.com/npc=52358) - Alliance) and Blax Bottlerocket ([52809](https://www.wowhead.com/npc=52809) - Horde) vendors: event-related items + quest items were displayed without quests.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Cursor (Grok 4.6) was used to draft the MariaDB Connector/C version check. The SQL world updates were authored locally and only packaged into this PR.

## Issues Addressed:
- Closes

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

MariaDB Connector/C reports package version 3.x (`30319` for 3.3.19), not `MYSQL_VERSION_ID` (`101118` for 10.11.18). The old `>= 50100` client check aborted `worldserver` on Linux. Oracle MySQL / Windows path is unchanged.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Linux (Debian 12, MariaDB 10.11 / Connector/C 3.3.19): `worldserver` starts past the client-version `WPFatal`. In-game checks for the Dun Morogh/Ironforge quest and vendor SQL were not completed as part of this PR.

## How to Test the Changes:
- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Build `worldserver` on Linux against MariaDB Connector/C and confirm it no longer exits with `BfaCore does not support MySQL versions below 5.1`.
2. Confirm a Windows / Oracle MySQL 8 build still starts (client-version equality check unchanged).
3. In-game: Bralla Cloudwing (43769) offers flying training; Midsummer vendors 52358/52809 sell the expected items; quests 24474, 24477, 6391/6388/6392, 384, 25668, 315, 25838, 25882 POIs and object bindings.

## Known Issues and TODO List:
- [ ] In-game verification of the 2026-08-28 world SQL updates
- [ ]

## How to Test BFA-HavenCore PRs

To test, you need to create a character:
- Race = Dwarf
- Class = Paladin
- Level = 1-15