### PR TITLE
CPP/SQL: Ragefire Chasm Dungeon Fix

### DIFF
--- a/sql/updates/world/2026_09_01_RFC_Complete_Normal_Mode_Fix.sql
+++ b/sql/updates/world/2026_09_01_RFC_Complete_Normal_Mode_Fix.sql
@@ -1,0 +1,655 @@
+-- ============================================================
+-- Ragefire Chasm - Complete Normal-Mode Fix
+-- BFA-HavenCore 8.3.7 / Build 35662
+--
+-- Consolidates the validated RFC SQL fixes for:
+--   * Adarogg
+--   * Dark Shaman Koranthal
+--   * Slagmaw
+--   * Lava Guard Gordoth
+--   * No Man Left Behind / No Orc Left Behind
+--   * Deprecated Animal Control quests
+--   * Gordoth laboratory intro
+--
+-- Faction-specific NPC filtering is handled in
+-- instance_ragefire_chasm.cpp.
+-- ============================================================
+
+-- ============================================================
+-- Ragefire Chasm - Adarogg (61408)
+-- Full SQL fix for BFA-HavenCore
+--
+-- Fixes:
+--   * Switches Adarogg from incomplete SmartAI to C++ boss script
+--   * Removes conflicting SmartAI behavior
+--   * Corrects boss gold
+--   * Replaces generic/trash loot with proper boss loot
+--
+-- C++ boss mechanics are handled in boss_adarogg.cpp:
+--   * Melee combat
+--   * Inferno Charge
+--   * Visible physical charge movement
+--   * Flame Breath
+--   * Retail-like recurring ability rotation
+-- ============================================================
+
+
+-- ------------------------------------------------------------
+-- 1. Attach Adarogg C++ boss script
+--
+-- Previously:
+--   AIName = 'SmartAI'
+--   ScriptName = ''
+--
+-- SmartAI only cast Inferno Charge once on aggro and
+-- then repeated Flame Breath.
+-- ------------------------------------------------------------
+
+UPDATE `creature_template`
+SET
+    `AIName` = '',
+    `ScriptName` = 'boss_adarogg'
+WHERE `entry` = 61408;
+
+
+-- ------------------------------------------------------------
+-- 2. Remove obsolete/incomplete SmartAI
+-- ------------------------------------------------------------
+
+DELETE FROM `smart_scripts`
+WHERE `entryorguid` = 61408
+  AND `source_type` = 0;
+
+
+-- ------------------------------------------------------------
+-- 3. Correct Adarogg boss gold
+--
+-- Previous behavior was approximately 6-7 silver.
+--
+-- Retail/reference boss range:
+--   65000-75000 copper = 6g 50s - 7g 50s
+-- ------------------------------------------------------------
+
+UPDATE `creature_template`
+SET
+    `lootid` = 61408,
+    `mingold` = 65000,
+    `maxgold` = 75000
+WHERE `entry` = 61408;
+
+
+-- ------------------------------------------------------------
+-- 4. Replace generic/trash loot with Adarogg boss loot
+--
+-- GroupId 1 + Chance 0 selects one item from the boss group.
+-- ------------------------------------------------------------
+
+DELETE FROM `creature_loot_template`
+WHERE `Entry` = 61408;
+
+INSERT INTO `creature_loot_template`
+(
+    `Entry`,
+    `Item`,
+    `Reference`,
+    `Chance`,
+    `QuestRequired`,
+    `LootMode`,
+    `GroupId`,
+    `MinCount`,
+    `MaxCount`,
+    `Comment`
+)
+VALUES
+(
+    61408,
+    82879,
+    0,
+    0,
+    0,
+    1,
+    1,
+    1,
+    1,
+    'Adarogg - Collarspike Bracers'
+),
+(
+    61408,
+    82772,
+    0,
+    0,
+    0,
+    1,
+    1,
+    1,
+    1,
+    'Adarogg - Snarlmouth Leggings'
+),
+(
+    61408,
+    82880,
+    0,
+    0,
+    0,
+    1,
+    1,
+    1,
+    1,
+    'Adarogg - Fang of Adarogg'
+),
+(
+    61408,
+    151421,
+    0,
+    0,
+    0,
+    1,
+    1,
+    1,
+    1,
+    'Adarogg - Scorched Blazehound Boots'
+),
+(
+    61408,
+    151422,
+    0,
+    0,
+    0,
+    1,
+    1,
+    1,
+    1,
+    'Adarogg - Bonecoal Waistguard'
+);
+
+-- ============================================================
+-- Ragefire Chasm - Dark Shaman Koranthal (61412)
+-- Full SQL fix for BFA-HavenCore
+--
+-- Fixes:
+--   * Switches boss from broken SmartAI to C++ boss script
+--   * Removes conflicting SmartAI spell loop
+--   * Binds Shadow Storm helper spell script
+--   * Restores retail-like boss dialogue
+--   * Corrects boss gold reward
+--   * Replaces generic trash loot with proper boss loot
+--
+-- C++ boss mechanics are handled in boss_koranthal.cpp:
+--   * Melee combat
+--   * Twisted Elements rotation
+--   * Shadow Storm phase
+--   * Shadow Storm targeting
+--   * Return to normal rotation after storm
+-- ============================================================
+
+
+-- ------------------------------------------------------------
+-- 1. Attach Koranthal C++ boss script
+--
+-- Previously:
+--   AIName = 'SmartAI'
+--   ScriptName = ''
+--
+-- SmartAI was causing the permanent Shadow Storm loop.
+-- ------------------------------------------------------------
+
+UPDATE `creature_template`
+SET
+    `AIName` = '',
+    `ScriptName` = 'boss_koranthal'
+WHERE `entry` = 61412;
+
+
+-- ------------------------------------------------------------
+-- 2. Remove obsolete/broken SmartAI for Koranthal
+-- ------------------------------------------------------------
+
+DELETE FROM `smart_scripts`
+WHERE `entryorguid` = 61412
+  AND `source_type` = 0;
+
+
+-- ------------------------------------------------------------
+-- 3. Bind Shadow Storm helper SpellScript
+--
+-- Required for proper Shadow Storm target handling.
+-- ------------------------------------------------------------
+
+DELETE FROM `spell_script_names`
+WHERE `spell_id` = 119973;
+
+INSERT INTO `spell_script_names`
+(
+    `spell_id`,
+    `ScriptName`
+)
+VALUES
+(
+    119973,
+    'spell_koranthal_shadow_storm'
+);
+
+
+-- ------------------------------------------------------------
+-- 4. Retail-like Koranthal dialogue
+--
+-- Group 0 = Aggro
+-- Group 1 = Shadow Storm warning
+-- Group 2 = Death
+-- ------------------------------------------------------------
+
+DELETE FROM `creature_text`
+WHERE `CreatureID` = 61412;
+
+INSERT INTO `creature_text`
+(
+    `CreatureID`,
+    `GroupID`,
+    `ID`,
+    `Text`,
+    `Type`,
+    `Language`,
+    `Probability`,
+    `Emote`,
+    `Duration`,
+    `Sound`,
+    `BroadcastTextId`,
+    `TextRange`
+)
+VALUES
+(
+    61412,
+    0,
+    0,
+    'The power of the Dark Shaman will overwhelm you!',
+    14,
+    0,
+    100,
+    0,
+    0,
+    0,
+    61305,
+    0
+),
+(
+    61412,
+    1,
+    0,
+    '|TInterface\\Icons\\spell_shadow_shadowfury:20|tDark Shaman Koranthal summons a |r|cFF9E09DE|Hspell:119971|h[Shadow Storm]|h|r!',
+    41,
+    0,
+    100,
+    0,
+    0,
+    0,
+    61139,
+    0
+),
+(
+    61412,
+    2,
+    0,
+    'My death... means... nothing...',
+    14,
+    0,
+    100,
+    0,
+    0,
+    0,
+    61306,
+    0
+);
+
+
+-- ------------------------------------------------------------
+-- 5. Correct Koranthal boss gold
+--
+-- Previous HavenCore behavior was approximately 6 silver.
+--
+-- Retail/reference boss range:
+--   65000-75000 copper = 6g 50s - 7g 50s
+-- ------------------------------------------------------------
+
+UPDATE `creature_template`
+SET
+    `lootid` = 61412,
+    `mingold` = 65000,
+    `maxgold` = 75000
+WHERE `entry` = 61412;
+
+
+-- ------------------------------------------------------------
+-- 6. Replace generic trash loot with Koranthal boss loot
+--
+-- GroupId 1 + Chance 0 selects one item from the boss group.
+-- ------------------------------------------------------------
+
+DELETE FROM `creature_loot_template`
+WHERE `Entry` = 61412;
+
+INSERT INTO `creature_loot_template`
+(
+    `Entry`,
+    `Item`,
+    `Reference`,
+    `Chance`,
+    `QuestRequired`,
+    `LootMode`,
+    `GroupId`,
+    `MinCount`,
+    `MaxCount`,
+    `Comment`
+)
+VALUES
+(
+    61412,
+    82882,
+    0,
+    0,
+    0,
+    1,
+    1,
+    1,
+    1,
+    'Dark Shaman Koranthal - Dark Ritual Cape'
+),
+(
+    61412,
+    82877,
+    0,
+    0,
+    0,
+    1,
+    1,
+    1,
+    1,
+    'Dark Shaman Koranthal - Grasp of the Broken Totem'
+),
+(
+    61412,
+    82881,
+    0,
+    0,
+    0,
+    1,
+    1,
+    1,
+    1,
+    'Dark Shaman Koranthal - Cuffs of Black Elements'
+),
+(
+    61412,
+    132551,
+    0,
+    0,
+    0,
+    1,
+    1,
+    1,
+    1,
+    'Dark Shaman Koranthal - Dark Shaman''s Jerkin'
+);
+
+-- ============================================================
+-- Ragefire Chasm - Slagmaw (61463)
+-- Full SQL fix for BFA-HavenCore
+--
+-- Fixes:
+--   * Attaches the Slagmaw C++ boss script
+--   * Removes obsolete Magnaw's Head helper spawn
+--   * Expands Slagmaw melee reach / hitbox
+--   * Corrects boss gold reward
+--   * Replaces generic trash loot with proper boss loot
+--
+-- C++ boss mechanics are handled in boss_slagmaw.cpp:
+--   * 5x Lava Spit
+--   * Submerge
+--   * Random emerge location
+--   * No movement/chasing onto land
+--   * Boundary reset
+--   * Encounter integration
+-- ============================================================
+
+
+-- ------------------------------------------------------------
+-- 1. Attach Slagmaw boss script
+-- ------------------------------------------------------------
+
+UPDATE `creature_template`
+SET `ScriptName` = 'boss_slagmaw'
+WHERE `entry` = 61463;
+
+
+-- ------------------------------------------------------------
+-- 2. Remove obsolete Magnaw's Head helper
+--
+-- This was an old/incomplete implementation artifact.
+-- Modern Slagmaw logic is handled entirely by creature 61463.
+-- ------------------------------------------------------------
+
+DELETE FROM `creature`
+WHERE `guid` = 10615949
+  AND `id` = 61800
+  AND `map` = 389;
+
+
+-- Ensure no unused script remains attached to Magnaw's Head
+UPDATE `creature_template`
+SET `ScriptName` = ''
+WHERE `entry` = 61800;
+
+
+-- ------------------------------------------------------------
+-- 3. Correct Slagmaw melee accessibility
+--
+-- Original values were:
+--   BoundingRadius = 0
+--   CombatReach    = 0
+--
+-- 10.0 allows melee players to attack safely from the
+-- surrounding platform without entering the lava.
+-- ------------------------------------------------------------
+
+UPDATE `creature_model_info`
+SET
+    `BoundingRadius` = 3.5,
+    `CombatReach` = 10.0
+WHERE `DisplayID` = 42247;
+
+
+-- ------------------------------------------------------------
+-- 4. Correct Slagmaw boss gold
+--
+-- Previous HavenCore values:
+--   600-700 copper = 6-7 silver
+--
+-- Correct boss range:
+--   65000-75000 copper = 6g 50s - 7g 50s
+-- ------------------------------------------------------------
+
+UPDATE `creature_template`
+SET
+    `lootid` = 61463,
+    `mingold` = 65000,
+    `maxgold` = 75000
+WHERE `entry` = 61463;
+
+
+-- ------------------------------------------------------------
+-- 5. Replace incorrect generic loot table with Slagmaw boss loot
+--
+-- GroupId 1 + Chance 0 causes the group to select one item.
+-- ------------------------------------------------------------
+
+DELETE FROM `creature_loot_template`
+WHERE `Entry` = 61463;
+
+INSERT INTO `creature_loot_template`
+(
+    `Entry`,
+    `Item`,
+    `Reference`,
+    `Chance`,
+    `QuestRequired`,
+    `LootMode`,
+    `GroupId`,
+    `MinCount`,
+    `MaxCount`,
+    `Comment`
+)
+VALUES
+    (61463, 82885,  0, 0, 0, 1, 1, 1, 1, 'Slagmaw - Flameseared Carapace'),
+    (61463, 82884,  0, 0, 0, 1, 1, 1, 1, 'Slagmaw - Chitonous Bracers'),
+    (61463, 82878,  0, 0, 0, 1, 1, 1, 1, 'Slagmaw - Fireworm Robes'),
+    (61463, 132552, 0, 0, 0, 1, 1, 1, 1, 'Slagmaw - Chitonous Bindings');
+
+-- ============================================================
+-- Ragefire Chasm - quests, faction filtering support, rescue
+-- behavior bindings, Gordoth intro/combat, and Gordoth loot
+-- BFA-HavenCore 8.3.7
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- Deprecated quests: Animal Control
+-- Remove both faction versions from quest givers.
+-- ------------------------------------------------------------
+
+DELETE FROM `creature_queststarter`
+WHERE `quest` IN (30982, 30997);
+
+DELETE FROM `creature_questender`
+WHERE `quest` IN (30982, 30997);
+
+
+-- ------------------------------------------------------------
+-- No Man Left Behind / No Orc Left Behind
+-- Bind hidden rescue props to the C++ rescue script.
+-- ------------------------------------------------------------
+
+UPDATE `creature_template`
+SET
+    `AIName` = '',
+    `ScriptName` = 'npc_rfc_hidden_prisoner'
+WHERE `entry` IN (61780, 61790);
+
+
+-- Bind the three final prisoner cages.
+UPDATE `gameobject_template`
+SET `ScriptName` = 'go_rfc_prisoner_cage'
+WHERE `entry` IN (211883, 211884, 211885);
+
+
+-- Ensure the rescue props remain gossip-enabled.
+UPDATE `creature_template`
+SET
+    `gossip_menu_id` = CASE
+        WHEN `entry` = 61780 THEN 13814
+        WHEN `entry` = 61790 THEN 13815
+        ELSE `gossip_menu_id`
+    END,
+    `npcflag` = 1
+WHERE `entry` IN (61780, 61790);
+
+
+-- Retail/reference rescue lines.
+-- BroadcastText IDs preserve client localization.
+DELETE FROM `creature_text`
+WHERE `CreatureID` IN (61788, 61680);
+
+INSERT INTO `creature_text`
+(
+    `CreatureID`,
+    `GroupID`,
+    `ID`,
+    `Text`,
+    `Type`,
+    `Language`,
+    `Probability`,
+    `Emote`,
+    `Duration`,
+    `Sound`,
+    `BroadcastTextId`,
+    `TextRange`
+)
+VALUES
+    (61788, 0, 0, 'RUN!!',                                      12, 0, 20, 0, 0, 0, 61290, 0),
+    (61788, 0, 1, 'Thanks!',                                    12, 0, 20, 0, 0, 0, 61286, 0),
+    (61788, 0, 2, 'I didn''t think anyone was coming for us.',  12, 0, 20, 0, 0, 0, 61287, 0),
+    (61788, 0, 3, 'I owe you an ale!',                          12, 0, 20, 0, 0, 0, 61288, 0),
+    (61788, 0, 4, 'I thought I was going to die down here!',    12, 0, 20, 0, 0, 0, 61285, 0),
+
+    (61680, 0, 0, 'RUN!!',                                      12, 0, 20, 0, 0, 0, 61290, 0),
+    (61680, 0, 1, 'Thanks!',                                    12, 0, 20, 0, 0, 0, 61286, 0),
+    (61680, 0, 2, 'I didn''t think anyone was coming for us.',  12, 0, 20, 0, 0, 0, 61287, 0),
+    (61680, 0, 3, 'I owe you an ale!',                          12, 0, 20, 0, 0, 0, 61288, 0),
+    (61680, 0, 4, 'I thought I was going to die down here!',    12, 0, 20, 0, 0, 0, 61285, 0);
+
+
+-- ------------------------------------------------------------
+-- Lava Guard Gordoth (61528)
+-- Use the C++ script for both the retail-like breakout intro
+-- and the validated combat rotation.
+-- ------------------------------------------------------------
+
+UPDATE `creature_template`
+SET
+    `AIName` = '',
+    `ScriptName` = 'boss_gordoth',
+    `lootid` = 61528,
+    `mingold` = 160000,
+    `maxgold` = 170000
+WHERE `entry` = 61528;
+
+
+-- Remove the obsolete SmartAI combat implementation.
+DELETE FROM `smart_scripts`
+WHERE `entryorguid` = 61528
+  AND `source_type` = 0;
+
+
+-- Bind Gordoth's laboratory intro trigger.
+DELETE FROM `areatrigger_scripts`
+WHERE `entry` = 7899;
+
+INSERT INTO `areatrigger_scripts`
+(
+    `entry`,
+    `ScriptName`
+)
+VALUES
+(
+    7899,
+    'at_rfc_gordoth_intro'
+);
+
+
+-- ------------------------------------------------------------
+-- Gordoth boss loot
+-- ------------------------------------------------------------
+
+DELETE FROM `creature_loot_template`
+WHERE `Entry` = 61528;
+
+INSERT INTO `creature_loot_template`
+(
+    `Entry`,
+    `Item`,
+    `Reference`,
+    `Chance`,
+    `QuestRequired`,
+    `LootMode`,
+    `GroupId`,
+    `MinCount`,
+    `MaxCount`,
+    `Comment`
+)
+VALUES
+    (61528, 82888,  0, 0, 0, 1, 1, 1, 1, 'Lava Guard Gordoth - Heartboiler Staff'),
+    (61528, 82886,  0, 0, 0, 1, 1, 1, 1, 'Lava Guard Gordoth - Gorewalker Treads'),
+    (61528, 82883,  0, 0, 0, 1, 1, 1, 1, 'Lava Guard Gordoth - Bloodcursed Felblade'),
+    (61528, 151424, 0, 0, 0, 1, 1, 1, 1, 'Lava Guard Gordoth - Belt of Boundless Fury'),
+    (61528, 151425, 0, 0, 0, 1, 1, 1, 1, 'Lava Guard Gordoth - Gordoth''s Crushers');
+
+-- NOTE:
+-- Faction-specific NPC visibility is handled in
+-- instance_ragefire_chasm.cpp so the same DB supports both factions.

