### PR TITLE
CPP/SQL: Additional Ragefire Chasm Dungeon Fixes

### DIFF
--- a/sql/updates/world/2026_09_06_00_RFC_Issues_481_482_483.sql
+++ b/sql/updates/world/2026_09_06_00_RFC_Issues_481_482_483.sql
@@ -1,0 +1,99 @@
+-- Ragefire Chasm retail polish
+-- Fixes:
+--   #481 Corrupted Houndmaster - Incite Frenzy targets players/caster
+--   #482 Missing Adarogg intro speeches
+--   #483 Oggleflint should appear dead
+--
+-- Reference basis:
+--   - Wowhead / retail behavior: Incite Frenzy affects nearby Flame Hounds.
+--   - TrinityCore retail sniff/reference data for RFC:
+--       * BroadcastText 61203 / 61204
+--       * AreaTrigger 7904
+--       * Oggleflint aura 35356 (Spawn Feign Death)
+--       * Oggleflint unit_flags 768, unit_flags2 2048, unit_flags3 1
+--   - HavenCore corpse presentation requires dynamicflags = 32
+--     (UNIT_DYNFLAG_DEAD) so the client presents the NPC as dead.
+
+-- ---------------------------------------------------------------------------
+-- #481 - Incite Frenzy (120093)
+-- Restrict all three aura effects to the two RFC Flame Hound entries.
+--
+-- SourceTypeOrReferenceId 13 = spell implicit target
+-- SourceGroup 1/2/4 = effect masks for effects 0/1/2
+-- Condition 31 = legacy object entry/guid
+-- ConditionValue1 3 = TYPEID_UNIT
+-- ElseGroup provides OR behavior between Adolescent and Mature Flame Hounds.
+-- ---------------------------------------------------------------------------
+
+DELETE FROM `conditions`
+WHERE `SourceTypeOrReferenceId` = 13
+  AND `SourceEntry` = 120093;
+
+INSERT INTO `conditions`
+(`SourceTypeOrReferenceId`,`SourceGroup`,`SourceEntry`,`SourceId`,`ElseGroup`,
+ `ConditionTypeOrReference`,`ConditionTarget`,`ConditionValue1`,`ConditionValue2`,`ConditionValue3`,
+ `NegativeCondition`,`ErrorType`,`ErrorTextId`,`ScriptName`,`Comment`)
+VALUES
+(13,1,120093,0,0,31,0,3,61657,0,0,0,0,'','Incite Frenzy effect 0 - Adolescent Flame Hound'),
+(13,1,120093,0,1,31,0,3,61658,0,0,0,0,'','Incite Frenzy effect 0 - Mature Flame Hound'),
+
+(13,2,120093,0,0,31,0,3,61657,0,0,0,0,'','Incite Frenzy effect 1 - Adolescent Flame Hound'),
+(13,2,120093,0,1,31,0,3,61658,0,0,0,0,'','Incite Frenzy effect 1 - Mature Flame Hound'),
+
+(13,4,120093,0,0,31,0,3,61657,0,0,0,0,'','Incite Frenzy effect 2 - Adolescent Flame Hound'),
+(13,4,120093,0,1,31,0,3,61658,0,0,0,0,'','Incite Frenzy effect 2 - Mature Flame Hound');
+
+-- Existing SmartAI remains unchanged:
+-- Corrupted Houndmaster casts 120093 on self at 60% health.
+-- The spell's implicit targets are now filtered to Flame Hounds only.
+
+-- ---------------------------------------------------------------------------
+-- #482 - Missing Adarogg intro speeches
+-- BroadcastText IDs preserve client localization.
+-- ---------------------------------------------------------------------------
+
+DELETE FROM `creature_text`
+WHERE `CreatureID` = 61666
+  AND `GroupID` IN (0,1);
+
+INSERT INTO `creature_text`
+(`CreatureID`,`GroupID`,`ID`,`Text`,`Type`,`Language`,`Probability`,
+ `Emote`,`Duration`,`Sound`,`BroadcastTextId`,`TextRange`)
+VALUES
+(61666,0,0,'He''s cornered!',14,0,100,0,0,0,61203,0),
+(61666,1,0,'We''ve got him now!',14,0,100,0,0,0,61204,0);
+
+DELETE FROM `areatrigger_scripts`
+WHERE `entry` = 7904;
+
+INSERT INTO `areatrigger_scripts`
+(`entry`,`ScriptName`)
+VALUES
+(7904,'at_rfc_adarogg_intro');
+
+-- ---------------------------------------------------------------------------
+-- #483 - Oggleflint (61669)
+-- Retail presents Oggleflint as a corpse using Spawn Feign Death (35356).
+-- HavenCore also needs UNIT_DYNFLAG_DEAD for the client to show him as dead.
+-- ---------------------------------------------------------------------------
+
+UPDATE `creature_template`
+SET
+    `AIName`       = '',
+    `ScriptName`   = '',
+    `unit_flags`   = 768,
+    `unit_flags2`  = 2048,
+    `unit_flags3`  = 1,
+    `dynamicflags` = 32
+WHERE `entry` = 61669;
+
+INSERT INTO `creature_template_addon`
+(`entry`,`auras`)
+VALUES
+(61669,'35356')
+ON DUPLICATE KEY UPDATE
+`auras` = '35356';
+
+-- Keep the existing Oggleflint spawn.
+-- Current HavenCore location already matches retail/reference data closely:
+--   -276.682, -34.6181, -60.6085

