### PR TITLE
DB: Ranger NPC And The Final Flame

### DIFF
--- a/sql/updates/world/2026_09_02_02_fix_darkshore_ranger_glynda_and_the_final_flame.sql
+++ b/sql/updates/world/2026_09_02_02_fix_darkshore_ranger_glynda_and_the_final_flame.sql
@@ -1,0 +1,26 @@
+-- Quest The Final Flame of Bashal'Aran (ID 13562)
+DELETE FROM `quest_poi` WHERE `QuestID` = 13562;
+INSERT INTO `quest_poi` (`QuestID`, `BlobIndex`, `Idx1`, `ObjectiveIndex`, `QuestObjectiveID`, `QuestObjectID`, `MapID`, `UiMapID`, `Priority`, `Flags`, `WorldEffectID`, `PlayerConditionID`, `SpawnTrackingID`, `AlwaysAllowMergingBlobs`, `VerifiedBuild`)
+VALUES
+  (13562, 0, 0, -1, 0, 0, 1, 62, 0, 0, 0, 0, 0, 0, 0),
+  (13562, 0, 1, 0, 0, 0, 1, 62, 0, 0, 0, 0, 0, 0, 0),
+  (13562, 0, 2, 32, 0, 0, 1, 62, 0, 0, 0, 0, 0, 0, 0);
+
+DELETE FROM `quest_poi_points` WHERE `QuestID` = 13562;
+INSERT INTO `quest_poi_points` (`QuestID`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`)
+VALUES
+  (13562, 0, 0, 7372, -259, 0),
+  (13562, 1, 0, 6748, 48, 0),
+  (13562, 3, 0, 7372, -259, 0);
+
+
+-- Quest (13562) - Fix description
+INSERT IGNORE INTO 
+`quest_offer_reward` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `RewardText`, `VerifiedBuild`) 
+VALUES (13562, 0, 0, 0, 0, 0, 0, 0, 0, 'You have our thanks. It is time that we leave the past behind us, and start looking to our future.', 0);
+
+
+-- NPC Ranger Glynda Nal'Shea (ID 32971) - Remove Aura ID - 49414 Generic Quest Invisibility 1
+UPDATE `creature_template_addon` SET
+  `auras` = NULL
+WHERE `entry` = 32971;


### PR DESCRIPTION
NOTICE: In issue #434 it mentions the GameObject not ticking the objective. When I clicked on the game object objective, it worked fine and ticked the quest as complete.

This PR fixes both an NPC and a quest related to her
- Fix Ranger Glynda Nal'Shea (32971)
- Fix The Final Flame of Bashal'Aran (13562)
 - Quest POI Fix (Was missing)
 - Quest Completion Description Fix (Was missing)

Issue(s) related to the fixes:
- #434 
- #391 

Images from testing.
<img width="1534" height="858" alt="Invis NPC" src="https://github.com/user-attachments/assets/2615eef3-22b0-4c1e-b32d-bae0fc9aba04" />

<img width="1040" height="571" alt="Final Flame fix" src="https://github.com/user-attachments/assets/d72b24e6-0a3f-4945-a562-df74eca997d4" />

<img width="1092" height="617" alt="The final flame complete" src="https://github.com/user-attachments/assets/ed0112c9-1ae6-4f04-8482-2b5fcac7b20f" />