--- a/src/server/scripts/Kalimdor/RagefireChasm/boss_adarogg.cpp
+++ b/src/server/scripts/Kalimdor/RagefireChasm/boss_adarogg.cpp
@@ -17,7 +17,7 @@ enum Spells
 
 enum Events
 {
-    EVENT_FLAME_BREATH,
+    EVENT_FLAME_BREATH = 1,
     EVENT_INFERNO
 };
 
@@ -34,8 +34,8 @@ class boss_adarogg : public CreatureScript
 
             void EnterCombat(Unit* /*who*/)
             {
-                events.ScheduleEvent(EVENT_FLAME_BREATH, 5000);
-                events.ScheduleEvent(EVENT_INFERNO, 15000);
+                events.ScheduleEvent(EVENT_INFERNO, 10000);
+                events.ScheduleEvent(EVENT_FLAME_BREATH, 20000);
             }
 
             void SpellHitTarget(Unit* target, SpellInfo const* spell) override
@@ -62,11 +62,30 @@ class boss_adarogg : public CreatureScript
                     {
                         case EVENT_FLAME_BREATH:
                             DoCastVictim(SPELL_FLAME_BREATH);
-                            events.ScheduleEvent(EVENT_FLAME_BREATH, 10*IN_MILLISECONDS);
+                            events.ScheduleEvent(EVENT_FLAME_BREATH, urand(15000, 20000));
                             break;
                         case EVENT_INFERNO:
-                            DoCastRandom(SPELL_INFERNO_CHARGE, 100);
-                            events.ScheduleEvent(EVENT_INFERNO, 18*IN_MILLISECONDS);
+                            if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 100.0f, true))
+                            {
+                                me->SetFacingToObject(target);
+
+                                // HavenCore lacks the modern TrinityCore
+                                // serverside Inferno Charge helper spells.
+                                // Move Adarogg physically to the selected
+                                // player's location so the charge is visible,
+                                // then use the existing spell for the impact.
+                                me->GetMotionMaster()->MoveCharge(
+                                    target->GetPositionX(),
+                                    target->GetPositionY(),
+                                    target->GetPositionZ(),
+                                    35.0f,
+                                    1,
+                                    true);
+
+                                DoCast(target, SPELL_INFERNO_CHARGE, true);
+                            }
+
+                            events.ScheduleEvent(EVENT_INFERNO, urand(15000, 20000));
                             break;
                         default:
                             break;

