### PR TITLE
db/quest: add missing quest POI for 25167 Breaking the Chain

### DIFF
--- a/sql/updates/world/2026_08_29_00_world_quest_25167_breaking_the_chain_poi.sql
+++ b/sql/updates/world/2026_08_29_00_world_quest_25167_breaking_the_chain_poi.sql
@@ -1,0 +1,31 @@
+-- Quest 25167 - Breaking the Chain
+-- Retail POI data absent from the 8.3.7 dump; every other Sen'jin questline
+-- entry (25151-25185) carries quest_poi rows, so the tracker arrow and map
+-- blob are missing only for this quest.
+
+DELETE FROM `quest_poi_points` WHERE `QuestID` = 25167;
+DELETE FROM `quest_poi` WHERE `QuestID` = 25167;
+
+INSERT INTO `quest_poi`
+    (`QuestID`, `BlobIndex`, `Idx1`, `ObjectiveIndex`, `QuestObjectiveID`, `QuestObjectID`,
+     `MapID`, `UiMapID`, `Priority`, `Flags`, `WorldEffectID`, `PlayerConditionID`,
+     `SpawnTrackingID`, `AlwaysAllowMergingBlobs`, `VerifiedBuild`)
+VALUES
+    (25167, 0, 0, -1, 0,      0, 1, 1, 0, 0, 0, 0, 0, 0, 35662),  -- overall / quest giver
+    (25167, 0, 1,  0, 266185, 0, 1, 1, 0, 0, 0, 0, 0, 0, 35662),  -- Northwatch Supply Crate
+    (25167, 0, 2,  1, 266186, 0, 1, 1, 0, 0, 0, 0, 0, 0, 35662),  -- Northwatch Lug
+    (25167, 0, 3, 32, 0,      0, 1, 1, 0, 0, 0, 0, 0, 0, 35662);  -- turn in
+
+INSERT INTO `quest_poi_points`
+    (`QuestID`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`)
+VALUES
+    (25167, 0, 0,  -826, -4921, 35662),
+    (25167, 1, 0, -1085, -4745, 35662),
+    (25167, 1, 1, -1085, -4405, 35662),
+    (25167, 1, 2,  -965, -4405, 35662),
+    (25167, 1, 3,  -965, -4745, 35662),
+    (25167, 2, 0, -1085, -4745, 35662),
+    (25167, 2, 1, -1085, -4405, 35662),
+    (25167, 2, 2,  -965, -4405, 35662),
+    (25167, 2, 3,  -965, -4745, 35662),
+    (25167, 3, 0,  -826, -4921, 35662);


### PR DESCRIPTION
Quest 25167 had no quest_poi/quest_poi_points rows, so the Durotar map blob and objective tracker arrow never appeared. Every other Sen'jin questline entry (25151-25185) carries POI data; this one was the gap.

Adds a per-objective blob over the Northwatch encampment (crates 39251, lugs 39245) plus the quest-giver/turn-in marker at Master Gadrin, modeled on sibling quest 25169. Verified in-game: map blob and tracker POI now display.

<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [ ] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test BFA-HavenCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub.

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
