### PR TITLE
DB: Fix Dark Strand Victim

### DIFF
--- a/sql/updates/world/2026_09_02_04_fix_dark_strand_victim.sql
+++ b/sql/updates/world/2026_09_02_04_fix_dark_strand_victim.sql
@@ -1,0 +1,2 @@
+-- Dark Strand Victim (ID 34030) - Show as dead, and not attackable
+UPDATE `creature_template` SET `unit_flags` = 768, `unit_flags3` = 8192 WHERE (`entry` = 34030);


### PR DESCRIPTION
Fix for Dark Strand Victim: now it won't be attackable, and it shows as dead. Issue related:
- #445
<img width="1540" height="859" alt="Random" src="https://github.com/user-attachments/assets/c5679bc6-f321-404f-a4e3-013b8ceb1e69" />