--- a/src/server/scripts/Kalimdor/RagefireChasm/boss_adarogg.cpp
+++ b/src/server/scripts/Kalimdor/RagefireChasm/boss_adarogg.cpp
@@ -1,12 +1,16 @@
 /*
  * 2026 BFA-HavenCore
  *
- * This SourceCode is NOT free a software. Please hold everything Private
- * and read our Terms
+ * Ragefire Chasm - Adarogg / Corrupted Houndmaster retail polish
+ *
+ * Restores the Corrupted Houndmaster intro dialogue used when players
+ * approach Adarogg. Combat behavior for Adarogg is intentionally left
+ * unchanged from the previously validated HavenCore implementation.
  */
 
 #include "ScriptMgr.h"
 #include "ScriptedCreature.h"
+#include "Player.h"
 
 enum Spells
 {
@@ -21,87 +25,195 @@ enum Events
     EVENT_INFERNO
 };
 
+enum AdaroggMisc
+{
+    NPC_ADAROGG               = 61408,
+    NPC_CORRUPTED_HOUNDMASTER = 61666,
+
+    ACTION_ADAROGG_INTRO_DIALOGUE = 1
+};
+
+enum HoundmasterTexts
+{
+    SAY_HES_CORNERED   = 0,
+    SAY_GOT_HIM_NOW    = 1
+};
+
+// Retail/reference positions for the two Corrupted Houndmasters that
+// deliver the Adarogg intro lines.
+static float const HoundmasterIntro1X = -275.0427f;
+static float const HoundmasterIntro1Y =  -63.9595f;
+static float const HoundmasterIntro1Z =  -60.3566f;
+
+static float const HoundmasterIntro2X = -273.0281f;
+static float const HoundmasterIntro2Y =  -50.9456f;
+static float const HoundmasterIntro2Z =  -60.7311f;
+
+// AreaTrigger 7904 - Adarogg intro dialogue
+class at_rfc_adarogg_intro : public AreaTriggerScript
+{
+public:
+    at_rfc_adarogg_intro() : AreaTriggerScript("at_rfc_adarogg_intro") { }
+
+    bool OnTrigger(Player* player, AreaTriggerEntry const* /*areaTrigger*/, bool entered) override
+    {
+        if (!entered || !player)
+            return false;
+
+        if (Creature* adarogg = player->FindNearestCreature(NPC_ADAROGG, 100.0f, true))
+        {
+            if (adarogg->AI())
+                adarogg->AI()->DoAction(ACTION_ADAROGG_INTRO_DIALOGUE);
+
+            return true;
+        }
+
+        return false;
+    }
+};
+
 class boss_adarogg : public CreatureScript
 {
-    public:
-        boss_adarogg() : CreatureScript("boss_adarogg") { }
+public:
+    boss_adarogg() : CreatureScript("boss_adarogg") { }
 
-        struct boss_adaroggAI : public ScriptedAI
+    struct boss_adaroggAI : public ScriptedAI
+    {
+        boss_adaroggAI(Creature* creature)
+            : ScriptedAI(creature), _introDialoguePlayed(false)
         {
-            boss_adaroggAI(Creature* creature) : ScriptedAI(creature) { }
-
-            void Reset() { } 
-
-            void EnterCombat(Unit* /*who*/)
-            {
-                events.ScheduleEvent(EVENT_INFERNO, 10000);
-                events.ScheduleEvent(EVENT_FLAME_BREATH, 20000);
-            }
-
-            void SpellHitTarget(Unit* target, SpellInfo const* spell) override
-            {
-                if (spell->Id == SPELL_INFERNO_CHARGE)
-                    me->CastSpell(target, SPELL_INFERNO_CHARGE_TRIGGERED, false);
-            }
-
-            void JustDied(Unit* /*killer*/) { }
-
-            void UpdateAI(uint32 const diff)
-            {
-                if(!UpdateVictim())
-                    return;
-
-                events.Update(diff);
-
-                if(me->HasUnitState(UNIT_STATE_CASTING))
-                    return;
-
-                if(uint32 eventId = events.ExecuteEvent())
-                {
-                    switch(eventId)
-                    {
-                        case EVENT_FLAME_BREATH:
-                            DoCastVictim(SPELL_FLAME_BREATH);
-                            events.ScheduleEvent(EVENT_FLAME_BREATH, urand(15000, 20000));
-                            break;
-                        case EVENT_INFERNO:
-                            if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 100.0f, true))
-                            {
-                                me->SetFacingToObject(target);
-
-                                // HavenCore lacks the modern TrinityCore
-                                // serverside Inferno Charge helper spells.
-                                // Move Adarogg physically to the selected
-                                // player's location so the charge is visible,
-                                // then use the existing spell for the impact.
-                                me->GetMotionMaster()->MoveCharge(
-                                    target->GetPositionX(),
-                                    target->GetPositionY(),
-                                    target->GetPositionZ(),
-                                    35.0f,
-                                    1,
-                                    true);
-
-                                DoCast(target, SPELL_INFERNO_CHARGE, true);
-                            }
-
-                            events.ScheduleEvent(EVENT_INFERNO, urand(15000, 20000));
-                            break;
-                        default:
-                            break;
-                    }
-                }
-                DoMeleeAttackIfReady();
-            }
-        };
-
-        CreatureAI* GetAI(Creature* creature) const
-        {
-            return new boss_adaroggAI(creature);
         }
