### PR TITLE
Core/DB: fix Ironforge High Seat chain and Dun Morogh chicken daily

### DIFF
--- a/sql/updates/world/2026_08_29_02_25937.sql
+++ b/sql/updates/world/2026_08_29_02_25937.sql
@@ -1,0 +1,22 @@
+/* Quest: Priceless Treasures 25937 */
+DELETE FROM `quest_poi_points` WHERE `QuestID` = 25937;
+INSERT INTO `quest_poi_points` (`QuestID`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES
+(25937, 1, 0, -5673.39, -1594.03, 0),
+(25937, 0, 0, -5570, -1802, 0),
+(25937, 0, 1, -5510, -1743, 0),
+(25937, 0, 2, -5539, -1695, 0),
+(25937, 0, 3, -5786, -1514, 0),
+(25937, 0, 4, -5833, -1492, 0),
+(25937, 0, 5, -5839, -1611, 0),
+(25937, 0, 6, -5819, -1695, 0),
+(25937, 0, 7, -5635, -1792, 0);
+
+DELETE FROM `quest_poi` WHERE `QuestID` = 25937;
+INSERT INTO `quest_poi` (`QuestID`, `BlobIndex`, `Idx1`, `ObjectiveIndex`, `QuestObjectiveID`, `QuestObjectID`, `MapID`, `UiMapID`, `Priority`, `Flags`, `WorldEffectID`, `PlayerConditionID`, `SpawnTrackingID`, `AlwaysAllowMergingBlobs`, `VerifiedBuild`) VALUES
+(25937, 0, 0, 0, 265327, 56225, 0, 27, 0, 1, 0, 0, 0, 0, 0),
+(25937, 0, 1, 0, 265328, 56226, 0, 27, 0, 1, 0, 0, 0, 0, 0);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID` = 25937 AND `locale` IN ('enUS', 'ruRU');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(25937, 'ruRU', 'Слава богу, ты здесь, Стентс. Клан Черного Железа атакует аэродром, и мы держимся с трудом.', 0),
+(25937, 'enUS', "Thank goodness you're here, $n. The airfield's been attacked by the Dark Irons and I don't think we can hold out much longer.", 0);

--- a/sql/updates/world/2026_08_29_03_26118.sql
+++ b/sql/updates/world/2026_08_29_03_26118.sql
@@ -1,0 +1,31 @@
+-- Seize the Ambassador (26118): C++ owns the council scene and escort.
+-- Broken SAI on 42153 completed the quest on a 1s timer and talked through
+-- Outland GUIDs 82277/82278 instead of High Seat guards.
+
+UPDATE `quest_template_addon` SET `PrevQuestID` = 26112 WHERE `ID` = 26118;
+
+UPDATE `creature_template` SET `AIName` = '' WHERE `entry` = 42146;
+UPDATE `creature_template` SET `AIName` = '', `ScriptName` = 'npc_ambassador_slaghammer' WHERE `entry` = 42153;
+
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 42146 AND `source_type` = 0;
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 42153 AND `source_type` = 0;
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 4215300 AND `source_type` = 9;
+
+DELETE FROM `spell_script_names` WHERE `spell_id` = 78628 AND `ScriptName` = 'spell_ironforge_arrest_slaghammer';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(78628, 'spell_ironforge_arrest_slaghammer');
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` IN (13, 17) AND `SourceEntry` = 78628;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(13, 1, 78628, 0, 0, 31, 0, 3, 42146, 0, 0, 0, 0, '', 'Arrest dest must be Ambassador Slaghammer'),
+(13, 2, 78628, 0, 0, 31, 0, 3, 42146, 0, 0, 0, 0, '', 'Arrest dummy must hit Ambassador Slaghammer'),
+(17, 0, 78628, 0, 0, 9, 0, 26118, 0, 0, 0, 0, 0, '', 'Arrest requires Seize the Ambassador taken');
+
+UPDATE `creature` SET `MovementType` = 0 WHERE `guid` IN (180727, 180726, 180861);
+UPDATE `creature` SET `unit_flags2` = 2048 WHERE `guid` = 180861;
+
+DELETE FROM `creature_addon` WHERE `guid` IN (180727, 180726, 180861);
+INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `aiAnimKit`, `movementAnimKit`, `meleeAnimKit`, `visibilityDistanceType`) VALUES
+(180727, 0, 0, 0, 1, 0, 0, 0, 0, 0),
+(180726, 0, 0, 0, 1, 0, 0, 0, 0, 0),
+(180861, 0, 0, 0, 1, 0, 0, 0, 0, 0);