--- a/src/server/scripts/Kalimdor/RagefireChasm/boss_gordoth.cpp
+++ b/src/server/scripts/Kalimdor/RagefireChasm/boss_gordoth.cpp
@@ -1,121 +1,224 @@
 /*
- * 2026 BFA-HavenCore
+ * Ragefire Chasm - Lava Guard Gordoth
+ * BFA-HavenCore 8.3.7
  *
- * This SourceCode is NOT free a software. Please hold everything Private
- * and read our Terms
+ * Retail-like intro adapted from modern TrinityCore reference behavior:
+ * - AreaTrigger 7899 starts the breakout
+ * - Gordoth breaks the cage and jumps into the laboratory
+ * - Lab vials are destroyed
+ * - Dark Shaman Researchers are killed by the experiment
+ * - Combat rotation: Ground Rupture, Seismic Slam, Enrage at 30%
  */
 
 #include "ScriptMgr.h"
 #include "ScriptedCreature.h"
+#include "Player.h"
+#include "GameObject.h"
+#include "MotionMaster.h"
 
-enum Spells
+enum GordothSpells
 {
-    SPELL_ENRAGE         = 50420,
-    SPELL_GROUND_RUPTURE = 119999,
-    SPELL_SEISMIC_SLAM   = 120024
+    // Intro
+    SPELL_JAIL_BREAK        = 120025,
+    SPELL_GROUND_SLAM       = 120023,
+    SPELL_MEAT_EXPLOSION_1  = 111778,
+    SPELL_MEAT_EXPLOSION_2  = 111779,
+    SPELL_MEAT_EXPLOSION_3  = 111780,
+    SPELL_BLOODY_SUICIDE    = 120022,
+
+    // Combat
+    SPELL_ENRAGE            = 50420,
+    SPELL_GROUND_RUPTURE    = 119999,
+    SPELL_SEISMIC_SLAM      = 120024
 };
 
-enum Events
+enum GordothEvents
 {
-    EVENT_RUPTURE,
+    EVENT_RUPTURE = 1,
     EVENT_SLAM
 };
 
-enum Creatures
+enum GordothMisc
 {
-    NPC_XORENTH = 61716
+    NPC_GORDOTH                 = 61528,
+    NPC_DARK_SHAMAN_RESEARCHER  = 61644,
+
+    GO_GORDOTH_CAGE             = 211792,
+    GO_LAB_VIAL                 = 211784,
+
+    ACTION_GORDOTH_BREAKOUT     = 1,
+    POINT_GORDOTH_JUMP          = 1
 };
 