+
+        void Reset() override
+        {
+            events.Reset();
+        }
+
+        void EnterCombat(Unit* /*who*/) override
+        {
+            events.ScheduleEvent(EVENT_INFERNO, 10000);
+            events.ScheduleEvent(EVENT_FLAME_BREATH, 20000);
+        }
+
+        void SpellHitTarget(Unit* target, SpellInfo const* spell) override
+        {
+            if (spell->Id == SPELL_INFERNO_CHARGE)
+                me->CastSpell(target, SPELL_INFERNO_CHARGE_TRIGGERED, false);
+        }
+
+        void JustDied(Unit* /*killer*/) override
+        {
+            events.Reset();
+        }
+
+        void DoAction(int32 action) override
+        {
+            if (action != ACTION_ADAROGG_INTRO_DIALOGUE || _introDialoguePlayed)
+                return;
+
+            _introDialoguePlayed = true;
+
+            Creature* first = FindIntroHoundmaster(
+                HoundmasterIntro1X, HoundmasterIntro1Y, HoundmasterIntro1Z);
+
+            Creature* second = FindIntroHoundmaster(
+                HoundmasterIntro2X, HoundmasterIntro2Y, HoundmasterIntro2Z);
+
+            if (first && first->AI())
+                first->AI()->Talk(SAY_HES_CORNERED);
+
+            if (second && second != first && second->AI())
+                second->AI()->Talk(SAY_GOT_HIM_NOW);
+        }
+
+        void UpdateAI(uint32 const diff) override
+        {
+            if (!UpdateVictim())
+                return;
+
+            events.Update(diff);
+
+            if (me->HasUnitState(UNIT_STATE_CASTING))
+                return;
+
+            if (uint32 eventId = events.ExecuteEvent())
+            {
+                switch (eventId)
+                {
+                    case EVENT_FLAME_BREATH:
+                        DoCastVictim(SPELL_FLAME_BREATH);
+                        events.ScheduleEvent(EVENT_FLAME_BREATH, urand(15000, 20000));
+                        break;
+
+                    case EVENT_INFERNO:
+                        if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 100.0f, true))
+                        {
+                            me->SetFacingToObject(target);
+
+                            // HavenCore lacks the modern TrinityCore
+                            // serverside Inferno Charge helper spells.
+                            // Move Adarogg physically to the selected
+                            // player's location so the charge is visible,
+                            // then use the existing spell for the impact.
+                            me->GetMotionMaster()->MoveCharge(
+                                target->GetPositionX(),
+                                target->GetPositionY(),
+                                target->GetPositionZ(),
+                                35.0f,
+                                1,
+                                true);
+
+                            DoCast(target, SPELL_INFERNO_CHARGE, true);
+                        }
+
+                        events.ScheduleEvent(EVENT_INFERNO, urand(15000, 20000));
+                        break;
+
+                    default:
+                        break;
+                }
+            }
+
+            DoMeleeAttackIfReady();
+        }
+
+    private:
+        Creature* FindIntroHoundmaster(float x, float y, float z)
+        {
+            std::list<Creature*> houndmasters;
+            GetCreatureListWithEntryInGrid(
+                houndmasters, me, NPC_CORRUPTED_HOUNDMASTER, 100.0f);
+
+            Creature* closest = nullptr;
+            float bestDistance = 5.0f;
+
+            for (Creature* houndmaster : houndmasters)
+            {
+                if (!houndmaster || !houndmaster->IsAlive())
+                    continue;
+
+                float distance = houndmaster->GetDistance(x, y, z);
+                if (distance < bestDistance)
+                {
+                    bestDistance = distance;
+                    closest = houndmaster;
+                }
+            }
+
+            return closest;
+        }
+
+        bool _introDialoguePlayed;
+    };
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return new boss_adaroggAI(creature);
+    }
 };
 
 void AddSC_boss_adarogg()
 {
+    new at_rfc_adarogg_intro();
     new boss_adarogg();
 }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [X] Scripts (bosses, spell scripts, creature scripts).