--- a/sql/updates/world/2026_08_29_04_29352.sql
+++ b/sql/updates/world/2026_08_29_04_29352.sql
@@ -1,0 +1,67 @@
+-- Quest 29352 A Fowl Shortage: click Dun Morogh Chicken 53568 for item 69982.
+-- Spellclick only had dummy 99486 (player-on-player) and SAI listened for
+-- SPELLHIT_TARGET of 99487, which is never cast. Mirror Sen'jin Frog 40176:
+-- dummy on the chicken, CREATE_ITEM on the player, despawn on dummy hit.
+
+DELETE FROM `npc_spellclick_spells` WHERE `npc_entry` = 53568;
+INSERT INTO `npc_spellclick_spells` (`npc_entry`, `spell_id`, `cast_flags`, `user_type`) VALUES
+(53568, 99486, 1, 0),
+(53568, 99487, 3, 0);
+
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 53568 AND `source_type` = 0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `comment`) VALUES
+(53568, 0, 0, 0, 8, 0, 100, 0, 99486, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 'Dun Morogh Chicken - On Spellhit Pickup Chicken dummy - Despawn');
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 18 AND `SourceGroup` = 53568;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(18, 53568, 99486, 0, 0, 8, 0, 29352, 0, 0, 1, 0, 0, '', 'Forbidden rewarded quest for spellclick'),
+(18, 53568, 99486, 0, 0, 9, 0, 29352, 0, 0, 0, 0, 0, '', 'Required quest active for spellclick'),
+(18, 53568, 99487, 0, 0, 8, 0, 29352, 0, 0, 1, 0, 0, '', 'Forbidden rewarded quest for spellclick'),
+(18, 53568, 99487, 0, 0, 9, 0, 29352, 0, 0, 0, 0, 0, '', 'Required quest active for spellclick');
+
+DELETE FROM `creature_addon` WHERE `guid` IN (302907, 302937, 302938, 302939, 302940, 302941, 302942, 302943, 302944, 302945, 302946, 302947, 302948, 302949, 302950, 302951, 302952, 302953, 302954, 302955, 302956, 302957, 302958, 302960, 302961, 302962, 302963, 302964, 302965, 302966, 302967, 302968, 302969, 302970, 302971, 302972, 302973, 302974, 302975, 302976, 302977, 302978, 302979, 302980);
+INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `aiAnimKit`, `movementAnimKit`, `meleeAnimKit`, `visibilityDistanceType`, `auras`) VALUES 
+(302907, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302937, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302938, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302939, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302940, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302941, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302942, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302943, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302944, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302945, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302946, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302947, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302948, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302949, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302950, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302951, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302952, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302953, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302954, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302955, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302956, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302957, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302958, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302960, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302961, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302962, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302963, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302964, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302965, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302966, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302967, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302968, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302969, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302970, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302971, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302972, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302973, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302974, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302975, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302976, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302977, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302978, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302979, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357'),
+(302980, 0, 0, 0, 1, 0, 0, 0, 0, 0, '94357');

--- a/sql/updates/world/2026_08_29_05_26078.sql
+++ b/sql/updates/world/2026_08_29_05_26078.sql
@@ -1,0 +1,9 @@
+/* Quest: Extinguish the Fires 26078 */
+DELETE FROM `quest_offer_reward` WHERE `ID` = 26078;
+INSERT INTO `quest_offer_reward` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `RewardText`, `VerifiedBuild`) VALUES
+(26078, 0, 0, 0, 0, 0, 0, 0, 0, "Well done! My men are working hard on getting our flying machines and steam tanks back into the fight.", 0);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID` = 26078 AND `locale` IN ('enUS', 'ruRU');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(26078, 'enUS', 'Well done! My men are working hard on getting our flying machines and steam tanks back into the fight.', 0),
+(26078, 'ruRU', 'Отличная работа! Мои люди работают над тем, чтобы наши летающие машины и паровые танки вернулись в бой.', 0);

--- a/sql/updates/world/2026_08_29_06_26085.sql
+++ b/sql/updates/world/2026_08_29_06_26085.sql
@@ -1,0 +1,9 @@
+/* Quest: Rallying the Defenders 26085 */
+DELETE FROM `quest_offer_reward` WHERE `ID` = 26085;
+INSERT INTO `quest_offer_reward` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `RewardText`, `VerifiedBuild`) VALUES
+(26085, 0, 0, 0, 0, 0, 0, 0, 0, "The men are finding hidden reserves of strength and courage to deal with the Dark Iron onslaught. The airfield will not fall on our watch! ", 0);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID` = 26085 AND `locale` IN ('enUS', 'ruRU');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(26085, 'enUS', 'The men are finding hidden reserves of strength and courage to deal with the Dark Iron onslaught. The airfield will not fall on our watch!', 0),
+(26085, 'ruRU', 'Защитники воспряли духом и с новыми силами и смелостью противостоят захватчикам Черного Железа. Аэродром не падет на наших глазах!', 0);

