### PR TITLE
SQL: Fix Tracking of Skinnable Creatures

### DIFF
--- a/sql/updates/world/2026_09_06_00_Skinning_Tracking_Issue_Fix.sql
+++ b/sql/updates/world/2026_09_06_00_Skinning_Tracking_Issue_Fix.sql
@@ -1,0 +1,3 @@
+UPDATE `creature_template`
+SET `unit_flags` = `unit_flags` - 67108864
+WHERE (`unit_flags` & 67108864) = 67108864;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->

This PR fixes an issue with the Skinning profession where learning Skinning caused living creatures that were flagged as skinnable to appear as tracking dots on the minimap.

The problem was traced to `UNIT_FLAG_SKINNABLE` (`0x04000000` / `67108864`) being stored directly in `creature_template.unit_flags` for a very large number of creature templates.

`UNIT_FLAG_SKINNABLE` is not intended to be a permanent template state for normal living creatures. The core already applies the skinnable flag dynamically when an eligible creature dies, has valid skinning loot, and reaches the proper corpse/loot state.

When the flag is present directly on a living creature template, the client interprets that creature as being currently skinnable. Characters with Skinning then see those creatures on the minimap, producing behavior similar to Hunter creature tracking.

The fix removes only the `UNIT_FLAG_SKINNABLE` bit from affected `creature_template.unit_flags` values while preserving every other unit flag already present on those creatures.

The database correction is:

```sql
UPDATE `creature_template`
SET `unit_flags` = `unit_flags` - 67108864
WHERE (`unit_flags` & 67108864) = 67108864;
```

This is intentionally written as a targeted bit cleanup rather than overwriting the entire `unit_flags` field.

For example:

- Stonetusk Boar (entry 113) had `unit_flags = 67108864`
  - After cleanup: `unit_flags = 0`
- Prowler (entry 118) had `unit_flags = 67108880`
  - `67108880 = 67108864 + 16`
  - After cleanup: `unit_flags = 16`

This preserves unrelated flags while removing only the incorrectly persistent skinnable state.

This does **not** disable Skinning and does **not** prevent creatures from becoming skinnable after death. The core continues to apply the skinnable flag dynamically to eligible corpses as intended.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #477 
- Fixes living skinnable creatures appearing as minimap tracking targets after learning Skinning.
- Fixes creature templates incorrectly storing `UNIT_FLAG_SKINNABLE` as a permanent unit flag.
- Preserves all unrelated `unit_flags` values on affected creatures.
- Keeps normal corpse Skinning behavior intact.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Additional validation was performed directly against BFA-HavenCore behavior and database state:

- A Rogue with no Hunter tracking abilities was used for testing.
- Before learning Skinning, the affected creatures were not displayed as Skinning targets on the minimap.
- After learning Skinning, living creatures with `UNIT_FLAG_SKINNABLE` already present in `creature_template.unit_flags` appeared as minimap tracking dots.
- `character_spell` was checked after learning Skinning.
- The character learned Skinning-related spells, but did **not** learn Hunter Track Beasts (`1494`) or the alternate Track Beasts spell (`210065`).
- `spell_linked_spell` and `spell_learn_spell` were also checked and did not show a Skinning-to-Track-Beasts relationship.
- This ruled out the profession incorrectly teaching the Hunter tracking spell.
- The behavior was then reproduced and isolated using individual creature templates.

The core's existing creature death/loot handling was also verified in-game: after removing the permanent template flag, eligible creatures still became skinnable normally after being killed and looted.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Testing performed:

### Profession / spell verification

A non-Hunter Rogue was tested before and after learning Skinning.

After learning Skinning, the character had Skinning-related spells including:

- `8613`
- `265855`

The character did **not** receive:

- `1494` - Track Beasts
- `210065` - Track Beasts

This confirmed that the minimap behavior was not caused by accidentally teaching the Hunter tracking ability.

### Database verification

A query was run to identify templates containing `UNIT_FLAG_SKINNABLE`:

```sql
SELECT
    entry,
    name,
    unit_flags
FROM creature_template
WHERE (unit_flags & 67108864) <> 0
ORDER BY entry;
```

This returned a very large number of affected templates, including normal beasts and many other creature types.

A controlled test was first performed on Prowler (entry 118).

Original value:

```text
entry: 118
name: Prowler
unit_flags: 67108880
```

Only the `UNIT_FLAG_SKINNABLE` bit was removed.

Result:

```text
entry: 118
name: Prowler
unit_flags: 16
```

After worldserver restart:

- The living Prowler no longer appeared on the minimap.
- The Prowler could still be killed normally.
- The corpse could still be looted normally.
- After looting, the corpse became skinnable.
- Skinning completed successfully.

A second controlled test was then performed on Stonetusk Boar (entry 113).

Original value:

```text
entry: 113
name: Stonetusk Boar
unit_flags: 67108864
```

After removing only the Skinning flag:

```text
entry: 113
name: Stonetusk Boar
unit_flags: 0
```

After worldserver restart:

- The living Stonetusk Boar no longer appeared on the minimap.
- The creature could still be killed and looted normally.
- The corpse became skinnable after looting.
- Skinning continued to work correctly.

The cleanup was then applied globally to every creature template containing the static Skinning bit.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create or use a non-Hunter character, preferably the same class used in the issue report such as a Rogue.

2. Confirm the character does not know Hunter Track Beasts:
   ```text
   1494
   210065
   ```

3. Visit an area containing creatures that are normally skinnable, such as Stonetusk Boars or Prowlers.

4. Before learning Skinning, observe the minimap.

5. Learn Skinning from a profession trainer.

6. Return to the same living creatures and observe the minimap.

7. With the fix applied, living skinnable creatures should **not** appear as Skinning tracking targets on the minimap.

8. Kill one of the test creatures.

9. Loot the corpse normally.

10. Verify the corpse becomes skinnable after looting.

11. Skin the corpse.

12. Confirm Skinning loot is awarded normally.

13. Repeat with multiple creature types to verify there is no regression in normal Skinning behavior.

14. Optional database verification:
   ```sql
   SELECT COUNT(*) AS remaining_static_skinnable
   FROM creature_template
   WHERE (unit_flags & 67108864) = 67108864;
   ```

15. The expected result after the cleanup is:
   ```text
   0
   ```

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Additional creature types and zones can be regression-tested to confirm no unusual template depends on `UNIT_FLAG_SKINNABLE` being permanently set while alive.
- [ ] Existing SQL update files that explicitly assign values containing `67108864` should be reviewed separately to ensure a fresh database setup cannot reintroduce the static Skinning flag after this cleanup.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test BFA-HavenCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub.

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
