### PR TITLE
DB: fix Tender right-click attack behavior

### DIFF
--- a/sql/updates/world/2026_08_30_00_world_npc_15271_15294_right_click.sql
+++ b/sql/updates/world/2026_08_30_00_world_npc_15271_15294_right_click.sql
@@ -1,0 +1,3 @@
+UPDATE `creature_template`
+SET `npcflag` = 0
+WHERE `entry` IN (15271, 15294);

--- a/sql/updates/world/2026_08_30_00_world_npc_15271_15294_right_click.sql
+++ b/sql/updates/world/2026_08_30_00_world_npc_15271_15294_right_click.sql
@@ -1,3 +1,3 @@
 UPDATE `creature_template`
 SET `npcflag` = 0
-WHERE `entry` IN (15271, 15294);
+WHERE `entry` IN (15271, 15273, 15294, 15298);


### PR DESCRIPTION
## Description

Fixes incorrect right-click behavior for the following NPCs:

- 15271 — Tender
- 15273 — Arcane Wraith
- 15294 — Feral Tender
- 15298 — Tainted Arcane Wraith

All four creatures had `npcflag = 2`, which incorrectly marked them as quest givers. As a result, right-clicking them attempted NPC interaction instead of initiating an attack.

This applies the same fix used for Felstalker in #346 by clearing their `npcflag`.

## Changes

- Set `creature_template.npcflag` to `0` for entries 15271, 15273, 15294, and 15298.

## Verification

- Confirmed all four creature templates had `npcflag = 2` in the source database.
- Confirmed the update targets only entries 15271, 15273, 15294, and 15298.
- Verified SQL and Git diff integrity.