### PR TITLE
CPP: Update .learn all gm Command for BFA

### DIFF
--- a/src/server/scripts/Commands/cs_learn.cpp
+++ b/src/server/scripts/Commands/cs_learn.cpp
@@ -26,6 +26,7 @@ EndScriptData */
 #include "Chat.h"
 #include "DB2Stores.h"
 #include "Language.h"
+#include "Log.h"
 #include "ObjectMgr.h"
 #include "Pet.h"
 #include "Player.h"
@@ -33,6 +34,8 @@ EndScriptData */
 #include "SpellMgr.h"
 #include "SpellInfo.h"
 #include "WorldSession.h"
+#include <algorithm>
+#include <cctype>
 
 class learn_commandscript : public CommandScript
 {
@@ -120,19 +123,93 @@ public:
 
     static bool HandleLearnAllGMCommand(ChatHandler* handler, char const* /*args*/)
     {
-        for (uint32 i = 0; i < sSpellMgr->GetSpellInfoStoreSize(); ++i)
+        Player* player = handler->GetSession()->GetPlayer();
+        int locale = handler->GetSessionDbcLocale();
+
+        // Confirmed useful/working BFA 8.3.7 GM spell list.
+        static uint32 const confirmedGMSpells[] =
         {
-            SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(i);
-            if (!spellInfo || !SpellMgr::IsSpellValid(spellInfo, handler->GetSession()->GetPlayer(), false))
-                continue;
+            1234,    // Joe's God Mode
+            265,     // Area Death (TEST)
+            5,       // Death Touch
+            160040,  // Freeze - explicit Blizzard GM tool
+            1852,    // Silenced - explicit Blizzard GM tool
+            9454,    // Freeze - targeted
+            43489,   // Grasp of the Lich King - pacify/silence + root
 
-            if (!spellInfo->IsAbilityOfSkillType(SKILL_INTERNAL))
-                continue;
+            142653,  // Teleport Target to Self
+            21463,   // Teleport to Player
+            36967,   // Teleport to Player
+            267414,  // Teleport Target to Self
+            319517,  // Teleport Target to Self
 
-            handler->GetSession()->GetPlayer()->LearnSpell(i, false);
+            20279,   // Summon Player
+            20477,   // Summon Player
+            223562,  // Summon Player
+
+            309787,  // _JKL - Instant Cast
+
+            23965,   // Instant Heal
+            67891,   // Full Heal
+            69693,   // Full Heal
+            72423,   // Mass Resurrection
+            62856,   // Detect Invisibility
+
+            37800,   // Transparency
+            134001   // Cooldown Reset - confirmed useful
+        };
+
+        TC_LOG_INFO("server.loading", "============================================================");
+        TC_LOG_INFO("server.loading", "[GM-LEARN] Learning confirmed BFA GM spell list");
+        TC_LOG_INFO("server.loading", "============================================================");
+
+        uint32 learned = 0;
+        uint32 alreadyKnown = 0;
+        uint32 invalid = 0;
+
+        for (uint32 spellId : confirmedGMSpells)
+        {
+            SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
+            if (!spellInfo || !SpellMgr::IsSpellValid(spellInfo, player, false))
+            {
+                ++invalid;
+                TC_LOG_INFO("server.loading", "[GM-LEARN] Spell=%u INVALID/NOT LOADED", spellId);
+                continue;
+            }
+
+            std::string name;
+            if (spellInfo->SpellName)
+            {
+                name = spellInfo->SpellName->Str[locale];
+                if (name.empty())
+                    name = spellInfo->SpellName->Str[0];
+            }
+
+            if (player->HasSpell(spellId))
+            {
+                ++alreadyKnown;
+                TC_LOG_INFO("server.loading",
+                    "[GM-LEARN] Spell=%u Name=\"%s\" ALREADY KNOWN",
+                    spellId, name.c_str());
+                continue;
+            }
+
+            player->LearnSpell(spellId, false);
+            ++learned;
+
+            TC_LOG_INFO("server.loading",
+                "[GM-LEARN] Spell=%u Name=\"%s\" LEARNED",
+                spellId, name.c_str());
         }
 
-        handler->SendSysMessage(LANG_LEARNING_GM_SKILLS);
+        TC_LOG_INFO("server.loading", "============================================================");
+        TC_LOG_INFO("server.loading",
+            "[GM-LEARN] Finished: learned=%u alreadyKnown=%u invalid=%u total=%u",
+            learned, alreadyKnown, invalid, uint32(sizeof(confirmedGMSpells) / sizeof(uint32)));
+        TC_LOG_INFO("server.loading", "============================================================");
+
+        handler->SendSysMessage("All GM Spells Learned");
+
         return true;
     }
 

--- a/src/server/scripts/Commands/cs_learn.cpp
+++ b/src/server/scripts/Commands/cs_learn.cpp
@@ -124,7 +124,6 @@ public:
     static bool HandleLearnAllGMCommand(ChatHandler* handler, char const* /*args*/)
     {
         Player* player = handler->GetSession()->GetPlayer();
-        int locale = handler->GetSessionDbcLocale();
 
         // Confirmed useful/working BFA 8.3.7 GM spell list.
         static uint32 const confirmedGMSpells[] =
@@ -156,60 +155,25 @@ public:
             62856,   // Detect Invisibility
 
             37800,   // Transparency
-            134001   // Cooldown Reset - confirmed useful
+            134001   // Cooldown Reset
         };
 
-        TC_LOG_INFO("server.loading", "============================================================");
-        TC_LOG_INFO("server.loading", "[GM-LEARN] Learning confirmed BFA GM spell list");
-        TC_LOG_INFO("server.loading", "============================================================");
-
-        uint32 learned = 0;
-        uint32 alreadyKnown = 0;
-        uint32 invalid = 0;
+        // Keep one concise audit log entry that the command was used.
+        TC_LOG_INFO("commands.gm",
+            "GM %s (GUID: %u) executed .learn all gm",
+            player->GetName().c_str(), player->GetGUID().GetCounter());
 
         for (uint32 spellId : confirmedGMSpells)
         {
             SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
             if (!spellInfo || !SpellMgr::IsSpellValid(spellInfo, player, false))
-            {
-                ++invalid;
-                TC_LOG_INFO("server.loading", "[GM-LEARN] Spell=%u INVALID/NOT LOADED", spellId);
                 continue;
-            }
 
-            std::string name;
-            if (spellInfo->SpellName)
-            {
-                name = spellInfo->SpellName->Str[locale];
-                if (name.empty())
-                    name = spellInfo->SpellName->Str[0];
-            }
-
-            if (player->HasSpell(spellId))
-            {
-                ++alreadyKnown;
-                TC_LOG_INFO("server.loading",
-                    "[GM-LEARN] Spell=%u Name=\"%s\" ALREADY KNOWN",
-                    spellId, name.c_str());
-                continue;
-            }
-
-            player->LearnSpell(spellId, false);
-            ++learned;
-
-            TC_LOG_INFO("server.loading",
-                "[GM-LEARN] Spell=%u Name=\"%s\" LEARNED",
-                spellId, name.c_str());
+            if (!player->HasSpell(spellId))
+                player->LearnSpell(spellId, false);
         }
 
-        TC_LOG_INFO("server.loading", "============================================================");
-        TC_LOG_INFO("server.loading",
-            "[GM-LEARN] Finished: learned=%u alreadyKnown=%u invalid=%u total=%u",
-            learned, alreadyKnown, invalid, uint32(sizeof(confirmedGMSpells) / sizeof(uint32)));
-        TC_LOG_INFO("server.loading", "============================================================");
-
         handler->SendSysMessage("All GM Spells Learned");
-
         return true;
     }
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [X] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Fix `.learn all gm` for BFA 8.3.7 and restore useful GM spell set