-  [X] Database (SAI, creatures, etc).
# Ragefire Chasm: Fix Houndmaster Frenzy, Intro Dialogue, and Oggleflint Corpse State

## Summary

This PR fixes three Ragefire Chasm normal-mode issues reported in:


<!-- If your fix has a relating issue, link it below -->
- Closes #481 
- Closes #482 
- Closes #483 

The fixes are based on retail/reference behavior from Wowhead and TrinityCore retail sniff/reference data, while preserving HavenCore compatibility and localization.

## Changes

### #481 — Corrupted Houndmaster: Incite Frenzy

Corrupted Houndmaster (61666) already had a SmartAI event that casts spell 120093, Incite Frenzy, at 60% health.

The issue was not the SmartAI trigger itself. The spell's implicit target selection allowed invalid units to receive the aura, including the player / caster.

This PR adds spell implicit-target conditions for all three effects of spell 120093 so that Incite Frenzy may only affect:

- 61657 — Adolescent Flame Hound
- 61658 — Mature Flame Hound

The existing 60% health SmartAI behavior is retained.

### #482 — Missing Adarogg Intro Dialogue

Retail/reference behavior includes two Corrupted Houndmaster lines during the Adarogg intro:

- "He's cornered!"
- "We've got him now!"

The dialogue is restored using the original BroadcastText IDs:

- 61203
- 61204

This preserves localization for non-English clients.

AreaTrigger 7904 is bound to a new `at_rfc_adarogg_intro` script in `boss_adarogg.cpp`.

When the player enters the trigger, the two retail-positioned Corrupted Houndmasters deliver the two lines once for that Adarogg instance.

The existing validated Adarogg combat behavior is otherwise unchanged.

### #483 — Oggleflint Corpse State

Oggleflint (61669, `<Hound Food>`) should be presented as dead.

Retail/reference data uses:

- Aura 35356 — Spawn Feign Death
- `unit_flags = 768`
- `unit_flags2 = 2048`
- `unit_flags3 = 1`

On HavenCore, the feign-death aura alone leaves Oggleflint visually prone but still presented by the client as a living unit.

This PR also sets:

- `dynamicflags = 32` (`UNIT_DYNFLAG_DEAD`)

This makes the client present Oggleflint as dead while keeping the retail-style feign-death presentation.

### SQL

Applies:

- Incite Frenzy spell target conditions
- Corrupted Houndmaster `creature_text`
- AreaTrigger 7904 script binding
- Oggleflint corpse flags
- Oggleflint Spawn Feign Death aura

## Testing

Tested on BFA 8.3.7 normal Ragefire Chasm.

### #481

Confirmed:

- Corrupted Houndmaster casts Incite Frenzy at 60% health
- Nearby Flame Hounds receive Incite Frenzy
- Player does not receive Incite Frenzy
- Corrupted Houndmaster does not receive Incite Frenzy

### #482

Confirmed:

- Adarogg-area intro dialogue fires
- "He's cornered!" is displayed
- "We've got him now!" is displayed
- BroadcastText IDs are used for localization

### #483

Confirmed:

- Oggleflint appears prone/dead
- Client no longer presents him with a normal living-health state
- Corpse presentation matches the intended retail behavior more closely

## Scope

Normal-mode Ragefire Chasm only.

No changes are made to heroic, mythic, or mythic+ behavior.


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