-Position XorenthPos = {-327.424f, 220.4f, -20.381f, 3.56417f};
+static Position const GordothJumpPos =
+{
+    -363.5392f,
+    203.36604f,
+    -22.005634f,
+    0.30812347f
+};
 
-Position XorenthCenterPos = {-347.99f, 210.165f, -21.785f, 3.52412f};
+// AreaTrigger 7899 - Gordoth laboratory intro
+class at_rfc_gordoth_intro : public AreaTriggerScript
+{
+public:
+    at_rfc_gordoth_intro() : AreaTriggerScript("at_rfc_gordoth_intro") { }
+
+    bool OnTrigger(Player* player, AreaTriggerEntry const* /*areaTrigger*/, bool entered) override
+    {
+        if (!entered || !player)
+            return false;
+
+        if (Creature* gordoth = player->FindNearestCreature(NPC_GORDOTH, 100.0f, true))
+        {
+            if (gordoth->AI())
+                gordoth->AI()->DoAction(ACTION_GORDOTH_BREAKOUT);
+
+            return true;
+        }
+
+        return false;
+    }
+};
 
 class boss_gordoth : public CreatureScript
 {
-    public:
-        boss_gordoth() : CreatureScript("boss_gordoth") { }
+public:
+    boss_gordoth() : CreatureScript("boss_gordoth") { }
 
-        struct boss_gordothAI : public ScriptedAI
+    struct boss_gordothAI : public ScriptedAI
+    {
+        boss_gordothAI(Creature* creature)
+            : ScriptedAI(creature), _enraged(false), _introStarted(false)
         {
-            boss_gordothAI(Creature* creature) : ScriptedAI(creature) { }
+        }
 
-            void Reset()
+        void Reset() override
+        {
+            events.Reset();
+            _enraged = false;
+        }
+
+        void EnterCombat(Unit* /*who*/) override
+        {
+            events.ScheduleEvent(EVENT_RUPTURE, 7300);
+            events.ScheduleEvent(EVENT_SLAM, 13300);
+        }
+
+        void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+        {
+            if (!_enraged && me->HealthBelowPctDamaged(30, damage))
             {
-                rage = false;
+                _enraged = true;
+                DoCast(me, SPELL_ENRAGE, true);
+            }
+        }
+
+        void DoAction(int32 action) override
+        {
+            if (action != ACTION_GORDOTH_BREAKOUT || _introStarted)
+                return;
+
+            _introStarted = true;
+
+            // Open/break the cage visually.
+            if (GameObject* cage = GetClosestGameObjectWithEntry(me, GO_GORDOTH_CAGE, 50.0f))
+                cage->SetGoState(GO_STATE_ACTIVE);
+
+            // Retail breakout visual.
+            DoCast(me, SPELL_JAIL_BREAK, true);
+
+            me->SetReactState(REACT_PASSIVE);
+            me->CombatStop(true);
+            me->GetMotionMaster()->Clear();
+            me->GetMotionMaster()->MoveJump(GordothJumpPos, 50.0f, 4.0f, POINT_GORDOTH_JUMP);
+        }
+
+        void MovementInform(uint32 /*type*/, uint32 id) override
+        {
+            if (id != POINT_GORDOTH_JUMP)
+                return;
+
+            me->SetHomePosition(GordothJumpPos);
+            me->SetFacingTo(GordothJumpPos.GetOrientation());
+
+            // Landing slam.
+            DoCast(me, SPELL_GROUND_SLAM, true);
+
+            // Smash/change the laboratory vials as part of the breakout.
+            std::list<GameObject*> vials;
+            GetGameObjectListWithEntryInGrid(vials, me, GO_LAB_VIAL, 30.0f);
+            for (GameObject* vial : vials)
+                vial->SetGoState(GO_STATE_ACTIVE_ALTERNATIVE);
+
+            // The researchers are killed by the failed experiment.
+            std::list<Creature*> researchers;
+            GetCreatureListWithEntryInGrid(researchers, me, NPC_DARK_SHAMAN_RESEARCHER, 30.0f);
+            for (Creature* researcher : researchers)
+            {
+                if (!researcher->IsAlive())
+                    continue;
+
+                researcher->CastSpell(researcher, SPELL_MEAT_EXPLOSION_1, true);
+                researcher->CastSpell(researcher, SPELL_MEAT_EXPLOSION_2, true);
+                researcher->CastSpell(researcher, SPELL_MEAT_EXPLOSION_3, true);
+                researcher->CastSpell(researcher, SPELL_BLOODY_SUICIDE, true);
+                researcher->KillSelf();
             }
 
-            void EnterCombat(Unit* /*who*/)
-            {
-                events.ScheduleEvent(EVENT_RUPTURE, 5000);
-                events.ScheduleEvent(EVENT_SLAM, 10000);
-            }
+            // Gordoth is now active and may engage nearby players normally.
+            me->SetReactState(REACT_AGGRESSIVE);
+            DoZoneInCombat();
+        }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& /*damage*/)
+        void UpdateAI(uint32 diff) override
+        {
+            if (!UpdateVictim())
+                return;
+
+            events.Update(diff);
+
+            if (me->HasUnitState(UNIT_STATE_CASTING))
+                return;
+
+            while (uint32 eventId = events.ExecuteEvent())
             {
-                if(!rage && !me->IsNonMeleeSpellCast(false) && HealthBelowPct(30))
+                switch (eventId)
                 {
-                    rage = true;
-                    DoCast(me, SPELL_ENRAGE);
-                }
-            }
+                    case EVENT_RUPTURE:
+                        DoCastRandom(SPELL_GROUND_RUPTURE, 30.0f);
+                        events.ScheduleEvent(EVENT_RUPTURE, 12100);
+                        break;
 
-            void JustDied(Unit* /*killer*/)
-            {
-                me->SummonCreature(NPC_XORENTH, XorenthPos);
-            }
+                    case EVENT_SLAM:
+                        DoCastVictim(SPELL_SEISMIC_SLAM);
+                        events.ScheduleEvent(EVENT_SLAM, 36300);
+                        break;
 
-            void JustSummoned(Creature* summon)
-            {
-                summons.Summon(summon);
-                switch (summon->GetEntry())
-                {
-                    case NPC_XORENTH:
-                        summon->GetMotionMaster()->MovePoint(0, XorenthCenterPos);
-                        return;
                     default:
                         break;
                 }
+
+                if (me->HasUnitState(UNIT_STATE_CASTING))
+                    return;
             }
 
-            void UpdateAI(uint32 const diff)
-            {
-                if(!UpdateVictim())
-                    return;
-
-                events.Update(diff);
-
-                if(me->HasUnitState(UNIT_STATE_CASTING))
-                    return;
-
-                if(uint32 eventId = events.ExecuteEvent())
-                {
-                    switch(eventId)
-                    {
-                        case EVENT_SLAM:
-                            DoCastVictim(SPELL_SEISMIC_SLAM);
-                            events.ScheduleEvent(EVENT_SLAM, 15*IN_MILLISECONDS);
-                            break;
-                        case EVENT_RUPTURE:
-			    DoCastRandom(SPELL_GROUND_RUPTURE, 30);
-                            events.ScheduleEvent(EVENT_RUPTURE, 12*IN_MILLISECONDS);
-                            break;
-                        default:
-                            break;
-                    }
-                }
-                DoMeleeAttackIfReady();
-            }
-        private:
-            bool rage;
-        };
-
-        CreatureAI* GetAI(Creature* creature) const
-        {
-            return new boss_gordothAI(creature);
+            DoMeleeAttackIfReady();
         }
+
+    private:
+        bool _enraged;
+        bool _introStarted;
+    };
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return new boss_gordothAI(creature);
+    }
 };
 
 void AddSC_boss_gordoth()
 {
+    new at_rfc_gordoth_intro();
     new boss_gordoth();
 }

