### PR TITLE
CPP: Fix General Chat and Local Defense Channel Changes

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -938,8 +938,9 @@ void WorldObject::ProcessPositionDataChanged(PositionFullTerrainStatus const& da
 {
     m_zoneId = m_areaId = data.areaId;
     if (AreaTableEntry const* area = sAreaTableStore.LookupEntry(m_areaId))
-        if (area->ID)
-            m_zoneId = area->ID;
+        if (area->ParentAreaID)
+            m_zoneId = area->ParentAreaID;
+
     m_staticFloorZ = data.floorZ;
 }
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

This pull request fixes incorrect zone resolution when a `WorldObject` enters or moves through a sub-zone.

The affected code path is `WorldObject::ProcessPositionDataChanged()` in `Object.cpp`. Previously, the function initialized both `m_zoneId` and `m_areaId` from the resolved `data.areaId`, then attempted to update `m_zoneId` using `area->ID`:

```cpp
m_zoneId = m_areaId = data.areaId;
if (AreaTableEntry const* area = sAreaTableStore.LookupEntry(m_areaId))
    if (area->ID)
        m_zoneId = area->ID;
```

Because `area->ID` is the same area identifier already stored in `m_areaId`, this caused the object's zone ID to become the current sub-zone ID instead of the parent zone ID.

For example, when moving through Elwynn Forest:

- `Elwynn Forest` should remain the player's zone.
- `Goldshire`, `Fargodeep Mine`, and `The Stonefield Farm` should be treated as areas/sub-zones within Elwynn Forest.
- The previous behavior caused `m_zoneId` to change to those sub-zone IDs.

This incorrect zone state affected systems that rely on `GetZoneId()`, including zone-dependent chat channels. As a result, General and LocalDefense channels changed when crossing sub-zone boundaries, producing channels such as:

- `General - Goldshire`
- `General - Fargodeep Mine`
- `General - The Stonefield Farm`

instead of remaining in:

- `General - Elwynn Forest`

The fix changes `ProcessPositionDataChanged()` to use `AreaTableEntry::ParentAreaID` when one exists:

```cpp
m_zoneId = m_areaId = data.areaId;
if (AreaTableEntry const* area = sAreaTableStore.LookupEntry(m_areaId))
    if (area->ParentAreaID)
        m_zoneId = area->ParentAreaID;
```

This matches the existing zone-resolution behavior already used by `Map::GetZoneId()` and `Map::GetZoneAndAreaId()`, which resolve sub-zones to their parent zone while preserving the actual sub-zone in `areaId`.

With this change:

- `m_areaId` continues to represent the current area/sub-zone.
- `m_zoneId` correctly represents the parent zone when applicable.
- Zone-dependent systems receive the correct zone ID.
- General chat no longer changes when moving between sub-zones within the same zone.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #466 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The fix is based on consistency with the existing core zone-resolution logic:

- `Map::GetZoneId()` already returns `ParentAreaID` when the resolved area belongs to a parent zone.
- `Map::GetZoneAndAreaId()` already preserves the current area in `areaid` while resolving `zoneid` to `ParentAreaID`.

`WorldObject::ProcessPositionDataChanged()` was inconsistent with those functions because it reassigned `m_zoneId` to `area->ID` rather than `area->ParentAreaID`.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Testing was performed in-game using the reproduction path from issue #466.

Before the fix:
- Moving from Elwynn Forest into Goldshire changed General to `General - Goldshire`.
- Moving into Fargodeep Mine changed General to `General - Fargodeep Mine`.
- Moving into The Stonefield Farm changed General to `General - The Stonefield Farm`.
- LocalDefense changed in the same way.

After the fix:
- The player still enters the correct sub-zone/area.
- General remains `General - Elwynn Forest`.
- The incorrect sub-zone channel switching no longer occurs.
- The fix was confirmed working in-game.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Log in with an Alliance character in Elwynn Forest.
2. Confirm the character is joined to `General - Elwynn Forest`.
3. Move into Goldshire.
4. Verify the player's area/sub-zone changes to Goldshire, but General remains `General - Elwynn Forest`.
5. Move back into the surrounding Elwynn Forest area.
6. Travel to Fargodeep Mine.
7. Enter Fargodeep Mine and verify General remains `General - Elwynn Forest`.
8. Travel to The Stonefield Farm and verify General still remains `General - Elwynn Forest`.
9. Confirm LocalDefense no longer incorrectly changes to sub-zone-specific channels during these transitions.
10. Repeat the same type of test in another zone containing multiple sub-zones to confirm that `GetZoneId()` remains the parent zone while `GetAreaId()` continues to reflect the current sub-zone.

Expected result:
- `GetAreaId()` changes as the player moves between sub-zones.
- `GetZoneId()` remains the parent zone unless the player actually crosses into a different zone.
- Zone-dependent chat channels only change on real zone transitions.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] No known issues observed during testing.
- [ ] Additional regression testing in zones with special PvP, sanctuary, city, or phased area behavior is welcome.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test BFA-HavenCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub.

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).**

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
