### PR TITLE
CPP/SQL: Fix for Deadmines Instance for BFA

### DIFF
--- a/sql/updates/world/2026_09_03_00_DM_All_Fixes_Merged.sql
+++ b/sql/updates/world/2026_09_03_00_DM_All_Fixes_Merged.sql
@@ -1,0 +1,296 @@
+-- ============================================================
+-- Deadmines - Consolidated World Database Fixes
+-- HavenCore BFA 8.3.7
+-- Map: 36
+--
+-- Consolidates the Deadmines SQL fixes from:
+--   2023_09_03_01_DM_Creatures_Clipping_Fix.sql
+--   2026_09_02_00_DM_Fix_Heroic_Loot_Mix.sql
+--   2026_09_02_01_DM_Fix Ripsnarl_Quest_Offer_Issue.sql
+--   2026_09_02_02_DM_Goblin_Teleport_Fix.sql
+--   2026_09_02_03_DM_Defias_Overseer_Fix.sql
+--   2026_09_03_00_DM_Drink Bunny Fixes.sql
+--
+-- Also includes the verified Ripsnarl fog-trigger visibility fix
+-- from the same Deadmines repair pass.
+-- ============================================================
+
+START TRANSACTION;
+
+-- ============================================================
+-- 1. Ambient Rat clipping fix
+-- ============================================================
+UPDATE `creature`
+SET `spawndist` = 3
+WHERE `map` = 36
+  AND `id` = 4075
+  AND `guid` IN
+  (
+      318999,
+      319000,
+      319001,
+      319002,
+      319003,
+      319004,
+      319005,
+      319378
+  );
+
+
+-- ============================================================
+-- 2. Separate Heroic boss loot from Normal loot
+-- ============================================================
+UPDATE `creature_loot_template`
+SET `LootMode` = 2
+WHERE `Entry` = 47162
+  AND `Item` IN (63467,63468,63470,63471,65163);
+
+UPDATE `creature_loot_template`
+SET `LootMode` = 2
+WHERE `Entry` = 47296
+  AND `Item` IN (63473,63474,63475,63476,65164);
+
+UPDATE `creature_loot_template`
+SET `LootMode` = 2
+WHERE `Entry` = 43778
+  AND `Item` IN (65157,65165,65166);
+
+UPDATE `creature_loot_template`
+SET `LootMode` = 2
+WHERE `Entry` = 47626
+  AND `Item` IN (65168,65169,65170);
+
+UPDATE `creature_loot_template`
+SET `LootMode` = 2
+WHERE `Entry` = 47739
+  AND `Item` IN (65171,65172,65173,65174,65177);
+
+
+-- ============================================================
+-- 3. Admiral Ripsnarl quest-offer cleanup
+--    Ripsnarl must not directly offer these dungeon quests.
+-- ============================================================
+DELETE FROM `creature_queststarter`
+WHERE `id` = 47626
+  AND `quest` IN (27785,27848);
+
+
+-- ============================================================
+-- 4. Vanessa note is Heroic-only
+-- ============================================================
+UPDATE `creature`
+SET `spawnDifficulties` = '2'
+WHERE `guid` = 326853
+  AND `id` = 49564;
+
+
+-- ============================================================
+-- 5. Goblin teleport GameObject script
+-- ============================================================
+UPDATE `gameobject_template`
+SET `ScriptName` = 'go_deadmines_tp'
+WHERE `entry` = 208002;
+
+
+-- ============================================================
+-- 6. Defias Overseer dialogue / AI registration
+-- ============================================================
+DELETE FROM `creature_text`
+WHERE `CreatureID` = 48421;
+
+INSERT INTO `creature_text`
+(
+    `CreatureID`,
+    `GroupID`,
+    `ID`,
+    `Text`,
+    `Type`,
+    `Language`,
+    `Probability`,
+    `Emote`,
+    `Duration`,
+    `Sound`,
+    `BroadcastTextId`,
+    `TextRange`,
+    `comment`
+)
+VALUES
+(48421, 0, 0, 'It''s broken.', 12, 0, 100, 0, 0, 0, 0, 0, 'Defias Overseer - pipe dialogue 1'),
+(48421, 1, 0, 'It''s not broken!', 12, 0, 100, 0, 0, 0, 0, 0, 'Defias Overseer - pipe dialogue 2'),
+(48421, 2, 0, 'Why''s it shooting steam out of the side there, then?', 12, 0, 100, 0, 0, 0, 0, 0, 'Defias Overseer - pipe dialogue 3'),
+(48421, 3, 0, 'That''s the ... pressure release valve.', 12, 0, 100, 0, 0, 0, 0, 0, 'Defias Overseer - pipe dialogue 4'),
+(48421, 4, 0, 'In the middle of the pipe?', 12, 0, 100, 0, 0, 0, 0, 0, 'Defias Overseer - pipe dialogue 5'),
+(48421, 5, 0, 'Er ... backup release valve?', 12, 0, 100, 0, 0, 0, 0, 0, 'Defias Overseer - pipe dialogue 6'),
+(48421, 6, 0, 'We should tell the Admiral.', 12, 0, 100, 0, 0, 0, 0, 0, 'Defias Overseer - pipe dialogue 7'),
+(48421, 7, 0, 'You tell him.', 12, 0, 100, 0, 0, 0, 0, 0, 'Defias Overseer - pipe dialogue 8'),
+(48421, 8, 0, 'No way! He gives me the creeps!', 12, 0, 100, 0, 0, 0, 0, 0, 'Defias Overseer - pipe dialogue 9'),
+(48421, 9, 0, 'I know! The way he looks at you with those hungry eyes. I''m afraid to even turn my back!', 12, 0, 100, 0, 0, 0, 0, 0, 'Defias Overseer - pipe dialogue 10');
+
+UPDATE `creature_template`
+SET `ScriptName` = 'npc_defias_overseer'
+WHERE `entry` = 48421;
+
+
+-- ============================================================
+-- 7. Mine Bunny combat AI - Drunken Haze
+-- ============================================================
+UPDATE `creature_template`
+SET `AIName` = 'SmartAI'
+WHERE `entry` IN (48338, 48351);
+
+DELETE FROM `smart_scripts`
+WHERE `source_type` = 0
+  AND `entryorguid` IN (48338, 48351);
+
+INSERT INTO `smart_scripts`
+(
+    `entryorguid`,
+    `source_type`,
+    `id`,
+    `link`,
+    `event_type`,
+    `event_phase_mask`,
+    `event_chance`,
+    `event_flags`,
+    `event_param1`,
+    `event_param2`,
+    `event_param3`,
+    `event_param4`,
+    `event_param5`,
+    `event_param_string`,
+    `action_type`,
+    `action_param1`,
+    `action_param2`,
+    `action_param3`,
+    `action_param4`,
+    `action_param5`,
+    `action_param6`,
+    `target_type`,
+    `target_param1`,
+    `target_param2`,
+    `target_param3`,
+    `target_x`,
+    `target_y`,
+    `target_z`,
+    `target_o`,
+    `comment`
+)
+VALUES
+(48338,0,0,0,0,0,100,0,2000,4000,7000,10000,0,'',
+ 11,91032,0,0,0,0,0,
+ 2,0,0,0,0,0,0,0,
+ 'Mine Bunny - Cast Drunken Haze'),
+
+(48351,0,0,0,0,0,100,0,2000,4000,7000,10000,0,'',
+ 11,91032,0,0,0,0,0,
+ 2,0,0,0,0,0,0,0,
+ 'Mine Bunny - Cast Drunken Haze');
+
+
+-- ============================================================
+-- 8. Mine Bunny patrols
+--    48338 spawn 319274 = Bunny 1
+--    48351 spawn 319125 = Bunny 2
+-- ============================================================
+UPDATE `creature`
+SET `MovementType` = 2,
+    `spawndist` = 0
+WHERE `guid` IN (319274, 319125);
+
+-- Bunny 2: correct starting height
+UPDATE `creature`
+SET `position_x` = -217.922409,
+    `position_y` = -495.439697,
+    `position_z` = 48.990154,
+    `orientation` = 2.281233
+WHERE `guid` = 319125
+  AND `id` = 48351;
+
+-- Bunny 1: corrected first ground point
+UPDATE `creature`
+SET `position_x` = -195.947937,
+    `position_y` = -501.173187,
+    `position_z` = 53.127834,
+    `orientation` = 3.515090
+WHERE `guid` = 319274
+  AND `id` = 48338;
+
+DELETE FROM `creature_addon`
+WHERE `guid` IN (319274, 319125);
+
+INSERT INTO `creature_addon`
+(
+    `guid`,
+    `path_id`,
+    `mount`,
+    `bytes1`,
+    `bytes2`,
+    `emote`,
+    `aiAnimKit`,
+    `movementAnimKit`,
+    `meleeAnimKit`,
+    `visibilityDistanceType`,
+    `auras`
+)
+VALUES
+(319274, 3192740, 0, 0, 1, 0, 0, 0, 0, 0, '89842'),
+(319125, 3191250, 0, 0, 1, 0, 0, 0, 0, 0, '89842');
+
+DELETE FROM `waypoint_data`
+WHERE `id` IN (3192740, 3191250);
+
+-- Bunny 1 patrol
+INSERT INTO `waypoint_data`
+(
+    `id`,
+    `point`,
+    `position_x`,
+    `position_y`,
+    `position_z`,
+    `orientation`,
+    `delay`,
+    `move_type`,
+    `action`,
+    `action_chance`,
+    `wpguid`
+)
+VALUES
+(3192740, 1, -189.765167, -499.350647, 53.012089, 3.742078, 0, 0, 0, 100, 0),
+(3192740, 2, -194.662170, -506.416382, 53.155178, 0.530578, 0, 0, 0, 100, 0),
+(3192740, 3, -179.990860, -504.032562, 53.719868, 6.213718, 0, 0, 0, 100, 0),
+(3192740, 4, -181.730530, -490.224915, 53.923595, 1.875180, 0, 0, 0, 100, 0);
+
+-- Bunny 2 patrol
+INSERT INTO `waypoint_data`
+(
+    `id`,
+    `point`,
+    `position_x`,
+    `position_y`,
+    `position_z`,
+    `orientation`,
+    `delay`,
+    `move_type`,
+    `action`,
+    `action_chance`,
+    `wpguid`
+)
+VALUES
+(3191250, 1, -217.922409, -495.439697, 48.990154, 2.281233, 0, 0, 0, 100, 0),
+(3191250, 2, -220.670029, -500.620239, 49.584881, 4.794508, 0, 0, 0, 100, 0),
+(3191250, 3, -218.647263, -510.027893, 51.129749, 4.763093, 0, 0, 0, 100, 0),
+(3191250, 4, -204.912201, -509.287567, 51.824902, 0.053846, 0, 0, 0, 100, 0);
+
+
+-- ============================================================
+-- 9. Ripsnarl fog helper visibility
+--    General Purpose Bunny trigger NPCs must be invisible to
+--    normal players.
+--    CREATURE_FLAG_EXTRA_TRIGGER = 128
+-- ============================================================
+UPDATE `creature_template`
+SET `flags_extra` = (`flags_extra` | 128)
+WHERE `entry` IN (47242, 47677);
+
+
+COMMIT;