--- a/src/server/scripts/Kalimdor/RagefireChasm/boss_koranthal.cpp
+++ b/src/server/scripts/Kalimdor/RagefireChasm/boss_koranthal.cpp
@@ -7,6 +7,7 @@
 
 #include "ScriptMgr.h"
 #include "ScriptedCreature.h"
+#include "SpellScript.h"
 
 enum Spells
 {
@@ -16,66 +17,121 @@ enum Spells
 
 enum Events
 {
-    EVENT_STORM,
+    EVENT_STORM = 1,
     EVENT_ELEMENTS
+};
+
+enum Texts
+{
+    SAY_AGGRO = 0,
+    SAY_SHADOW_STORM = 1,
+    SAY_DEATH = 2
 };
 
 class boss_koranthal : public CreatureScript
 {
-    public:
-        boss_koranthal() : CreatureScript("boss_koranthal") { }
+public:
+    boss_koranthal() : CreatureScript("boss_koranthal") { }
 
-        struct boss_koranthalAI : public ScriptedAI
+    struct boss_koranthalAI : public ScriptedAI
+    {
+        boss_koranthalAI(Creature* creature) : ScriptedAI(creature) { }
+
+        void Reset() override
         {
-            boss_koranthalAI(Creature* creature) : ScriptedAI(creature) { }
-
-            void Reset() { }
-
-            void EnterCombat(Unit* /*who*/)
-            {
-                events.ScheduleEvent(EVENT_STORM, 10000);
-                events.ScheduleEvent(EVENT_ELEMENTS, 8000);
-            }
-
-            void JustDied(Unit* /*killer*/) { }
-
-            void UpdateAI(uint32 const diff)
-            {
-                if(!UpdateVictim())
-                    return;
-
-                events.Update(diff);
-
-                if(me->HasUnitState(UNIT_STATE_CASTING))
-                    return;
-
-                if(uint32 eventId = events.ExecuteEvent())
-                {
-                    switch(eventId)
-                    {
-                        case EVENT_STORM:
-                            DoCast(me, SPELL_SHADOW_STORM, false);
-                            events.ScheduleEvent(EVENT_STORM, 15*IN_MILLISECONDS);
-                            break;
-                        case EVENT_ELEMENTS:
-                            DoCastVictim(SPELL_TWISTED_ELEMENTS);
-                            events.ScheduleEvent(EVENT_ELEMENTS, 8*IN_MILLISECONDS);
-                            break;
-                        default:
-                            break;
-                    }
-                }
-                DoMeleeAttackIfReady();
-            }
-        };
-
-        CreatureAI* GetAI(Creature* creature) const
-        {
-            return new boss_koranthalAI(creature);
+            events.Reset();
         }
+
+        void EnterCombat(Unit* /*who*/) override
+        {
+            Talk(SAY_AGGRO);
+
+            events.ScheduleEvent(EVENT_ELEMENTS, 6000);
+            events.ScheduleEvent(EVENT_STORM, 20500);
+        }
+
+        void JustDied(Unit* /*killer*/) override
+        {
+            Talk(SAY_DEATH);
+            events.Reset();
+        }
+
+        void UpdateAI(uint32 const diff) override
+        {
+            if (!UpdateVictim())
+                return;
+
+            events.Update(diff);
+
+            if (me->HasUnitState(UNIT_STATE_CASTING))
+                return;
+
+            while (uint32 eventId = events.ExecuteEvent())
+            {
+                switch (eventId)
+                {
+                    case EVENT_ELEMENTS:
+                    {
+                        DoCastVictim(SPELL_TWISTED_ELEMENTS);
+                        events.ScheduleEvent(EVENT_ELEMENTS, 7300);
+                        break;
+                    }
+
+                    case EVENT_STORM:
+                    {
+                        Talk(SAY_SHADOW_STORM);
+                        DoCast(me, SPELL_SHADOW_STORM, false);
+
+                        // Shadow Storm is a phase, not a permanent recast loop.
+                        // Delay Twisted Elements until the storm phase ends.
+                        events.RescheduleEvent(EVENT_ELEMENTS, 15700);
+
+                        // Reference cadence for the next Shadow Storm.
+                        events.ScheduleEvent(EVENT_STORM, 47200);
+                        break;
+                    }
+
+                    default:
+                        break;
+                }
+
+                if (me->HasUnitState(UNIT_STATE_CASTING))
+                    return;
+            }
+
+            DoMeleeAttackIfReady();
+        }
+    };
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return new boss_koranthalAI(creature);
+    }
+};
+
+// 119973 - Shadow Storm
+class spell_koranthal_shadow_storm : public SpellScript
+{
+    PrepareSpellScript(spell_koranthal_shadow_storm);
+
+    void HandleScript(SpellEffIndex /*effIndex*/)
+    {
+        if (Unit* caster = GetCaster())
+            if (Unit* target = GetHitUnit())
+                caster->CastSpell(target, GetEffectValue(), true);
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(
+            spell_koranthal_shadow_storm::HandleScript,
+            EFFECT_0,
+            SPELL_EFFECT_DUMMY);
+    }
 };
 
 void AddSC_boss_koranthal()
 {
     new boss_koranthal();
+    RegisterSpellScript(spell_koranthal_shadow_storm);
 }

--- a/src/server/scripts/Kalimdor/RagefireChasm/boss_slagmaw.cpp
+++ b/src/server/scripts/Kalimdor/RagefireChasm/boss_slagmaw.cpp
@@ -1,124 +1,226 @@
 /*
  * 2026 BFA-HavenCore
  *
- * This SourceCode is NOT free a software. Please hold everything Private
- * and read our Terms
+ * Ragefire Chasm - Slagmaw (61463)
+ * Retail-style encounter behavior adapted for HavenCore 8.3.7.
  */
 
 #include "ScriptMgr.h"
 #include "ScriptedCreature.h"
+#include "InstanceScript.h"
 
-enum Spells
+enum SlagmawSpells
 {
     SPELL_LAVA_SPIT = 119434,
     SPELL_SUBMERGE  = 120384
 };
 