--- a/sql/updates/world/2026_08_29_07_26094.sql
+++ b/sql/updates/world/2026_08_29_07_26094.sql
@@ -1,0 +1,9 @@
+/* Quest: Striking Back 26094 */
+DELETE FROM `quest_offer_reward` WHERE `ID` = 26094;
+INSERT INTO `quest_offer_reward` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `RewardText`, `VerifiedBuild`) VALUES
+(26094, 0, 0, 0, 0, 0, 0, 0, 0, "The momentum is starting to shift, $n, largely due to your efforts. Now, it is time to strike at the Dark Iron leadership. ", 0);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID` = 26094 AND `locale` IN ('enUS', 'ruRU');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(26094, 'enUS', 'The momentum is starting to shift, $n, largely due to your efforts. Now, it is time to strike at the Dark Iron leadership.', 0),
+(26094, 'ruRU', 'Чаша весов начинает склоняться в нашу сторону, $n, и во многом благодаря твоим усилиям. Теперь пришло время нанести удар по предводителям клана Черного Железа.', 0);

--- a/sql/updates/world/2026_08_29_08_26102.sql
+++ b/sql/updates/world/2026_08_29_08_26102.sql
@@ -1,0 +1,23 @@
+/* Quest: Grimaxe's Demise 26102 */
+DELETE FROM `quest_poi_points` WHERE `QuestID` = 26102;
+INSERT INTO `quest_poi_points` (`QuestID`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES
+(26102, 0, 0, -4611, -1695, 22908),
+(26102, 1, 0, -5039, -1704, 22908);
+
+DELETE FROM `quest_poi` WHERE `QuestID` = 26102;
+INSERT INTO `quest_poi` (`QuestID`, `BlobIndex`, `Idx1`, `ObjectiveIndex`, `QuestObjectiveID`, `QuestObjectID`, `MapID`, `UiMapID`, `Priority`, `Flags`, `WorldEffectID`, `PlayerConditionID`, `SpawnTrackingID`, `AlwaysAllowMergingBlobs`, `VerifiedBuild`) VALUES
+(26102, 0, 0, -1, 0, 0, 0, 27, 0, 1, 0, 0, 0, 0, 0),
+(26102, 0, 1, 0, 263284, 42010, 0, 27, 0, 7, 0, 0, 0, 0, 0);
+
+DELETE FROM `quest_offer_reward` WHERE `ID` = 26102;
+INSERT INTO `quest_offer_reward` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `RewardText`, `VerifiedBuild`) VALUES
+(26102, 0, 0, 0, 0, 0, 0, 0, 0, "We've done it! Without your help, Ironforge Airfield would surely be occupied by the enemy and the Dark Irons would have a clear road to Ironforge itself. The Council of Three Hammers must be informed of what happened here.", 0);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID` = 26102 AND `locale` IN ('enUS', 'ruRU');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(26102, 'enUS', "We've done it! Without your help, Ironforge Airfield would surely be occupied by the enemy and the Dark Irons would have a clear road to Ironforge itself. 
+
+The Council of Three Hammers must be informed of what happened here.", 0),
+(26102, 'ruRU', "Мы сделали это! Без твоей помощи аэродром Стальгорна наверняка был бы занят врагом, а клан Черного Железа имел бы прямой доступ к Стальгорну.
+
+Совет Трех Кланов должен узнать о том, что здесь произошло.", 0);

--- a/sql/updates/world/2026_08_29_09_26112.sql
+++ b/sql/updates/world/2026_08_29_09_26112.sql
@@ -1,0 +1,2 @@
+/* Quest: Demanding Answers 26112 */
+UPDATE `quest_poi` SET `QuestObjectiveID` = 265529, `QuestObjectID` = 56823 WHERE `QuestID` = 26112 AND `BlobIndex` = 0 AND `Idx1` = 0;

--- a/sql/updates/world/2026_08_29_10_1578.sql
+++ b/sql/updates/world/2026_08_29_10_1578.sql
@@ -1,0 +1,4 @@
+/* Quest: Supplying the Front 1578 */
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 19 AND `SourceEntry` = 1578;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `Comment`) VALUES
+(19, 0, 1578, 7, 0, 164, 35, 0, 0, 0, 0, 'Required Blacksmithing 35 skill');

--- a/src/server/scripts/EasternKingdoms/zone_ironforge.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_ironforge.cpp
@@ -16,164 +16,587 @@
  */
 
 #include "ScriptMgr.h"
+#include "Map.h"
+#include "MotionMaster.h"
+#include "ObjectAccessor.h"
+#include "ObjectMgr.h"
+#include "PetDefines.h"
+#include "Player.h"
+#include "QuestDef.h"
 #include "ScriptedCreature.h"
 #include "ScriptedGossip.h"
-#include "Player.h"
+#include "SpellScript.h"
+#include "UnitDefines.h"
 #include "Vehicle.h"
+#include <algorithm>
+#include <vector>
 
-enum Moira
+enum IronforgeSeizeAmbassador
 {
-    QUEST_SEIZE_AMBASSADOR = 26118
+    QUEST_DEMANDING_ANSWERS              = 26112,
+    QUEST_SEIZE_AMBASSADOR               = 26118,
+
+    NPC_MOIRA_THAURISSAN                 = 42129,
+    NPC_FALSTAD_WILDHAMMER               = 42131,
+    NPC_AMBASSADOR_SLAGHAMMER            = 42146,
+    NPC_AMBASSADOR_SLAGHAMMER_ESCORT     = 42153,
+    NPC_MURADIN_BRONZEBEARD              = 42928,
+    NPC_IRONFORGE_GUARD                  = 5595,
+
+    SPELL_ARREST_SLAGHAMMER              = 78628,
+    // Dummy aura with chain visual; 78628 has no apply-aura effect, and 125467 is Root in 8.3.7.
+    SPELL_COSMETIC_ENSLAVE_CHAINS        = 45631,
+
+    SPAWN_ID_GUARD_ESCORT                = 180741,
+    SPAWN_ID_GUARD_DOOR_OTHER            = 180742,
+
+    SAY_MOIRA_COUNCIL_0                  = 0,
+    SAY_MOIRA_COUNCIL_1                  = 1,
+    SAY_MOIRA_COUNCIL_2                  = 2,
+    SAY_MOIRA_COUNCIL_3                  = 3,
+    SAY_MOIRA_COUNCIL_4                  = 4,
+    SAY_MOIRA_FINALE                     = 5,
+
+    SAY_MURADIN_COUNCIL_0                = 0,
+    SAY_MURADIN_COUNCIL_1                = 1,
+    SAY_MURADIN_COUNCIL_2                = 2,
+
+    SAY_FALSTAD_COUNCIL                  = 0,
+
+    SAY_SLAGHAMMER_ARREST                = 0,
+    SAY_SLAGHAMMER_FINALE                = 1,
+
+    SAY_GUARD_DOOR_0                     = 0,
+    SAY_GUARD_DOOR_1                     = 1,
+    SAY_GUARD_ESCORT                     = 2,
+
+    ACTION_START_COUNCIL                 = 1,
+
+    POINT_HALT                           = 1
 };
 
-class npc_moira_thaurissan : public CreatureScript
+// Hall floor in front of the High Seat, not on the dais. Facing Moira on the throne.
+static Position const HighSeatHaltPos = { -4848.698730f, -1043.593628f, 502.189972f, 2.544585f };
+static Position const GuardEscortHomePos = { -4858.79f, -1056.22f, 502.19f, 1.15192f };
+
+// World 42146 must respawn so a second player can still arrest; dummy of 78628 hides the original.
+static Seconds const AmbassadorWorldRespawn = 60s;
+
+static Creature* GetCreatureBySpawnId(WorldObject* searcher, uint32 spawnId)
 {
-public:
-    npc_moira_thaurissan() : CreatureScript("npc_moira_thaurissan") { }
+    if (!searcher || !searcher->GetMap())
+        return nullptr;
 
-    enum Data
+    auto bounds = searcher->GetMap()->GetCreatureBySpawnIdStore().equal_range(spawnId);
+    for (auto itr = bounds.first; itr != bounds.second; ++itr)
+        if (Creature* creature = itr->second)
+            if (creature->IsAlive() && creature->IsInWorld())
+                return creature;
+
+    return nullptr;
+}
+
+static void TalkIfAI(Creature* creature, uint32 group)
+{
+    if (!creature || !creature->IsAIEnabled || !creature->IsInWorld())
+        return;
+
+    creature->AI()->Talk(group);
+}
+
+struct npc_moira_thaurissan : public ScriptedAI
+{
+    npc_moira_thaurissan(Creature* creature) : ScriptedAI(creature), _eventActive(false) { }
+
+    enum CouncilEvents
     {
-        NPC_MURADIN         = 42928,
-        NPC_WILDHAMMER      = 42131,
-        ACTION_START_EVENT  = 1,
+        EVENT_COUNCIL_MOIRA_0 = 1,
+        EVENT_COUNCIL_MURADIN_0,
+        EVENT_COUNCIL_MOIRA_1,
+        EVENT_COUNCIL_MURADIN_1,
+        EVENT_COUNCIL_MOIRA_2,
+        EVENT_COUNCIL_MURADIN_2,
+        EVENT_COUNCIL_FALSTAD,
+        EVENT_COUNCIL_MOIRA_3,
+        EVENT_COUNCIL_MOIRA_4,
+        EVENT_COUNCIL_DONE
     };
 
-    enum TalkData
+    void Reset() override
     {
-        TALK_0 = 0,
-        TALK_1 = 1,
-        TALK_2 = 2,
-        TALK_3 = 3,
-        TALK_4 = 4,
-    };
+        if (_eventActive)
+            return;
 
-    bool OnQuestAccept(Player* /*player*/, Creature* creature, Quest const* quest) override
-    {
-        switch (quest->GetQuestId())
-        {
-            case QUEST_SEIZE_AMBASSADOR:
-                creature->AI()->DoAction(ACTION_START_EVENT);
-                break;
-            default:
-                break;
-        }
-
-        return true;
+        events.Reset();
     }
 
-    struct npc_moira_thaurissanAI : public ScriptedAI
+    void sQuestReward(Player* /*player*/, Quest const* quest, uint32 /*opt*/) override
     {
-        npc_moira_thaurissanAI(Creature* creature) : ScriptedAI(creature) { }
+        if (quest->GetQuestId() == QUEST_DEMANDING_ANSWERS)
+            DoAction(ACTION_START_COUNCIL);
+    }
 
-        uint32 SummonTimer;
-        uint8 Phase;
+    void DoAction(int32 action) override
+    {
+        if (action != ACTION_START_COUNCIL || _eventActive)
+            return;
 
-        void Reset() override
+        _eventActive = true;
+        events.Reset();
+        events.ScheduleEvent(EVENT_COUNCIL_MOIRA_0, 500ms);
+    }
+
+    void UpdateAI(uint32 diff) override
+    {
+        if (!_eventActive)
+            return;
+
+        events.Update(diff);
+        while (uint32 eventId = events.ExecuteEvent())
         {
-            Phase = 0;
-            SummonTimer = 300;
-        }
-
-        void DoAction(int32 action) override
-        {
-            switch (action)
+            switch (eventId)
             {
-                case ACTION_START_EVENT:
-                    SummonTimer = 300;
+                case EVENT_COUNCIL_MOIRA_0:
+                    Talk(SAY_MOIRA_COUNCIL_0);
+                    events.ScheduleEvent(EVENT_COUNCIL_MURADIN_0, 5500ms);
+                    break;
+                case EVENT_COUNCIL_MURADIN_0:
+                    TalkIfAI(me->FindNearestCreature(NPC_MURADIN_BRONZEBEARD, 25.0f, true), SAY_MURADIN_COUNCIL_0);
+                    events.ScheduleEvent(EVENT_COUNCIL_MOIRA_1, 5500ms);
+                    break;
+                case EVENT_COUNCIL_MOIRA_1:
+                    Talk(SAY_MOIRA_COUNCIL_1);
+                    events.ScheduleEvent(EVENT_COUNCIL_MURADIN_1, 5500ms);
+                    break;
+                case EVENT_COUNCIL_MURADIN_1:
+                    TalkIfAI(me->FindNearestCreature(NPC_MURADIN_BRONZEBEARD, 25.0f, true), SAY_MURADIN_COUNCIL_1);
+                    events.ScheduleEvent(EVENT_COUNCIL_MOIRA_2, 5500ms);
+                    break;
+                case EVENT_COUNCIL_MOIRA_2:
+                    Talk(SAY_MOIRA_COUNCIL_2);
+                    events.ScheduleEvent(EVENT_COUNCIL_MURADIN_2, 5500ms);
+                    break;
+                case EVENT_COUNCIL_MURADIN_2:
+                    TalkIfAI(me->FindNearestCreature(NPC_MURADIN_BRONZEBEARD, 25.0f, true), SAY_MURADIN_COUNCIL_2);
+                    events.ScheduleEvent(EVENT_COUNCIL_FALSTAD, 5500ms);
+                    break;
+                case EVENT_COUNCIL_FALSTAD:
+                    TalkIfAI(me->FindNearestCreature(NPC_FALSTAD_WILDHAMMER, 25.0f, true), SAY_FALSTAD_COUNCIL);
+                    events.ScheduleEvent(EVENT_COUNCIL_MOIRA_3, 5500ms);
+                    break;
+                case EVENT_COUNCIL_MOIRA_3:
+                    Talk(SAY_MOIRA_COUNCIL_3);
+                    events.ScheduleEvent(EVENT_COUNCIL_MOIRA_4, 6000ms);
+                    break;
+                case EVENT_COUNCIL_MOIRA_4:
+                    Talk(SAY_MOIRA_COUNCIL_4);
+                    events.ScheduleEvent(EVENT_COUNCIL_DONE, 1s);
+                    break;
+                case EVENT_COUNCIL_DONE:
+                    _eventActive = false;
+                    events.Reset();
                     break;
                 default:
                     break;
             }
         }
+    }
 
-        void UpdateAI(uint32 diff) override
-        {
-            if (SummonTimer < diff)
-            {
-                switch (Phase)
-                {
-                    case 0:
-                    {
-                        Talk(TALK_0);
-                        SummonTimer = 1500;
-                        Phase++;
-                        break;
-                    }
-                    case 1:
-                    {
-                        if (Creature* agent = me->FindNearestCreature(NPC_MURADIN, 25.0f, true))
-                            agent->AI()->Talk(TALK_0);
+private:
+    EventMap events;
+    bool _eventActive;
+};
 
-                        SummonTimer = 2500;
-                        Phase++;
-                    }
-                    /* fallthrough */
-                    case 2:
-                    {
-                        Talk(TALK_1);
-                        SummonTimer = 3500;
-                        Phase++;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if (Creature* agent = me->FindNearestCreature(NPC_MURADIN, 25.0f, true))
-                            agent->AI()->Talk(TALK_1);
+struct npc_ambassador_slaghammer : public ScriptedAI
+{
+    npc_ambassador_slaghammer(Creature* creature) : ScriptedAI(creature),
+        _started(false), _doorDone(false), _finale(false), _halted(false), _credited(false) { }
 
-                        SummonTimer = 4500;
-                        Phase++;
-                    }
-                    /* fallthrough */
-                    case 4:
-                    {
-                        Talk(TALK_2);
-                        SummonTimer = 5500;
-                        Phase++;
-                        break;
-                    }
-                    case 5:
-                    {
-                        if (Creature* agent = me->FindNearestCreature(NPC_MURADIN, 25.0f, true))
-                            agent->AI()->Talk(TALK_2);
-
-                        SummonTimer = 6500;
-                        Phase++;
-                    }
-                    /* fallthrough */
-                    case 6:
-                    {
-                        Talk(TALK_3);
-                        SummonTimer = 7500;
-                        Phase++;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if (Creature* agent = me->FindNearestCreature(NPC_WILDHAMMER, 25.0f, true))
-                            agent->AI()->Talk(TALK_0);
-
-                        SummonTimer = 8500;
-                        Phase++;
-                    }
-                    /* fallthrough */
-                    case 8:
-                    {
-                        Talk(TALK_4);
-                        Phase++;
-                        break;
-                    }
-                    default:
-                        break;
-                }
-
-            }
-            else SummonTimer -= diff;
-        }
+    enum EscortEvents
+    {
+        EVENT_CHECK_OWNER = 1,
+        EVENT_CHECK_PROGRESS,
+        EVENT_HALT_TIMEOUT,
+        EVENT_SAY_MOIRA_FINALE,
+        EVENT_SAY_SLAGHAMMER_FINALE,
+        EVENT_GUARD_APPROACH,
+        EVENT_SAY_GUARD_ESCORT,
+        EVENT_CREDIT_QUEST,
+        EVENT_LEAVE,
+        EVENT_GUARD_HOME
     };
 
-    CreatureAI* GetAI(Creature* creature) const override
+    void Reset() override
     {
-        return new npc_moira_thaurissanAI(creature);
+        me->SetReactState(REACT_PASSIVE);
+        SetCombatMovement(false);
+
+        if (_started)
+            return;
+
+        if (Unit* owner = me->GetOwner())
+            if (Player* player = owner->ToPlayer())
+                StartEscort(player);
+    }
+
+    void EnterEvadeMode(EvadeReason /*why*/) override
+    {
+        me->CombatStop(true);
+        if (_finale || !_started)
+            return;
+
+        if (Player* player = GetEscortPlayer())
+            FollowPlayer(player);
+    }
+
+    void IsSummonedBy(Unit* summoner) override
+    {
+        Player* player = summoner ? summoner->ToPlayer() : nullptr;
+        if (!player)
+        {
+            me->DespawnOrUnsummon();
+            return;
+        }
+
+        StartEscort(player);
+    }
+
+    void MovementInform(uint32 type, uint32 id) override
+    {
+        if (type != POINT_MOTION_TYPE)
+            return;
+
+        if (id == POINT_HALT)
+            BeginSentencing();
+    }
+
+    void UpdateAI(uint32 diff) override
+    {
+        if (!_started)
+            return;
+
+        events.Update(diff);
+        while (uint32 eventId = events.ExecuteEvent())
+        {
+            switch (eventId)
+            {
+                case EVENT_CHECK_OWNER:
+                    if (!_finale && !GetEscortPlayer())
+                    {
+                        me->DespawnOrUnsummon();
+                        return;
+                    }
+                    events.ScheduleEvent(EVENT_CHECK_OWNER, 1s);
+                    break;
+                case EVENT_CHECK_PROGRESS:
+                    UpdateProgress();
+                    if (_started && me->IsInWorld())
+                        events.ScheduleEvent(EVENT_CHECK_PROGRESS, 1s);
+                    break;
+                case EVENT_HALT_TIMEOUT:
+                    BeginSentencing();
+                    break;
+                case EVENT_SAY_MOIRA_FINALE:
+                    TalkIfAI(me->FindNearestCreature(NPC_MOIRA_THAURISSAN, 40.0f, true), SAY_MOIRA_FINALE);
+                    events.ScheduleEvent(EVENT_SAY_SLAGHAMMER_FINALE, 7s);
+                    break;
+                case EVENT_SAY_SLAGHAMMER_FINALE:
+                    Talk(SAY_SLAGHAMMER_FINALE);
+                    events.ScheduleEvent(EVENT_GUARD_APPROACH, 1s);
+                    break;
+                case EVENT_GUARD_APPROACH:
+                    StartGuardApproach();
+                    events.ScheduleEvent(EVENT_SAY_GUARD_ESCORT, 8s);
+                    break;
+                case EVENT_SAY_GUARD_ESCORT:
+                    TalkIfAI(GetEscortGuard(), SAY_GUARD_ESCORT);
+                    events.ScheduleEvent(EVENT_CREDIT_QUEST, 2s);
+                    break;
+                case EVENT_CREDIT_QUEST:
+                    CreditEscortPlayer();
+                    events.ScheduleEvent(EVENT_LEAVE, 1s);
+                    break;
+                case EVENT_LEAVE:
+                    BeginGuardEscortAway();
+                    events.ScheduleEvent(EVENT_GUARD_HOME, 10s);
+                    break;
+                case EVENT_GUARD_HOME:
+                    RestoreEscortGuard();
+                    me->DespawnOrUnsummon();
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+private:
+    Player* GetEscortOwner() const
+    {
+        if (_playerGuid.IsEmpty())
+            return nullptr;
+
+        Player* player = ObjectAccessor::GetPlayer(*me, _playerGuid);
+        if (!player || !player->IsInWorld() || player->GetMap() != me->GetMap())
+            return nullptr;
+
+        return player;
+    }
+
+    Player* GetEscortPlayer() const
+    {
+        Player* player = GetEscortOwner();
+        if (!player)
+            return nullptr;
+
+        // After ForceCompleteQuest the status is no longer INCOMPLETE; the leave walk still needs the owner.
+        if (!_finale && player->GetQuestStatus(QUEST_SEIZE_AMBASSADOR) != QUEST_STATUS_INCOMPLETE)
+            return nullptr;
+
+        return player;
+    }
+
+    void FollowPlayer(Player* player)
+    {
+        if (!player)
+            return;
+
+        me->GetMotionMaster()->Clear();
+        me->SetWalk(true);
+        me->GetMotionMaster()->MoveFollow(player, PET_FOLLOW_DIST, PET_FOLLOW_ANGLE);
+    }
+
+    void StartEscort(Player* player)
+    {
+        if (_started || !player)
+            return;
+
+        _started = true;
+        _playerGuid = player->GetGUID();
+
+        me->setActive(true);
+        me->SetReactState(REACT_PASSIVE);
+        SetCombatMovement(false);
+        me->AddUnitFlag(UnitFlags(UNIT_FLAG_IMMUNE_TO_PC | UNIT_FLAG_IMMUNE_TO_NPC | UNIT_FLAG_NON_ATTACKABLE));
+
+        ApplyManacles();
+        Talk(SAY_SLAGHAMMER_ARREST);
+        FollowPlayer(player);
+
+        events.Reset();
+        events.ScheduleEvent(EVENT_CHECK_OWNER, 1s);
+        events.ScheduleEvent(EVENT_CHECK_PROGRESS, 1s);
+    }
+
+    void UpdateProgress()
+    {
+        if (_finale)
+            return;
+
+        if (!GetEscortPlayer())
+            return;
+
+        float const dist = me->GetExactDist(HighSeatHaltPos);
+        if (!_doorDone && dist < 28.0f)
+        {
+            _doorDone = true;
+            PlayDoorComments();
+        }
+
+        if (dist <= 8.0f)
+            StartFinale();
+    }
+
+    void PlayDoorComments()
+    {
+        TalkIfAI(GetCreatureBySpawnId(me, SPAWN_ID_GUARD_ESCORT), SAY_GUARD_DOOR_0);
+        TalkIfAI(GetCreatureBySpawnId(me, SPAWN_ID_GUARD_DOOR_OTHER), SAY_GUARD_DOOR_1);
+    }
+
+    void StartFinale()
+    {
+        if (_finale)
+            return;
+
+        _finale = true;
+        me->GetMotionMaster()->Clear();
+        me->SetWalk(true);
+        me->GetMotionMaster()->MovePoint(POINT_HALT, HighSeatHaltPos, true);
+        events.ScheduleEvent(EVENT_HALT_TIMEOUT, 12s);
+    }
+
+    void BeginSentencing()
+    {
+        if (_halted)
+            return;
+
+        _halted = true;
+        events.CancelEvent(EVENT_HALT_TIMEOUT);
+        me->GetMotionMaster()->MoveIdle();
+        me->SetFacingTo(HighSeatHaltPos.GetOrientation());
+        me->SetStandState(UNIT_STAND_STATE_KNEEL);
+        events.ScheduleEvent(EVENT_SAY_MOIRA_FINALE, 1s);
+    }
+
+    Creature* GetEscortGuard()
+    {
+        return GetCreatureBySpawnId(me, SPAWN_ID_GUARD_ESCORT);
+    }
+
+    void ApplyManacles()
+    {
+        if (me->HasAura(SPELL_COSMETIC_ENSLAVE_CHAINS))
+            return;
+
+        me->CastSpell(me, SPELL_COSMETIC_ENSLAVE_CHAINS, true);
+    }
+
+    void StartGuardApproach()
+    {
+        Creature* guard = GetEscortGuard();
+        if (!guard)
+            return;
+
+        _guardGuid = guard->GetGUID();
+        guard->setActive(true);
+        guard->SetWalk(true);
+        guard->SetReactState(REACT_PASSIVE);
+        guard->GetMotionMaster()->Clear();
+        guard->GetMotionMaster()->MovePoint(0, me->GetPositionX(), me->GetPositionY(), me->GetPositionZ(), true);
+    }
+
+    void BeginGuardEscortAway()
+    {
+        me->SetStandState(UNIT_STAND_STATE_STAND);
+        me->GetMotionMaster()->Clear();
+        me->SetWalk(true);
+
+        Creature* guard = _guardGuid.IsEmpty() ? GetEscortGuard() : ObjectAccessor::GetCreature(*me, _guardGuid);
+        if (!guard)
+        {
+            me->GetMotionMaster()->MovePoint(0, GuardEscortHomePos, true);
+            me->DespawnOrUnsummon(10s);
+            return;
+        }
+
+        guard->SetWalk(true);
+        guard->GetMotionMaster()->Clear();
+        guard->GetMotionMaster()->MovePoint(0, guard->GetHomePosition(), true);
+        me->GetMotionMaster()->MoveFollow(guard, PET_FOLLOW_DIST, PET_FOLLOW_ANGLE);
+    }
+
+    void RestoreEscortGuard()
+    {
+        Creature* guard = _guardGuid.IsEmpty() ? GetEscortGuard() : ObjectAccessor::GetCreature(*me, _guardGuid);
+        if (!guard)
+            return;
+
+        Position const& home = guard->GetHomePosition();
+        guard->SetReactState(REACT_AGGRESSIVE);
+        guard->GetMotionMaster()->Clear();
+        guard->StopMoving();
+        // MovePoint does not restore spawn facing; home orientation comes from creature.orientation.
+        if (guard->GetExactDist(home) > 2.0f)
+            guard->NearTeleportTo(home);
+        else
+            guard->SetFacingTo(home.GetOrientation(), true);
+        guard->setActive(false);
+    }
+
+    void CreditEscortPlayer()
+    {
+        if (_credited)
+            return;
+
+        _credited = true;
+
+        Player* player = GetEscortOwner();
+        Quest const* quest = sObjectMgr->GetQuestTemplate(QUEST_SEIZE_AMBASSADOR);
+        if (!player || !quest)
+            return;
+
+        // SpecialFlags exploration quests need Explored before CanCompleteQuest; the client
+        // also never saw SMSG_QUEST_UPDATE_COMPLETE from ForceCompleteQuest alone.
+        player->AreaExploredOrEventHappens(QUEST_SEIZE_AMBASSADOR);
+        if (player->GetQuestStatus(QUEST_SEIZE_AMBASSADOR) != QUEST_STATUS_COMPLETE)
+            player->ForceCompleteQuest(QUEST_SEIZE_AMBASSADOR);
+        player->SendQuestComplete(quest);
+    }
+
+    EventMap events;
+    ObjectGuid _playerGuid;
+    ObjectGuid _guardGuid;
+    bool _started;
+    bool _doorDone;
+    bool _finale;
+    bool _halted;
+    bool _credited;
+};
+
+class spell_ironforge_arrest_slaghammer : public SpellScript
+{
+    PrepareSpellScript(spell_ironforge_arrest_slaghammer);
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_ARREST_SLAGHAMMER, SPELL_COSMETIC_ENSLAVE_CHAINS });
+    }
+
+    SpellCastResult CheckCast()
+    {
+        Player* player = GetCaster() ? GetCaster()->ToPlayer() : nullptr;
+        if (!player)
+            return SPELL_FAILED_BAD_TARGETS;
+
+        if (player->GetQuestStatus(QUEST_SEIZE_AMBASSADOR) != QUEST_STATUS_INCOMPLETE)
+            return SPELL_FAILED_BAD_TARGETS;
+
+        for (Unit* controlled : player->m_Controlled)
+        {
+            if (controlled && controlled->GetEntry() == NPC_AMBASSADOR_SLAGHAMMER_ESCORT && controlled->IsAlive())
+            {
+                SetCustomCastResultMessage(SPELL_CUSTOM_ERROR_SLAGHAMMER_ALREADY_PRISONER);
+                return SPELL_FAILED_CUSTOM_ERROR;
+            }
+        }
+
+        Unit* target = GetExplTargetUnit();
+        if (!target || target->GetEntry() != NPC_AMBASSADOR_SLAGHAMMER || !target->IsAlive())
+            return SPELL_FAILED_BAD_TARGETS;
+
+        return SPELL_CAST_OK;
+    }
+
+    void HandleDummy(SpellEffIndex /*effIndex*/)
+    {
+        Player* player = GetCaster() ? GetCaster()->ToPlayer() : nullptr;
+        Unit* hit = GetHitUnit();
+        Creature* orig = (hit && hit->GetEntry() == NPC_AMBASSADOR_SLAGHAMMER) ? hit->ToCreature() : nullptr;
+
+        Creature* escort = nullptr;
+        if (player)
+        {
+            for (Unit* controlled : player->m_Controlled)
+            {
+                if (controlled && controlled->GetEntry() == NPC_AMBASSADOR_SLAGHAMMER_ESCORT && controlled->IsAlive())
+                {
+                    escort = controlled->ToCreature();
+                    break;
+                }
+            }
+        }
+
+        if (escort)
+            escort->CastSpell(escort, SPELL_COSMETIC_ENSLAVE_CHAINS, true);
+
+        if (orig)
+            orig->DespawnOrUnsummon(1s, AmbassadorWorldRespawn);
+    }
+
+    void Register() override
+    {
+        OnCheckCast += SpellCheckCastFn(spell_ironforge_arrest_slaghammer::CheckCast);
+        OnEffectHitTarget += SpellEffectFn(spell_ironforge_arrest_slaghammer::HandleDummy, EFFECT_1, SPELL_EFFECT_DUMMY);
     }
 };
 
@@ -232,6 +655,8 @@ public:
 
 void AddSC_ironforge()
 {
-    new npc_moira_thaurissan();
+    RegisterCreatureAI(npc_moira_thaurissan);
+    RegisterCreatureAI(npc_ambassador_slaghammer);
+    RegisterSpellScript(spell_ironforge_arrest_slaghammer);
     new npc_mountaineer_watch();
 }


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

The Ironforge/High Seat airfield quest chain and the Dun Morogh chicken cooking daily have been fixed.

### Seize the Ambassador (26118)

Turning in Demanding Answers to [Moire Thaurissan](https://www.wowhead.com/npc=42129) triggers the Council of Three Hammers scene ([Muradin Bronzebeard](https://www.wowhead.com/npc=42928), [Falstad Wildhammer](https://www.wowhead.com/npc=42131)). Taking 26118 no longer triggers this scene repeatedly.

Using [Imperious Shackles](https://www.wowhead.com/item=56837) casts [Arrest](https://www.wowhead.com/spell=78628) on the world [Ambassador Slaghammer](https://www.wowhead.com/npc=42146). Dummy despawns the world NPC (60-second respawn), summons an escort for [Ambassador Slaghammer](https://www.wowhead.com/npc=42153), and applies [Enslave Chains](https://www.wowhead.com/spell=45631) as a visual for the manacles (`78628` in 8.3.7 without apply-aura; `125467` on this build is Root Self).

The escort follows the player to the High Seat. The [Ironforge guards](https://www.wowhead.com/npc=5595) at the door comment. Moira delivers her sentence, the guard takes him away, and the quest is closed by a script (`SpecialFlags = 2`). After the escort, the guard's home coordinates and facing are restored.

### A Fowl Shortage (29352)

Clicking on the [Dun Morogh Chicken](https://www.wowhead.com/npc=53568) did nothing: spellclick cast a dummy [Pickup Chicken](https://www.wowhead.com/spell=99486) player-to-player, and the SAI waited for `SPELLHIT_TARGET` from the [Pickup Chicken](https://www.wowhead.com/spell=99487), which wasn't cast.

Sen'jin Frog pattern repeated:
- `99486` dummy, player → chicken (`cast_flags = 1`)
- `99487` CREATE_ITEM [Dun Morogh Chicken](https://www.wowhead.com/item=69982), player → player (`cast_flags = 3`)
- SAI despawns the chicken on spellhit `99486`
- Spellclick only until 29352 is taken and not turned in

### Other DB

- 25937 Priceless Treasures: POI for [Frozen Artifact](https://www.wowhead.com/item=56225) / [Excavator Pickaxes](https://www.wowhead.com/item=56226), turn-in locales
- 26078 / 26085 / 26094: turn-in text and locales enUS/ruRU
- 26102 Grimaxe's Demise: POI for [General Grimaxe](https://www.wowhead.com/npc=42010), turn-in text + locales
- 26112 Demanding Answers: POI target is now [Stonebreaker's Report](https://www.wowhead.com/item=56823)
- 1578 Supplying the Front: requires Blacksmithing 35

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Cursor (Grok 4.6) assisted with implementation and SQL. Every line was reviewed against 8.3.7 spell data, in-game checks, and the Sen'jin Frog spellclick analog. The author checked the code architecture.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (Wowhead)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Linux (clang RelWithDebInfo). No unit-test framework in this repo.
Video on testing the event for quest 26118[Seize the Ambassador](https://youtu.be/QbbTy9ggeXA)

In-game:
- 26118: council on 26112 turn-in only; arrest on [Ambassador Slaghammer](https://www.wowhead.com/npc=42146); escort to High Seat; door-guard comments; halt; sentence; credit.
- 29352: click [Dun Morogh Chicken](https://www.wowhead.com/npc=53568) grants [Dun Morogh Chicken](https://www.wowhead.com/item=69982) and despawns the NPC.

Not walked end-to-end this session: airfield locales/POI (25937, 26078, 26085, 26094, 26102) and 1578 skill gate.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

### 26118 Seize the Ambassador

1. Alliance character, Ironforge High Seat. `.quest add 26112` (or play 25998 → 26078 → 26085 → 26094 → 26102 → 26112).
2. Turn in Demanding Answers to [Moira Thaurissan](https://www.wowhead.com/npc=42129). Council dialogue with [Muradin Bronzebeard](https://www.wowhead.com/npc=42928) and [Falstad Wildhammer](https://www.wowhead.com/npc=42131) should play once.
3. Accept 26118. Council must **not** replay. Confirm [Sturdy Manacles](https://www.wowhead.com/item=56837) in bags.
4. Go to the Dark Iron Embassy. Use the manacles on world [Ambassador Slaghammer](https://www.wowhead.com/npc=42146). World NPC despawns; escort [Ambassador Slaghammer](https://www.wowhead.com/npc=42153) appears with [Enslave Chains](https://www.wowhead.com/spell=45631) and follows.
5. Using [Arrest](https://www.wowhead.com/spell=78628) again while an escort exists should fail (already a prisoner).
6. Walk to the High Seat. Door [Ironforge Guard](https://www.wowhead.com/npc=5595) comments; escort stops on the hall floor; Moira sentences; a guard leads him off; quest completes.
7. Confirm the walking guard returns to home position and facing. After 60s the world ambassador should respawn for another player.

### 29352 A Fowl Shortage

1. Cooking skill at least 1. `.quest add 29352` (daily).
2. At the Ironforge gates, click [Dun Morogh Chicken](https://www.wowhead.com/npc=53568).
3. Inventory gains one [Dun Morogh Chicken](https://www.wowhead.com/item=69982); the NPC despawns.
4. Repeat to 6/6 and turn in. Without the quest, Pickup cursor should not appear.

### Locales / POI / 1578

1. 25937: map pins for [Frozen Artifact](https://www.wowhead.com/item=56225) / [Excavator's Pick](https://www.wowhead.com/item=56226); turn-in text enUS/ruRU.
2. 26078, 26085, 26094, 26102: turn-in text. 26102 pin on [General Grimaxe](https://www.wowhead.com/npc=42010).
3. 26112: POI for [Stonebreaker's Report](https://www.wowhead.com/item=56823).
4. 1578: quest should not be offered below Blacksmithing 35.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Airfield locales/POI and 1578 skill gate were not re-tested in-game after the SQL split.
- [ ] Multi-player overlap on 26118 (two players arresting at once) still needs a dedicated check.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test BFA-HavenCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub.

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