--- a/src/server/scripts/EasternKingdoms/Deadmines/boss_admiral_ripsnarl.cpp
+++ b/src/server/scripts/EasternKingdoms/Deadmines/boss_admiral_ripsnarl.cpp
@@ -1,8 +1,19 @@
 /*
-*
-* Copyright (C) 2012-2014 Cerber Project <https://bitbucket.org/mojitoice/>
-*
-*/
+ * 2026 BFA-HavenCore
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include "ScriptMgr.h"
 #include "deadmines.h"
@@ -165,13 +176,28 @@ public:
             if (!me)
                 return;
 
+            // Ripsnarl is explicitly hidden during each fog phase with
+            // SetVisible(false). If he dies before EVENT_SHOW_UP restores him,
+            // the corpse inherits that hidden state and normal players cannot
+            // see or loot it (GM visibility bypasses this).
+            //
+            // Always restore normal visibility/selectability before processing
+            // boss death so the corpse is visible and lootable.
+            me->SetVisible(true);
+            me->RemoveUnitFlag(UnitFlags(UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE | UNIT_FLAG_PACIFIED));
+            phase = PHASE_NORMAL;
+
             _JustDied();
             summons.DespawnAll();
             Talk(SAY_DEATH);
             instance->SendEncounterUnit(ENCOUNTER_FRAME_DISENGAGE, me);
             RemoveAuraFromMap();
             RemoveFog();