-enum Events
+enum SlagmawPositions
 {
-    EVENT_LAVA_SPIT,
-    EVENT_SUBMERGE
+    POSITION_NORTH = 0,
+    POSITION_EAST,
+    POSITION_SOUTH,
+    POSITION_WEST,
+    POSITION_MAX
+};
+
+// Retail/TrinityCore emergence positions for Slagmaw in map 389.
+Position const SlagmawTeleportPositions[POSITION_MAX] =
+{
+    { -222.940f, 165.703f, -19.721f, 3.797819f },
+    { -226.477f, 135.704f, -19.721f, 2.330294f },
+    { -263.212f, 136.244f, -19.721f, 0.7556769f },
+    { -256.389f, 172.884f, -19.721f, 5.577933f }
+};
+
+enum SlagmawEvents
+{
+    EVENT_LAVA_SPIT = 1,
+    EVENT_TELEPORT,
+    EVENT_EMERGE,
+    EVENT_BOUNDARY_CHECK
 };
 
 class boss_slagmaw : public CreatureScript
 {
-    public:
-        boss_slagmaw() : CreatureScript("boss_slagmaw") { }
+public:
+    boss_slagmaw() : CreatureScript("boss_slagmaw") { }
 
-        struct boss_slagmawAI : public ScriptedAI
+    struct boss_slagmawAI : public ScriptedAI
+    {
+        boss_slagmawAI(Creature* creature)
+            : ScriptedAI(creature),
+              instance(creature->GetInstanceScript()),
+              lavaSpitCount(0),
+              lastTeleport(POSITION_WEST)
         {
-            boss_slagmawAI(Creature* creature) : ScriptedAI(creature)
-            {
-            }
-
-            void JustDied(Unit* /*who*/) override
-            {
-                me->RemoveUnitFlag(UnitFlags(UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE));
-                me->AddDynamicFlag(UNIT_DYNFLAG_LOOTABLE);
-            }
-
-
-            void Reset() override
-            {
-                events.Reset();
-                me->AddUnitFlag(UnitFlags(UNIT_FLAG_NOT_SELECTABLE | UNIT_FLAG_NON_ATTACKABLE));
-            }
-
-            void AttackStart(Unit* target) override
-            {
-                if (me->Attack(target, true))
-                    DoStartNoMovement(target);
-            }
-
-            void UpdateAI(uint32 const diff) override
-            {
-
-                if(me->HasUnitState(UNIT_STATE_CASTING))
-                    return;
-            }
-        };
-
-        CreatureAI* GetAI(Creature* creature) const
-        {
-            return new boss_slagmawAI(creature);
         }
-};
 
-class boss_slagmaw_head : public CreatureScript
-{
-    public:
-        boss_slagmaw_head() : CreatureScript("boss_slagmaw_head") { }
+        InstanceScript* instance;
+        uint8 lavaSpitCount;
+        uint8 lastTeleport;
 
-        struct boss_slagmaw_headAI : public ScriptedAI
+        void Reset() override
         {
-            boss_slagmaw_headAI(Creature* creature) : ScriptedAI(creature) { }
+            events.Reset();
 
-            void EnterCombat(Unit* /*who*/) override
+            lavaSpitCount = 0;
+            lastTeleport = POSITION_WEST;
+
+            me->RemoveAurasDueToSpell(SPELL_SUBMERGE);
+            me->RemoveUnitFlag(UnitFlags(
+                UNIT_FLAG_NON_ATTACKABLE |
+                UNIT_FLAG_NOT_SELECTABLE));
+
+            if (instance)
+                instance->SendEncounterUnit(ENCOUNTER_FRAME_DISENGAGE, me);
+        }
+
+        void AttackStart(Unit* target) override
+        {
+            if (!target)
+                return;
+
+            if (me->Attack(target, true))
+                DoStartNoMovement(target);
+        }
+
+        void EnterCombat(Unit* who) override
+        {
+            DoStartNoMovement(who);
+
+            if (instance)
+                instance->SendEncounterUnit(ENCOUNTER_FRAME_ENGAGE, me);
+
+            events.ScheduleEvent(EVENT_LAVA_SPIT, 1000);
+            events.ScheduleEvent(EVENT_BOUNDARY_CHECK, 2500);
+        }
+
+        void JustReachedHome() override
+        {
+            if (instance)
+                instance->SendEncounterUnit(ENCOUNTER_FRAME_DISENGAGE, me);
+        }
+
+        void JustDied(Unit* /*killer*/) override
+        {
+            events.Reset();
+            me->RemoveAurasDueToSpell(SPELL_SUBMERGE);
+
+            if (instance)
+                instance->SendEncounterUnit(ENCOUNTER_FRAME_DISENGAGE, me);
+        }
+
+        uint8 GetNextTeleport()
+        {
+            uint8 selected;
+
+            do
             {
-                events.ScheduleEvent(EVENT_LAVA_SPIT, 8000);
+                selected = urand(0, POSITION_MAX - 1);
             }
+            while (selected == lastTeleport);
 
-            void JustDied(Unit* /*killer*/) override
+            lastTeleport = selected;
+            return selected;
+        }
+
+        void StartSubmerge()
+        {
+            DoCast(me, SPELL_SUBMERGE);
+            lavaSpitCount = 0;
+            events.ScheduleEvent(EVENT_TELEPORT, 3000);
+        }
+
+        void UpdateAI(uint32 diff) override
+        {
+            if (!UpdateVictim())
+                return;
+
+            events.Update(diff);
+
+            if (me->HasUnitState(UNIT_STATE_CASTING))
+                return;
+
+            while (uint32 eventId = events.ExecuteEvent())
             {
-                if (Creature* SlagmawBody = me->FindNearestCreature(61463, 50.0f))
-                    me->Kill(SlagmawBody);
-
-                me->DespawnOrUnsummon(500);
-            }
-
-            void UpdateAI(uint32 const diff) override
-            {
-                if(!UpdateVictim())
-                    return;
-
-                events.Update(diff);
-
-                if(me->HasUnitState(UNIT_STATE_CASTING))
-                    return;
-
-                if(uint32 eventId = events.ExecuteEvent())
+                switch (eventId)
                 {
-                    switch(eventId)
+                    case EVENT_LAVA_SPIT:
                     {
-                        case EVENT_LAVA_SPIT:
-                            DoCastVictim(SPELL_LAVA_SPIT);
-                            events.ScheduleEvent(EVENT_LAVA_SPIT, 5*IN_MILLISECONDS);
-                            break;
-                        default:
-                            break;
+                        if (lavaSpitCount < 5)
+                        {
+                            if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
+                            {
+                                DoCast(target, SPELL_LAVA_SPIT);
+                                ++lavaSpitCount;
+                            }
+
+                            events.ScheduleEvent(EVENT_LAVA_SPIT, 1000);
+                        }
+                        else
+                        {
+                            StartSubmerge();
+                        }
+
+                        break;
                     }
+
+                    case EVENT_TELEPORT:
+                    {
+                        uint8 positionIndex = GetNextTeleport();
+                        Position const& pos = SlagmawTeleportPositions[positionIndex];
+
+                        me->NearTeleportTo(
+                            pos.GetPositionX(),
+                            pos.GetPositionY(),
+                            pos.GetPositionZ(),
+                            pos.GetOrientation());
+
+                        events.ScheduleEvent(EVENT_EMERGE, 1000);
+                        break;
+                    }
+
+                    case EVENT_EMERGE:
+                    {
+                        me->RemoveAurasDueToSpell(SPELL_SUBMERGE);
+
+                        if (Unit* victim = me->GetVictim())
+                            DoStartNoMovement(victim);
+
+                        events.ScheduleEvent(EVENT_LAVA_SPIT, 1000);
+                        break;
+                    }
+
+                    case EVENT_BOUNDARY_CHECK:
+                    {
+                        if (Unit* victim = me->GetVictim())
+                        {
+                            if (me->GetDistance(victim) > 50.0f)
+                            {
+                                EnterEvadeMode(EVADE_REASON_OTHER);
+                                return;
+                            }
+                        }
+
+                        events.ScheduleEvent(EVENT_BOUNDARY_CHECK, 2500);
+                        break;
+                    }
+
+                    default:
+                        break;
                 }
             }
-        };
-
-        CreatureAI* GetAI(Creature* creature) const
-        {
-            return new boss_slagmaw_headAI(creature);
         }
+    };
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return new boss_slagmawAI(creature);
+    }
 };
 
 void AddSC_boss_slagmaw()
 {
     new boss_slagmaw();
-    new boss_slagmaw_head();
 }

--- a/src/server/scripts/Kalimdor/RagefireChasm/instance_ragefire_chasm.cpp
+++ b/src/server/scripts/Kalimdor/RagefireChasm/instance_ragefire_chasm.cpp
@@ -1,29 +1,57 @@
 /*
  * 2026 BFA-HavenCore
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * Ragefire Chasm instance support.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program. If not, see <http://www.gnu.org/licenses/>.
+ * Keeps the existing LFG/instance-script behavior and filters the duplicated
+ * faction-specific rescue NPCs so Alliance and Horde prisoners are not
+ * rendered on top of each other in the same instance.
  */
-
-/*
-This placeholder for the instance is needed for dungeon finding to be able
-to give credit after the boss defined in lastEncounterDungeon is killed.
-Without it, the party doing random dungeon won't get satchel of spoils and
-gets instead the deserter debuff.
-*/
 
 #include "ScriptMgr.h"
 #include "InstanceScript.h"