## Summary

This PR fixes the `.learn all gm` command for the BFA 8.3.7 client and
updates it with a curated set of GM/developer spells that are confirmed
to exist and work with the BFA client/core.

The existing implementation attempted to discover GM spells through:

``` cpp
spellInfo->IsAbilityOfSkillType(SKILL_INTERNAL)
```

where:

``` cpp
SKILL_INTERNAL = 769
```

This worked with older clients such as 3.3.5a because the client data
contained the **Internal** skill line and associated `SkillLineAbility`
mappings. In the BFA 8.3.7 data used by HavenCore, the old Internal
skill mapping is no longer populated, so the command completes
successfully but does not actually teach the useful GM spells.

The command has therefore been changed to learn a curated BFA-compatible
GM spell set instead of relying on the obsolete `SKILL_INTERNAL` lookup.

## Problem

Running:

``` text
.learn all gm
```

previously returned:

``` text
You have learned all default GM spells/skills.
```

but the expected GM spells were not learned.

On 3.3.5a, GM/developer spells such as **Death Touch** and **Area
Death** were associated with:

``` text
SkillLine = 769
```

which corresponds to:

``` text
Internal
```

The BFA client/core no longer provides the same usable
`SkillLineAbility` relationship, causing this code to return no useful
GM abilities:

``` cpp
if (!spellInfo->IsAbilityOfSkillType(SKILL_INTERNAL))
    continue;
```

## Fix

`HandleLearnAllGMCommand` now uses an explicit list of GM/developer
spells that have been individually validated against the BFA 8.3.7
client and HavenCore.

Each spell is still checked through `SpellInfo` and
`SpellMgr::IsSpellValid()` before being learned.

Already-known spells are safely skipped.

After completion the command now reports:

``` text
All GM Spells Learned
```

rather than implying that the obsolete Internal skill scan succeeded.

## Confirmed BFA GM spells

The following spells were individually tested in-game and retained
because they provide useful GM functionality:

    Spell ID Spell / Purpose
  ---------- -----------------------------------------------------
        1234 Joe's God Mode
         265 Area Death (TEST)
           5 Death Touch
      160040 Freeze
        1852 Silenced
        9454 Freeze (targeted)
       43489 Grasp of the Lich King --- pacify/silence/root
      142653 Teleport Target to Self
       21463 Teleport to Player / pull target to GM
       36967 Teleport to Player / pull target to GM
      267414 Teleport Target to Self
      319517 Teleport Target to Self
       20279 Summon Player
       20477 Summon Player
      223562 Summon Player
      309787 Instant Cast
       23965 Instant Heal
       67891 Full Heal
       69693 Full Heal
       72423 Mass Resurrection
       62856 Detect Invisibility
       37800 Transparency --- useful for unobtrusive GM movement
      134001 Cooldown Reset

## Validation

The implementation was tested on the BFA 8.3.7 client.

Testing included:

-   confirming each retained spell exists in the BFA `SpellInfo` store;
-   validating the spell through `SpellMgr::IsSpellValid()`;
-   learning and retaining the spell on a GM character;
-   testing the actual spell behavior in-game;
-   testing targeted control abilities against players/NPCs;
-   testing teleport/summon abilities;
-   testing healing and resurrection abilities;
-   testing GM visibility/transparency functionality;
-   testing cooldown reset functionality; and
-   confirming `.learn all gm` can be run when spells are already known.

A number of spells discovered during testing were intentionally excluded
because they were missing from BFA, had no useful effect, affected the
GM unintentionally, or were normal player/encounter abilities rather
than useful GM tools.

For example, spell `192255` was rejected because its Freeze effect also
freezes the GM/large surrounding area.

## Result

Before this PR:

``` text
.learn all gm
```

reported success but did not provide the expected GM toolkit.

After this PR:

``` text
.learn all gm
```

teaches the validated BFA GM spell set and reports:

``` text
All GM Spells Learned
```

This restores the practical purpose of the command for BFA while
avoiding dependency on the obsolete `SKILL_INTERNAL` spell mapping.