-            me->SummonCreature(NPC_CAPTAIN_COOKIE, CookieSpawn);
+
+            // Captain Cookie (47739) already has a static Deadmines spawn in the DB.
+            // His own AI keeps him inactive until Ripsnarl is DONE, then activates
+            // when players approach. Summoning another Cookie here creates a
+            // duplicate boss encounter.
         }
 
         void SetData(uint32 /*uiI*/, uint32 uiValue) override
@@ -219,7 +245,7 @@ public:
             if (!me)
                 return;
 
-            phase = PHASE_FOG;
+            phase = apply ? PHASE_FOG : PHASE_NORMAL;
             std::list<Creature*> creature_list;
             me->GetCreatureListWithEntryInGrid(creature_list, NPC_GENERAL_PURPOSE_BUNNY_JMF2, 100.0f);
 
@@ -276,10 +302,16 @@ public:
             if (!me || !instance)
                 return;
 
-            if (!UpdateVictim())
+            // During the fog phase Ripsnarl becomes invisible/non-attackable and can
+            // temporarily lose his victim. Events must continue ticking or
+            // EVENT_SHOW_UP / EVENT_SUMMON_VAPOR will freeze indefinitely.
+            bool hasVictim = UpdateVictim();
+
+            if (!hasVictim && phase == PHASE_NORMAL)
                 return;
 
-            DoMeleeAttackIfReady();
+            if (hasVictim)
+                DoMeleeAttackIfReady();
 
             events.Update(uiDiff);
 
@@ -325,7 +357,11 @@ public:
                         break;
 
                     case EVENT_UPDATE_FOG:
-                        instance->DoCastSpellOnPlayers(SPELL_FOG_AURA);
+                        if (phase == PHASE_FOG)
+                        {
+                            instance->DoCastSpellOnPlayers(SPELL_FOG_AURA);
+                            events.ScheduleEvent(EVENT_UPDATE_FOG, 1000);
+                        }
                         break;
 
                     case EVENT_GO_FOR_THROAT:

--- a/src/server/scripts/EasternKingdoms/Deadmines/boss_foe_reaper_5000.cpp
+++ b/src/server/scripts/EasternKingdoms/Deadmines/boss_foe_reaper_5000.cpp
@@ -17,8 +17,23 @@
 
 #include "ScriptMgr.h"
 #include "deadmines.h"
+#include "ObjectMgr.h"
+#include "Player.h"
+#include "QuestDef.h"
 #include "Object.h"
 #include "MapManager.h"
+#include <set>
+
+enum DeadminesHordeQuest
+{
+    QUEST_NOT_QUITE_THERE = 27847,
+    NPC_MISS_MAYHEM = 46902
+};
+
+const Position MissMayhemSpawn =
+{
+    -207.508926f, -551.236877f, 51.229359f, 3.911717f
+};
 
 enum eSpell
 {
@@ -127,6 +142,7 @@ public:
         ObjectGuid prototypeGUID;
 
         bool Below;
+        std::set<ObjectGuid> _notQuiteThereOfferedTo;
 
         void Reset() override
         {
@@ -140,6 +156,27 @@ public:
             me->SetPowerType(POWER_ENERGY);
             Step = 0;
             Below = false;
+            _notQuiteThereOfferedTo.clear();
+
+            // Horde questgiver for 27847.
+            //
+            // Do not reuse an older Miss Mayhem summon. Older versions of this
+            // script created her at Foe Reaper's position and that summon can
+            // survive an encounter reset because she is intentionally excluded
+            // from BossAI's SummonList. Remove it and create a clean summon at
+            // the fixed quest location every reset.
+            if (Creature* mayhem = me->FindNearestCreature(NPC_MISS_MAYHEM, 150.0f, true))
+                mayhem->DespawnOrUnsummon();
+
+            if (Creature* mayhem = me->SummonCreature(
+                NPC_MISS_MAYHEM,
+                MissMayhemSpawn,
+                TEMPSUMMON_MANUAL_DESPAWN))
+            {
+                mayhem->StopMoving();
+                mayhem->GetMotionMaster()->Clear();
+                mayhem->SetHomePosition(MissMayhemSpawn);
+            }
 
             instance->SendEncounterUnit(ENCOUNTER_FRAME_DISENGAGE, me);
 
@@ -160,6 +197,43 @@ public:
                     prototypeGUID = prototype->GetGUID();
                 }
             }