+#include "Player.h"
+#include "Creature.h"
+
+namespace
+{
+    enum RfcCreatures
+    {
+        NPC_KORKRON_ELITE          = 61404,
+        NPC_KORKRON_SCOUT          = 61680,
+        NPC_INVOKER_XORENTH        = 61716,
+        NPC_COMMANDER_BAGRAN       = 61724,
+
+        NPC_SI7_RANGER             = 61788,
+        NPC_SI7_COMMANDO           = 61821,
+        NPC_SI7_FIELD_COMMANDER    = 61822,
+        NPC_HIGH_SORCERESS_ARYNA   = 61823
+    };
+
+    uint32 const HordeRescueSpawns[] =
+    {
+        10615981,
+        10615985,
+        10615984,
+        10615969,
+        10615970,
+        10615942,
+        10615916,
+        10615895
+    };
+
+    uint32 const AllianceRescueSpawns[] =
+    {
+        10642794,
+        10642797,
+        10642796,
+        10642793,
+        10642795,
+        10642790,
+        10642791,
+        10642792
+    };
+}
 
 class instance_ragefire_chasm : public InstanceMapScript
 {
@@ -32,14 +60,86 @@ public:
 
     struct instance_ragefire_chasm_InstanceMapScript : public InstanceScript
     {
-        instance_ragefire_chasm_InstanceMapScript(InstanceMap* map) : InstanceScript(map) { }
+        instance_ragefire_chasm_InstanceMapScript(InstanceMap* map)
+            : InstanceScript(map), _teamInitialized(false), _teamId(TEAM_NEUTRAL)
+        {
+        }
+
+        void OnPlayerEnter(Player* player) override
+        {
+            if (!player || _teamInitialized)
+                return;
+
+            _teamId = player->GetTeamId();
+            _teamInitialized = true;
+
+            // Creatures in unloaded grids may not exist yet. Remove any that
+            // are already loaded now; OnCreatureCreate below handles the rest.
+            if (_teamId == TEAM_ALLIANCE)
+            {
+                for (uint32 spawnId : HordeRescueSpawns)
+                    DespawnSpawn(spawnId);
+            }
+            else if (_teamId == TEAM_HORDE)
+            {
+                for (uint32 spawnId : AllianceRescueSpawns)
+                    DespawnSpawn(spawnId);
+            }
+        }
+
+        void OnCreatureCreate(Creature* creature) override
+        {
+            if (!creature || !_teamInitialized)
+                return;
+
+            if (_teamId == TEAM_ALLIANCE)
+            {
+                switch (creature->GetEntry())
+                {
+                    case NPC_KORKRON_ELITE:
+                    case NPC_KORKRON_SCOUT:
+                    case NPC_INVOKER_XORENTH:
+                    case NPC_COMMANDER_BAGRAN:
+                        creature->DespawnOrUnsummon();
+                        break;
+                    default:
+                        break;
+                }
+            }
+            else if (_teamId == TEAM_HORDE)
+            {
+                switch (creature->GetEntry())
+                {
+                    case NPC_SI7_RANGER:
+                    case NPC_SI7_COMMANDO:
+                    case NPC_SI7_FIELD_COMMANDER:
+                    case NPC_HIGH_SORCERESS_ARYNA:
+                        creature->DespawnOrUnsummon();
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+    private:
+        void DespawnSpawn(uint32 spawnId)
+        {
+            auto bounds = instance->GetCreatureBySpawnIdStore().equal_range(spawnId);
+            for (auto itr = bounds.first; itr != bounds.second; ++itr)
+                if (Creature* creature = itr->second)
+                    if (creature->IsInWorld())
+                        creature->DespawnOrUnsummon();
+        }
+
+        bool _teamInitialized;
+        TeamId _teamId;
     };
- 
+
     InstanceScript* GetInstanceScript(InstanceMap* map) const override
     {
         return new instance_ragefire_chasm_InstanceMapScript(map);
     }
-   
 };
 
 void AddSC_instance_ragefire_chasm()

--- a/src/server/scripts/Kalimdor/RagefireChasm/ragefire_chasm.cpp
+++ b/src/server/scripts/Kalimdor/RagefireChasm/ragefire_chasm.cpp
@@ -1,29 +1,203 @@
 /*
  * 2026 BFA-HavenCore
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program. If not, see <http://www.gnu.org/licenses/>.
+ * Ragefire Chasm support
  */
- 
+
 #include "ScriptMgr.h"
+#include "Creature.h"
+#include "GameObject.h"
+#include "MotionMaster.h"
+#include "Player.h"
 #include "ScriptedCreature.h"
-#include "PassiveAI.h"
+#include "ScriptedGossip.h"
 #include "ragefire_chasm.h"
 
+namespace RagefireChasm
+{
+    enum Quests
+    {
+        QUEST_NO_ORC_LEFT_BEHIND = 30984,
+        QUEST_NO_MAN_LEFT_BEHIND = 30995
+    };
 
+    enum Creatures
+    {
+        NPC_KORKRON_SCOUT = 61680,
+        NPC_SI7_RANGER    = 61788,
+
+        NPC_SUSPICIOUS_ROCK     = 61780,
+        NPC_INCONSPICUOUS_CRATE = 61790
+    };
+
+    enum GameObjects
+    {
+        GO_RANGER_CAGE_1 = 211883,
+        GO_RANGER_CAGE_2 = 211884,
+        GO_RANGER_CAGE_3 = 211885
+    };
+
+    // Returns the appropriate quest-credit creature for the player.
+    uint32 GetRescueCreditEntry(Player* player)
+    {
+        if (player->GetQuestStatus(QUEST_NO_MAN_LEFT_BEHIND) == QUEST_STATUS_INCOMPLETE)
+            return NPC_SI7_RANGER;
+
+        if (player->GetQuestStatus(QUEST_NO_ORC_LEFT_BEHIND) == QUEST_STATUS_INCOMPLETE)
+            return NPC_KORKRON_SCOUT;
+
+        return 0;
+    }
+
+    bool RescuePrisoner(Player* player, WorldObject* source)
+    {
+        if (!player || !source)
+            return false;
+
+        uint32 creditEntry = GetRescueCreditEntry(player);
+        if (!creditEntry)
+            return false;
+
+        uint32 questId = creditEntry == NPC_SI7_RANGER
+            ? QUEST_NO_MAN_LEFT_BEHIND
+            : QUEST_NO_ORC_LEFT_BEHIND;
+
+        // Do not give additional credit once the objective is already complete.
+        if (player->GetReqKillOrCastCurrentCount(questId, creditEntry) >= 5)
+            return false;
+
+        // Each rescue point already has the appropriate prisoner spawned
+        // at or immediately beside it.
+        Creature* prisoner = source->FindNearestCreature(creditEntry, 6.0f, true);
+        if (!prisoner)
+            return false;
+
+        player->KilledMonsterCredit(creditEntry, prisoner->GetGUID());
+
+        // Retail-like rescue presentation:
+        // prisoner acknowledges the rescue, becomes passive, follows a
+        // location-specific escape route, then despawns.
+        prisoner->SetReactState(REACT_PASSIVE);
+        prisoner->CombatStop(true);
+        prisoner->DeleteThreatList();
+        prisoner->SetWalk(false);
+
+        if (prisoner->AI())
+            prisoner->AI()->Talk(0);
+
+        prisoner->GetMotionMaster()->Clear();
+
+        // Suspicious Rock rescue point.
+        if (source->GetEntry() == NPC_SUSPICIOUS_ROCK)
+        {
+            prisoner->GetMotionMaster()->MovePoint(1, -306.174f, -23.1592f, -59.0882f);
+            prisoner->GetMotionMaster()->MovePoint(2, -297.9861f, -41.88261f, -60.91673f);
+            prisoner->GetMotionMaster()->MovePoint(3, -286.8949f, -48.55449f, -60.93217f);
+            prisoner->GetMotionMaster()->MovePoint(4, -276.6081f, -47.31757f, -60.93217f);
+            prisoner->GetMotionMaster()->MovePoint(5, -253.9539f, -39.25582f, -60.49646f);
+            prisoner->GetMotionMaster()->MovePoint(6, -225.0045f, -37.12025f, -55.7888f);
+            prisoner->DespawnOrUnsummon(18000);
+            return true;
+        }
+
+        // Inconspicuous Crate rescue point.
+        if (source->GetEntry() == NPC_INCONSPICUOUS_CRATE)
+        {
+            prisoner->GetMotionMaster()->MovePoint(1, -92.523f, 65.7691f, -18.6579f);
+            prisoner->GetMotionMaster()->MovePoint(2, -108.3838f, 23.41842f, -18.44852f);
+            prisoner->GetMotionMaster()->MovePoint(3, -129.3571f, 9.659675f, -20.64646f);
+            prisoner->GetMotionMaster()->MovePoint(4, -143.5467f, 8.586313f, -21.6209f);
+            prisoner->DespawnOrUnsummon(14000);
+            return true;
+        }
+
+        // Final laboratory cages. Give them a short clean escape from
+        // the cage line and despawn outside the immediate encounter area.
+        if (source->GetEntry() == GO_RANGER_CAGE_1 ||
+            source->GetEntry() == GO_RANGER_CAGE_2 ||
+            source->GetEntry() == GO_RANGER_CAGE_3)
+        {
+            float x = prisoner->GetPositionX();
+            float y = prisoner->GetPositionY();
+            float z = prisoner->GetPositionZ();
+
+            prisoner->GetMotionMaster()->MovePoint(1, x + 5.0f, y + 1.0f, z);
+            prisoner->GetMotionMaster()->MovePoint(2, x + 12.0f, y - 4.0f, z);
+            prisoner->GetMotionMaster()->MovePoint(3, x + 20.0f, y - 8.0f, z);
+            prisoner->DespawnOrUnsummon(12000);
+            return true;
+        }
+
+        // Fallback for any other rescue point.
+        Position escapePosition = prisoner->GetNearPosition(22.0f, 0.0f);
+        prisoner->GetMotionMaster()->MovePoint(1, escapePosition);
+        prisoner->DespawnOrUnsummon(8000);
+
+        return true;
+    }
+}
+
+// Suspicious Rock / Inconspicuous Crate.
+//
+// Their gossip text is already supplied by the DB through broadcast text
+// 61264 ("It's safe to come out now."), preserving client localization.
+class npc_rfc_hidden_prisoner : public CreatureScript
+{
+public:
+    npc_rfc_hidden_prisoner() : CreatureScript("npc_rfc_hidden_prisoner") { }
+
+    struct npc_rfc_hidden_prisonerAI : public ScriptedAI
+    {
+        npc_rfc_hidden_prisonerAI(Creature* creature) : ScriptedAI(creature) { }
+
+        void Reset() override
+        {
+            // These are hiding-place props represented as creatures.
+            // Keep them stationary instead of allowing continuous turning.
+            me->GetMotionMaster()->Clear();
+            me->StopMoving();
+            me->SetReactState(REACT_PASSIVE);
+        }
+
+        void UpdateAI(uint32 /*diff*/) override { }
+    };
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return new npc_rfc_hidden_prisonerAI(creature);
+    }
+
+    bool OnGossipSelect(Player* player, Creature* creature, uint32 /*sender*/, uint32 /*action*/) override
+{
+    CloseGossipMenuFor(player);
+
+    if (RagefireChasm::RescuePrisoner(player, creature))
+    {
+        // This rescue point is consumed for the instance.
+        creature->RemoveNpcFlag(UNIT_NPC_FLAG_GOSSIP);
+        creature->DespawnOrUnsummon(1000);
+    }
+
+    return true;
+}
+};
+
+// Final laboratory prisoner cages.
+class go_rfc_prisoner_cage : public GameObjectScript
+{
+public:
+    go_rfc_prisoner_cage() : GameObjectScript("go_rfc_prisoner_cage") { }
+
+    bool OnGossipHello(Player* player, GameObject* go) override
+    {
+        RagefireChasm::RescuePrisoner(player, go);
+
+        return false;
+    }
+};
 
 void AddSC_ragefire_chasm()
 {
-  
+    new npc_rfc_hidden_prisoner();
+    new go_rfc_prisoner_cage();
 }
-


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [X] Core (units, players, creatures, game systems).
-  [X] Scripts (bosses, spell scripts, creature scripts).
-  [X] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #230 
- Closes #421 
- Closes #68  
- Closes #47 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [X] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


# Ragefire Chasm: Complete Normal-Mode Restoration

## Summary

This PR restores Ragefire Chasm for the current BFA-HavenCore normal-mode leveling scope and brings the dungeon substantially closer to retail behavior.

The work covers all four bosses, faction-specific NPC presentation, prisoner rescue quests, deprecated quest cleanup, boss loot/gold, Gordoth's laboratory breakout sequence, and instance persistence.

## Boss fixes

### Adarogg

- Replaced incomplete SmartAI with `boss_adarogg`.
- Restored recurring Inferno Charge / Flame Breath rotation with melee between abilities.
- Added visible physical charge movement for Inferno Charge.
- Corrected boss gold and replaced generic trash loot with boss-specific loot.
- Kill credit verified.

### Dark Shaman Koranthal

- Replaced broken SmartAI with `boss_koranthal`.
- Fixed the permanent Shadow Storm loop.
- Restored melee and Twisted Elements between Shadow Storm phases.
- Corrected Shadow Storm targeting and bound `spell_koranthal_shadow_storm` to spell `119973`.
- Restored dialogue/warning text using BroadcastText IDs for localization.
- Corrected boss gold and boss-specific loot.
- Kill credit verified.

### Slagmaw

- Attached `boss_slagmaw`.
- Restored the 5x Lava Spit -> Submerge -> Emerge cycle.
- Added multiple emerge locations and prevented chasing onto land.
- Removed the obsolete Magnaw's Head helper spawn.
- Increased melee reach so melee characters can attack reasonably from the platform.
- Corrected boss gold and boss-specific loot.
- Kill credit verified.

### Lava Guard Gordoth

- Replaced SmartAI with `boss_gordoth`.
- Preserved Ground Rupture, Seismic Slam, melee, and 30% Enrage.
- Added retail-like breakout using AreaTrigger `7899`.
- Gordoth now breaks out automatically, jumps into the laboratory, kills nearby researchers, and breaks the Lab Vials.
- Corrected boss gold and boss-specific loot.
- Kill credit verified.

## Quest and instance fixes

### No Man Left Behind / No Orc Left Behind

- Restored rescue credit for Suspicious Rock, Inconspicuous Crate, and final-room cages.
- Rescue objects are single-use.
- Rescued SI:7 Rangers and Kor'kron Scouts use BroadcastText-backed rescue dialogue.
- Rescued NPCs run away and despawn instead of remaining inside their hiding locations.
- Rock/crate rescue movement uses location-specific paths to avoid walls and lava.

### Faction-specific population

- Added instance-level faction filtering.
- Alliance instances show Alliance rescue/quest NPCs only.
- Horde instances show Horde rescue/quest NPCs only.
- Both faction spawn sets remain in the DB; visibility is handled per instance.

### Deprecated quests

- Removed deprecated Horde and Alliance `Animal Control` quest starters/enders.

## Loot fixes

Replaced generic low-level trash-style boss loot with boss-specific loot groups and corrected gold:

- Adarogg: `65000-75000` copper
- Dark Shaman Koranthal: `65000-75000` copper
- Slagmaw: `65000-75000` copper
- Lava Guard Gordoth: `160000-170000` copper

## Localization

Restored dialogue uses existing BroadcastText IDs where available so localized clients can use the normal localization path.

## Testing

Validated on normal Ragefire Chasm with Horde and Alliance characters:

- All four bosses give kill credit.
- Adarogg rotation and visible Inferno Charge verified.
- Koranthal no longer becomes stuck casting Shadow Storm.
- Slagmaw submerge/emerge cycle and melee accessibility verified.
- Gordoth breakout, researcher deaths, broken Lab Vials, knockbacks, and 30% Enrage verified.
- Boss loot and gold verified.
- No Man Left Behind / No Orc Left Behind reaches 5/5 and can be turned in.
- Rescue dialogue, movement, despawn, and one-use behavior verified.
- Faction-overlapping NPCs removed correctly.
- Deprecated Animal Control no longer appears.
- Dungeon tracker clears after Gordoth.
- Instance persistence verified by killing bosses, leaving, re-entering the same instance, and confirming completed encounters remained complete.