+        }
+
+        void MoveInLineOfSight(Unit* who) override
+        {
+            if (Player* player = who ? who->ToPlayer() : nullptr)
+            {
+                if (player->GetTeam() == HORDE &&
+                    player->GetQuestStatus(QUEST_NOT_QUITE_THERE) == QUEST_STATUS_NONE &&
+                    _notQuiteThereOfferedTo.find(player->GetGUID()) == _notQuiteThereOfferedTo.end())
+                {
+                    if (Creature* mayhem = me->FindNearestCreature(NPC_MISS_MAYHEM, 150.0f, true))
+                    {
+                        if (player->IsWithinDistInMap(mayhem, 15.0f))
+                        {
+                            if (Quest const* quest = sObjectMgr->GetQuestTemplate(QUEST_NOT_QUITE_THERE))
+                            {
+                                if (player->CanTakeQuest(quest, false))
+                                {
+                                    player->PrepareQuestMenu(mayhem->GetGUID());
+                                    player->SendPreparedQuest(mayhem);
+                                    _notQuiteThereOfferedTo.insert(player->GetGUID());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            BossAI::MoveInLineOfSight(who);
+        }
+
+        void JustSummoned(Creature* summoned) override
+        {
+            if (summoned->GetEntry() == NPC_MISS_MAYHEM)
+                return;
+
+            BossAI::JustSummoned(summoned);
         }
 
         void EnterCombat(Unit* /*who*/) override

--- a/src/server/scripts/EasternKingdoms/Deadmines/boss_helix_gearbreaker.cpp
+++ b/src/server/scripts/EasternKingdoms/Deadmines/boss_helix_gearbreaker.cpp
@@ -17,7 +17,17 @@
 
 #include "ScriptMgr.h"
 #include "deadmines.h"
+#include "ObjectMgr.h"
+#include "Player.h"
+#include "QuestDef.h"
 #include "Vehicle.h"
+#include <set>
+
+enum DeadminesHordeQuest
+{
+    QUEST_TRAITORS = 27844,
+    NPC_SLINKY_SHARPSHIV = 46906
+};
 
 enum eSpels
 {
@@ -49,6 +59,11 @@ const Position OafPos[2] =
 {
     {-289.809f, -527.215f, 49.8021f, 0},
     {-289.587f, -489.575f, 49.9126f, 0},
+};
+
+const Position SlinkySpawn =
+{
+    -273.8260f, -477.7030f, 49.2435f, 1.04438f
 };
 
 const Position CrewSpawn[] =
@@ -101,6 +116,7 @@ public:
         uint32 uiTimer;
         uint32 numberKillMineRat;
         Creature* oaf;
+        std::set<ObjectGuid> _traitorsOfferedTo;
 
         void Reset() override
         {
@@ -108,6 +124,7 @@ public:
             Phase = 1;
             uiTimer = 2000;
             numberKillMineRat = 0;
+            _traitorsOfferedTo.clear();
 
             if (!me)
                 return;
@@ -117,6 +134,59 @@ public:
             me->AddUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
             summons.DespawnAll();
             OafSupport();
+
+            // Slinky Sharpshiv is Horde-only. Do not summon her from Reset(),
+            // because boss/grid reset can run before the first player enters the
+            // instance and the instance faction has been established.
+        }
+
+        Creature* EnsureSlinkyForHorde(Player* player)
+        {
+            if (!player || player->GetTeam() != HORDE)
+                return nullptr;
+
+            if (Creature* slinky = me->FindNearestCreature(NPC_SLINKY_SHARPSHIV, 150.0f, true))
+                return slinky;
+
+            // Spawn at the pre-Helix doorway as soon as a Horde player enters
+            // Helix's loaded grid. Alliance players never cause this summon.
+            return me->SummonCreature(
+                NPC_SLINKY_SHARPSHIV,
+                SlinkySpawn,
+                TEMPSUMMON_MANUAL_DESPAWN);
+        }
+
+        void MoveInLineOfSight(Unit* who) override
+        {
+            if (Player* player = who ? who->ToPlayer() : nullptr)
+            {
+                // If an old/pre-existing summon somehow survived into an
+                // Alliance run, remove it immediately.
+                if (player->GetTeam() == ALLIANCE)
+                {
+                    if (Creature* slinky = me->FindNearestCreature(NPC_SLINKY_SHARPSHIV, 150.0f, true))
+                        slinky->DespawnOrUnsummon();
+                }
+                else if (Creature* slinky = EnsureSlinkyForHorde(player))
+                {
+                    if (player->GetQuestStatus(QUEST_TRAITORS) == QUEST_STATUS_NONE &&
+                        _traitorsOfferedTo.find(player->GetGUID()) == _traitorsOfferedTo.end() &&
+                        player->IsWithinDistInMap(slinky, 15.0f))
+                    {
+                        if (Quest const* quest = sObjectMgr->GetQuestTemplate(QUEST_TRAITORS))
+                        {
+                            if (player->CanTakeQuest(quest, false))
+                            {
+                                player->PrepareQuestMenu(slinky->GetGUID());
+                                player->SendPreparedQuest(slinky);
+                                _traitorsOfferedTo.insert(player->GetGUID());
+                            }
+                        }
+                    }
+                }
+            }
+
+            BossAI::MoveInLineOfSight(who);
         }
 
         void EnterCombat(Unit* /*pWho*/) override
@@ -160,6 +230,9 @@ public:
 
         void JustSummoned(Creature* summoned) override
         {
+            if (summoned->GetEntry() == NPC_SLINKY_SHARPSHIV)
+                return;
+
             summons.Summon(summoned);
         }
 

--- a/src/server/scripts/EasternKingdoms/Deadmines/deadmines.cpp
+++ b/src/server/scripts/EasternKingdoms/Deadmines/deadmines.cpp
@@ -340,6 +340,117 @@ public:
     };
 };
 
+
+enum DefiasOverseerData
+{
+    NPC_DEFIAS_OVERSEER            = 48421,
+    SPAWN_OVERSEER_DIALOGUE_MASTER = 319095,
+    EVENT_OVERSEER_DIALOGUE        = 1,
+    MAX_OVERSEER_DIALOGUE_LINES    = 10
+};
+
+Position const OverseerPipePosition = { -310.87f, -608.34f, 49.20f };
+
+class npc_defias_overseer : public CreatureScript
+{
+public:
+    npc_defias_overseer() : CreatureScript("npc_defias_overseer") { }
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return new npc_defias_overseerAI(creature);
+    }
+
+    struct npc_defias_overseerAI : public ScriptedAI
+    {
+        npc_defias_overseerAI(Creature* creature) : ScriptedAI(creature), _line(0) { }
+
+        void Reset() override
+        {
+            _events.Reset();
+            _line = 0;
+
+            me->SetFacingTo(me->GetAngle(OverseerPipePosition.GetPositionX(), OverseerPipePosition.GetPositionY()));
+
+            if (me->GetSpawnId() == SPAWN_OVERSEER_DIALOGUE_MASTER)
+                _events.ScheduleEvent(EVENT_OVERSEER_DIALOGUE, 4000);
+        }
+
+        void EnterCombat(Unit* /*who*/) override
+        {
+            _events.Reset();
+        }
+
+        void JustReachedHome() override
+        {
+            Reset();
+        }
+
+        void UpdateAI(uint32 diff) override
+        {
+            _events.Update(diff);
+
+            while (uint32 eventId = _events.ExecuteEvent())
+            {
+                if (eventId != EVENT_OVERSEER_DIALOGUE)
+                    continue;
+
+                Creature* partner = nullptr;
+                std::list<Creature*> overseers;
+                GetCreatureListWithEntryInGrid(overseers, me, NPC_DEFIAS_OVERSEER, 30.0f);
+
+                for (Creature* overseer : overseers)
+                {
+                    if (overseer && overseer != me && overseer->IsAlive())
+                    {
+                        partner = overseer;
+                        break;
+                    }
+                }
+
+                if (!partner)
+                {
+                    _events.ScheduleEvent(EVENT_OVERSEER_DIALOGUE, 5000);
+                    continue;
+                }
+
+                me->SetFacingTo(me->GetAngle(OverseerPipePosition.GetPositionX(), OverseerPipePosition.GetPositionY()));
+                partner->SetFacingTo(partner->GetAngle(OverseerPipePosition.GetPositionX(), OverseerPipePosition.GetPositionY()));
+
+                if (me->IsInCombat() || partner->IsInCombat())
+                {
+                    _events.ScheduleEvent(EVENT_OVERSEER_DIALOGUE, 5000);
+                    continue;
+                }
+
+                if ((_line % 2) == 0)
+                    Talk(_line);
+                else
+                    partner->AI()->Talk(_line);
+
+                ++_line;
+
+                if (_line < MAX_OVERSEER_DIALOGUE_LINES)
+                    _events.ScheduleEvent(EVENT_OVERSEER_DIALOGUE, 3500);
+                else
+                {
+                    _line = 0;
+                    _events.ScheduleEvent(EVENT_OVERSEER_DIALOGUE, 90000);
+                }
+            }
+
+            if (!UpdateVictim())
+                return;
+
+            DoMeleeAttackIfReady();
+        }
+
+    private:
+        EventMap _events;
+        uint8 _line;
+    };
+};
+
 class npc_goblin_engineer : public CreatureScript
 {
 public:
@@ -1133,6 +1244,7 @@ void AddSC_deadmines()
     new npc_deadmines_bird();
     //new go_heavy_door();
     new npc_goblin_engineer();
+    new npc_defias_overseer();
     new go_deadmines_tp();
     new npc_mining_powder();
 

--- a/src/server/scripts/EasternKingdoms/Deadmines/instance_deadmines.cpp
+++ b/src/server/scripts/EasternKingdoms/Deadmines/instance_deadmines.cpp
@@ -18,8 +18,51 @@
 #include "ScriptMgr.h"
 #include "deadmines.h"
 #include "GameObject.h"
+#include "Player.h"
+#include "Creature.h"
 
 #define NOTE_TEXT "A note falls to the floor!"
+
+namespace
+{
+    // Faction-specific Deadmines entrance/support spawns.
+    // Keep both factions in the DB and remove the wrong-faction set per instance,
+    // matching the runtime filtering approach used by Ragefire Chasm.
+    uint32 const HordeEntranceSpawns[] =
+    {
+        319267, // Kagtha (46889)
+        319264, // Shattered Hand Assassin (46890)
+        319269, // Shattered Hand Assassin (46890)
+
+        319268, // Mayhem Reaper Prototype (46903)
+        319270,
+        319373,
+        319374
+    };
+
+    uint32 const AllianceEntranceSpawns[] =
+    {
+        327276, // Lieutenant Horatio Laine (46612)
+        327270, // Quartermaster Lewis (491)
+
+        327265, // Crime Scene Alarm-o-Bot (46613)
+        327267,
+        327268,
+        327269,
+        327271,
+
+        327266, // Stormwind Defender (50595)
+        327272,
+        327274,
+        327275,
+        327277,
+
+        327263, // Stormwind Investigator (46614)
+        327264,
+        327273,
+        327278
+    };
+}
 
 Position const NoteSpawn = {-74.36111f, -820.0139f, 40.67145f, 4.014257f};
 
@@ -30,50 +73,74 @@ public:
 
     struct instance_deadmines_InstanceMapScript : public InstanceScript
     {
-        instance_deadmines_InstanceMapScript(InstanceMap* map) : InstanceScript(map)
+        instance_deadmines_InstanceMapScript(InstanceMap* map)
+            : InstanceScript(map), TeamInInstance(TEAM_NEUTRAL), TeamInitialized(false), IsVisionOfThePastRunning(false)
         {
             SetBossNumber(MAX_BOSSES);
-            IsVisionOfThePastRunning = false;
         };
+
+        void OnPlayerEnter(Player* player) override
+        {
+            if (!player || TeamInitialized)
+                return;
+
+            TeamInInstance = player->GetTeam();
+            TeamInitialized = true;
+
+            // Remove wrong-faction creatures already loaded in the instance.
+            // OnCreatureCreate below handles creatures from grids loaded later.
+            if (TeamInInstance == ALLIANCE)
+            {
+                for (uint32 spawnId : HordeEntranceSpawns)
+                    DespawnSpawn(spawnId);
+            }
+            else if (TeamInInstance == HORDE)
+            {
+                for (uint32 spawnId : AllianceEntranceSpawns)
+                    DespawnSpawn(spawnId);
+            }
+        }
 
         void OnCreatureCreate(Creature* creature) override
         {
-            Map::PlayerList const &players = instance->GetPlayers();
-            if (!players.isEmpty())
+            if (!creature)
+                return;
+
+            // The old implementation converted wrong-faction NPCs into unrelated
+            // entries (including GM WAYPOINT). Do not mutate templates. Despawn
+            // the wrong faction instead, as done by the RFC faction fix.
+            if (TeamInitialized)
             {
-                if (Player* player = players.begin()->GetSource())
-                    TeamInInstance = player->GetTeam();
+                if (TeamInInstance == ALLIANCE)
+                {
+                    switch (creature->GetEntry())
+                    {
+                        case 46889: // Kagtha
+                        case 46890: // Shattered Hand Assassin
+                        case 46902: // Miss Mayhem
+                        case 46903: // Mayhem Reaper Prototype
+                        case 46906: // Slinky Sharpshiv
+                            creature->DespawnOrUnsummon();
+                            return;
+                    }
+                }
+                else if (TeamInInstance == HORDE)
+                {
+                    switch (creature->GetEntry())
+                    {
+                        case 46612: // Lieutenant Horatio Laine
+                        case 491:   // Quartermaster Lewis
+                        case 46613: // Crime Scene Alarm-o-Bot
+                        case 46614: // Stormwind Investigator
+                        case 50595: // Stormwind Defender
+                            creature->DespawnOrUnsummon();
+                            return;
+                    }
+                }
             }
+
             switch (creature->GetEntry())
             {
-                case 46889: // Kagtha
-                    if (TeamInInstance == ALLIANCE)
-                        creature->UpdateEntry(42308); // Lieutenant Horatio Laine
-                    break;
-                case 46902: // Miss Mayhem
-                    if (TeamInInstance == ALLIANCE)
-                        creature->UpdateEntry(491); // Quartermaster Lewis <Quartermaster>
-                    break;
-                case 46903: // Mayhem Reaper Prototype
-                    if (TeamInInstance == ALLIANCE)
-                        creature->UpdateEntry(1); // GM WAYPOINT
-                    break;
-                case 46906: // Slinky Sharpshiv
-                    if (TeamInInstance == ALLIANCE)
-                        creature->UpdateEntry(46612); // Lieutenant Horatio Laine
-                    break;
-                case 46613: // Crime Scene Alarm-O-Bot
-                    if (TeamInInstance == HORDE)
-                        creature->UpdateEntry(1); // GM WAYPOINT
-                    break;
-                case 50595: // Stormwind Defender
-                    if (TeamInInstance == HORDE)
-                        creature->UpdateEntry(46890); // Shattered Hand Assassin
-                    break;
-                case 46614: // Stormwind Investigator
-                    if (TeamInInstance == HORDE)
-                        creature->UpdateEntry(1); // GM WAYPOINT
-                    break;
                 case NPC_VANESSA_VANCLEEF:
                     uiVanessa = creature->GetGUID();
                     break;
@@ -357,7 +424,17 @@ public:
         ObjectGuid EdwinVanCleefGUID;
         ObjectGuid VanessaVanCleefGUID;
 
+        void DespawnSpawn(uint32 spawnId)
+        {
+            auto bounds = instance->GetCreatureBySpawnIdStore().equal_range(spawnId);
+            for (auto itr = bounds.first; itr != bounds.second; ++itr)
+                if (Creature* creature = itr->second)
+                    if (creature->IsInWorld())
+                        creature->DespawnOrUnsummon();
+        }
+
         uint32 TeamInInstance;
+        bool TeamInitialized;
         bool IsVisionOfThePastRunning;
     };
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

This PR performs a broad repair pass on **The Deadmines (Map 36)** for Battle for Azeroth 8.3.7, covering encounter behavior, faction-specific dungeon content, dungeon quest flow, NPC presentation, movement, loot difficulty separation, and several dungeon-specific database issues.

### Summary of fixes

#### Faction-specific entrance and quest NPC handling
The Deadmines contained overlapping Alliance and Horde support NPCs in the same instance.

The instance script now filters the incorrect faction's NPCs instead of converting them into unrelated creature entries.

This includes:
- Horde-only NPCs such as Kagtha, Shattered Hand Assassins, Mayhem Reaper Prototypes, Miss Mayhem, and Slinky Sharpshiv.
- Alliance-only NPCs such as Lieutenant Horatio Laine, Crime Scene Alarm-o-Bots, Stormwind Investigators, Stormwind Defenders, and Quartermaster Lewis.
- Slinky Sharpshiv is now spawned only for Horde players and cannot appear during an Alliance run.

#### Horde Deadmines quest chain
The Horde dungeon quest chain was incomplete because Slinky Sharpshiv and Miss Mayhem were not present in the database and their quests were therefore unavailable during normal progression.

The following quest flow has been restored:
- `27842 - Only the Beginning`
- `27844 - Traitors!!!`
- `27847 - Not Quite There`
- `27848 - Good Intentions...Poor Execution`
- `27850 - The Defias Kingpin`

Fixes include:
- Slinky Sharpshiv spawning at the appropriate pre-Helix location for Horde players.
- Automatic quest presentation when approaching Slinky.
- Slinky no longer appearing during Alliance runs.
- Miss Mayhem spawning near the Foe Reaper encounter at a corrected accessible position.
- Automatic quest presentation when approaching Miss Mayhem.
- Miss Mayhem persists correctly through the Foe Reaper encounter.
- Incorrect Ripsnarl queststarter relations were removed from the database.
- Kagtha correctly handles the Ripsnarl and Cookie portions of the chain.

#### Defias Overseer scene
The Defias Overseer scene near the damaged pipe was incomplete.

The fix adds:
- The missing Defias Overseer conversation.
- Correct creature script registration.
- The full multi-line dialogue sequence between the Overseers.
- Corrected positioning so the scene occurs in the intended location.

#### Mine Bunny
The two Mine Bunny NPCs were not behaving as intended.

The fix restores:
- Hostile combat behavior.
- Periodic use of `Drunken Haze (91032)`.
- Their vehicle/aura setup.
- Individual patrol paths.
- Corrected starting positions and waypoint placement so they remain on valid dungeon geometry instead of appearing at incorrect elevations or locations.

#### Ambient rat clipping
Several ambient rats used an excessive random movement radius and could wander through nearby walls.

Their movement radius has been reduced so they remain within the surrounding dungeon geometry.

#### Goblin teleport
The Deadmines Goblin teleport GameObject was missing its required script assignment.

The database now assigns:
- `go_deadmines_tp`

to GameObject entry `208002`.

#### Heroic loot appearing on Normal difficulty
Several boss loot templates contained Heroic items using Normal loot mode.

The affected items are now restricted to Heroic loot mode for:
- Glubtok
- Helix Gearbreaker
- Foe Reaper 5000
- Admiral Ripsnarl
- Captain Cookie

This prevents Heroic-only items from dropping during Normal runs.

#### A Note From Vanessa
`A Note From Vanessa (49564)` was available in Normal difficulty and allowed the Heroic Vanessa nightmare sequence to be started during a Normal run.

The spawn is now restricted to Heroic difficulty only.

#### Admiral Ripsnarl
Several encounter issues were corrected:

- Ripsnarl's fog phase could stall because encounter events stopped processing after he became invisible and temporarily lost his victim.
- Fog was not being refreshed during the full fog phase.
- Fog phases now continue correctly at the intended health thresholds.
- Vapor activity continues while Ripsnarl is hidden.
- Ripsnarl correctly becomes visible and attackable again after each fog phase.
- Fog cleanup occurs correctly when the encounter ends.
- General Purpose Bunny helper creatures used by the fog encounter are now marked as trigger creatures and no longer appear as visible NPCs.
- A duplicate Captain Cookie could be created after Ripsnarl died because Cookie already existed as a database spawn and was also being summoned from the boss script. The duplicate summon was removed.
- Ripsnarl could die while still carrying hidden/non-selectable fog-phase state, causing his corpse to be invisible and unlootable to normal players while still visible to GMs. Death cleanup now restores visibility and clears the fog-phase unit flags before completing boss death handling.

#### Captain Cookie
Captain Cookie now transitions correctly after Admiral Ripsnarl is defeated without producing a duplicate spawn.

The existing dungeon behavior is preserved:
- Cookie is present near the cabin.
- Approaching him starts his movement toward the deck.
- The cauldron encounter begins normally.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #11 
- Closes #10 
- Closes #12 
- 
- Fixes mixed Alliance/Horde Deadmines NPCs appearing in the same dungeon instance.
- Fixes Horde Deadmines dungeon quests being unavailable because required quest NPCs were missing.
- Fixes Slinky Sharpshiv appearing in Alliance instances.
- Fixes incorrect Ripsnarl queststarter relations.
- Fixes incomplete Defias Overseer scene.
- Fixes Mine Bunny combat behavior and patrol movement.
- Fixes ambient rats clipping through dungeon geometry.
- Fixes missing Goblin teleport script assignment.
- Fixes Heroic boss loot appearing in Normal Deadmines.
- Fixes Vanessa's Heroic-only nightmare trigger being available on Normal difficulty.
- Fixes Admiral Ripsnarl fog phases stalling.
- Fixes Ripsnarl fog not remaining active for the complete phase.
- Fixes visible General Purpose Bunny helper creatures during the Ripsnarl encounter.
- Fixes duplicate Captain Cookie after Admiral Ripsnarl.
- Fixes Admiral Ripsnarl's corpse becoming invisible/unlootable when killed during fog-related state.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Behavior was compared against historical/public Deadmines documentation and player reference material, including Wowhead and Warcraft Wiki information covering:
- Horde Deadmines dungeon quests and quest NPCs.
- Slinky Sharpshiv and Miss Mayhem quest progression.
- Admiral Ripsnarl's fog phases.
- Captain Cookie's post-Ripsnarl encounter behavior.
- Heroic-only Vanessa nightmare content.
- Mine Bunny behavior in the dungeon.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Testing was performed on a Windows development environment using a BFA 8.3.7 client.

The dungeon was repeatedly reset and run from the beginning during testing.

Verified in-game:
- Horde entrance NPCs appear correctly without the Alliance set.
- Alliance entrance NPCs appear correctly without the Horde set.
- Slinky Sharpshiv appears for Horde players near the Helix section.
- Slinky Sharpshiv does not appear for Alliance players.
- `Traitors!!!` can be accepted and completed.
- Miss Mayhem appears at the corrected Foe Reaper location.
- `Not Quite There` can be accepted, completed, and turned in.
- Kagtha correctly handles the Admiral Ripsnarl quest.
- `The Defias Kingpin` is offered after the Ripsnarl quest is completed.
- Captain Cookie can be defeated and the final Horde quest completed.
- No additional Horde dungeon quest is incorrectly offered after the chain is complete.
- Defias Overseer dialogue plays correctly.
- Mine Bunnies are hostile, patrol correctly, and use Drunken Haze.
- Ambient rats remain within valid dungeon geometry.
- Heroic-only loot no longer appears in Normal boss loot.
- Vanessa's note is not available during a Normal run.
- Ripsnarl enters and exits each fog phase correctly.
- Fog remains active throughout the hidden phase.
- Vapors continue to function during fog.
- Fog helper trigger NPCs are not visible to normal players.
- Only one Captain Cookie exists after Ripsnarl dies.
- Ripsnarl's corpse remains visible and lootable with GM mode disabled.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Apply the included Deadmines world database update and rebuild the server with the modified Deadmines scripts.
2. Create or use a Horde character of appropriate Deadmines level and enter Normal Deadmines with GM mode disabled.
3. Verify only Horde entrance/support NPCs are present.
4. Progress through the dungeon and verify the Horde quest chain:
   - Accept `27842 - Only the Beginning`.
   - Kill Glubtok and continue.
   - Verify Slinky Sharpshiv appears near the pre-Helix doorway.
   - Accept and complete `27844 - Traitors!!!`.
   - Verify Miss Mayhem appears near the Foe Reaper section.
   - Accept and complete `27847 - Not Quite There`.
   - Continue to Kagtha and complete `27848 - Good Intentions...Poor Execution` after killing Admiral Ripsnarl.
   - Verify Kagtha offers `27850 - The Defias Kingpin`.
   - Kill Captain Cookie and complete the final quest.
5. Verify the Defias Overseer pipe conversation occurs and both Overseers are positioned correctly.
6. Verify both Mine Bunnies patrol their assigned routes, are hostile, and cast `Drunken Haze (91032)`.
7. Observe the ambient rats and confirm they no longer wander through nearby walls.
8. Verify the Goblin teleport GameObject functions through `go_deadmines_tp`.
9. Kill each Normal boss and verify Heroic-only items do not appear in Normal loot.
10. During Admiral Ripsnarl:
    - Verify fog occurs at the expected health thresholds.
    - Verify Ripsnarl disappears during fog.
    - Verify fog remains active while he is hidden.
    - Verify Vapors continue spawning/behaving during fog.
    - Verify Ripsnarl returns and becomes attackable after each phase.
    - Verify no visible helper/bunny NPCs appear.
    - Kill Ripsnarl and verify his corpse remains visible and lootable with GM mode disabled.
    - Verify only one Captain Cookie is present after the kill.
11. Complete the Cookie encounter and verify normal dungeon progression.
12. Reset the instance and repeat the run with an Alliance character.
13. Verify only Alliance entrance/support NPCs are present.
14. Verify Horde-only NPCs such as Kagtha, Mayhem Reaper Prototypes, Miss Mayhem, and Slinky Sharpshiv do not appear.
15. Run Normal difficulty to the end and verify `A Note From Vanessa` does not appear.
16. Run Heroic difficulty and verify Vanessa's note/nightmare content remains available as expected.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Additional community testing on both Alliance and Horde is welcome.
- [ ] Heroic Deadmines should receive a complete regression pass to ensure the Normal-mode fixes do not affect Vanessa's Heroic nightmare sequence.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test BFA-HavenCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub.

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).**

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
